### PR TITLE
cli: add status subcommand

### DIFF
--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -1,8 +1,15 @@
-use clap::Command;
+mod status;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "ogygia", version, about = "ogygia")]
+struct Cli {
+    #[command(subcommand)]
+    command: status::Command,
+}
 
 fn main() {
-    Command::new("ogygia")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("ogygia")
-        .get_matches();
+    let cli = Cli::parse();
+    cli.command.run();
 }

--- a/src/ogygia/src/status.rs
+++ b/src/ogygia/src/status.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+
+use clap::Subcommand;
+
+const STATE_PATHS: [(&str, &str, &str); 3] = [
+    ("⚡", "Current system", "/run/current-system"),
+    ("🥾", "Booted system", "/run/booted-system"),
+    ("🔜", "Next boot system", "/nix/var/nix/profiles/system"),
+];
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Show build commits for the local host
+    Status,
+}
+
+impl Command {
+    pub fn run(&self) {
+        match self {
+            Command::Status => show_revisions(),
+        }
+    }
+}
+
+fn show_revisions() {
+    for (emoji, label, path) in STATE_PATHS {
+        let revision = format_revision(Path::new(path));
+        println!("{} {:18} {}", emoji, label, revision);
+    }
+}
+
+fn format_revision(base_path: &Path) -> String {
+    let revision_path = base_path.join("sw/share/ogygia/build-revision");
+
+    match std::fs::read_to_string(&revision_path) {
+        Ok(contents) => {
+            let trimmed = contents.trim();
+            if trimmed.len() > 12 {
+                trimmed[..12].to_string()
+            } else {
+                trimmed.to_string()
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => "unknown".into(),
+        Err(error) => format!("error reading ({}): {}", revision_path.display(), error),
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the ogygia binary to derive its clap parser instead of building it manually
- move the status command handling into a clap `Subcommand` enum with an associated run method

## Testing
- cargo check -p ogygia

------
https://chatgpt.com/codex/tasks/task_e_68ed87966b74832f8db190b3291e746e