### PR TITLE
versions: better document and fix build-revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # ogygia-nix
+
+## How to use
+
+### Configuration revision tracking
+
+To enable configuration revision tracking in your NixOS configuration, you need to set `system.configurationRevision` in your flake. Add this to your NixOS configuration:
+
+```nix
+system.configurationRevision = nixpkgs.lib.mkIf (self ? rev) self.rev;
+```
+
+This ensures that:
+- When the flake is clean (committed), the git revision is embedded in the system closure
+- When the flake is dirty (uncommitted changes), the revision is set to "unknown"
+
+The revision will be written to `/run/current-system/sw/share/ogygia/build-revision` when `ogygia.versions.build_revision.enable` is enabled (which happens automatically when `ogygia.enable` is set).

--- a/nixos/versions/build_revision.nix
+++ b/nixos/versions/build_revision.nix
@@ -2,6 +2,7 @@
 
 let
   cfg = config.ogygia.versions.build_revision;
+  revision = if config.system.configurationRevision != null then config.system.configurationRevision else "unknown";
 in
 {
   options.ogygia.versions.build_revision = {
@@ -10,7 +11,7 @@ in
 
   config = lib.mkIf cfg.enable {
     environment = {
-      systemPackages = [ (pkgs.writeTextDir "share/ogygia/build-revision" ((config.system.configurationRevision or "dirty") + "\n")) ];
+      systemPackages = [ (pkgs.writeTextDir "share/ogygia/build-revision" (revision + "\n")) ];
       pathsToLink = [ "/share/ogygia" ];
     };
   };


### PR DESCRIPTION
build-revision relies on something else being set in your flake, so document this. The `or` from before also didn't work making building from a dirty flake fail - fix that.

Test plan:
- with dirty; `nix build --no-link --override-input ogygia /data/users/jake/repos/ogygia-nix /data/users/jake/repos/nixos#nixosConfigurations."merlin.rig.neb.jakehillion.me".config.system.build.toplevel`