### PR TITLE
ogygia: migrate from println!/eprintln! to tracing/tracing-subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "ogygia"
 version = "0.1.0"
 dependencies = [
@@ -307,14 +334,28 @@ dependencies = [
  "hostname",
  "serde",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "zookeeper",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "proc-macro2"
@@ -333,6 +374,23 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "serde"
@@ -374,10 +432,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snowflake"
@@ -411,6 +484,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -455,6 +537,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +608,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 zookeeper = "0.8"
 hostname = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -11,3 +11,5 @@ serde = { workspace = true }
 toml = { workspace = true }
 zookeeper = { workspace = true }
 hostname = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -26,6 +26,8 @@ mod status;
 
 use clap::Parser;
 use std::process;
+use tracing::error;
+use tracing_subscriber::EnvFilter;
 
 /// Ogygia CLI application.
 #[derive(Parser)]
@@ -36,9 +38,17 @@ struct Cli {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("ogygia=info,warn")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
     if let Err(error) = cli.command.run() {
-        eprintln!("error: {error}");
+        error!(%error, "fatal error");
         process::exit(1);
     }
 }

--- a/src/ogygia/src/status/mod.rs
+++ b/src/ogygia/src/status/mod.rs
@@ -44,6 +44,7 @@ mod tests;
 
 use anyhow::Result;
 use clap::Subcommand;
+use tracing::{info, warn};
 
 use display::print_host_table;
 use state::{
@@ -89,10 +90,10 @@ fn show_status() -> Result<()> {
     match cli_config.as_ref() {
         Some(cli_config) => {
             if let Some(zookeeper) = cli_config.zookeeper.as_ref() {
-                println!(
-                    "ZooKeeper fleet state ({} via {}):",
-                    zookeeper.namespace,
-                    cli_config.path.display()
+                info!(
+                    namespace = %zookeeper.namespace,
+                    config = %cli_config.path.display(),
+                    "ZooKeeper fleet state"
                 );
 
                 match fetch_zookeeper_state(zookeeper, Some(&host_matcher)) {
@@ -102,29 +103,30 @@ fn show_status() -> Result<()> {
                         all_states.extend(remote_states);
 
                         if all_states.len() == 1 {
-                            println!("Only the local host is currently registered in ZooKeeper.");
+                            info!("only the local host is currently registered in ZooKeeper");
                         }
 
                         print_host_table(&all_states, domain_suffix);
                     }
                     Err(error) => {
-                        println!(
-                            "Failed to read ZooKeeper from {}: {error}. Showing local data only.",
-                            cli_config.path.display()
+                        warn!(
+                            config = %cli_config.path.display(),
+                            %error,
+                            "failed to read ZooKeeper, showing local data only"
                         );
                         print_host_table(&[local_state], domain_suffix);
                     }
                 }
             } else {
-                println!(
-                    "ZooKeeper settings not found in {}; showing local data only.",
-                    cli_config.path.display()
+                info!(
+                    config = %cli_config.path.display(),
+                    "ZooKeeper settings not found, showing local data only"
                 );
                 print_host_table(&[local_state], domain_suffix);
             }
         }
         None => {
-            println!("Ogygia config not found; showing local data only.");
+            info!("config not found, showing local data only");
             print_host_table(&[local_state], domain_suffix);
         }
     }


### PR DESCRIPTION
All diagnostic output used println!/eprintln!, mixing informational messages with table output on stdout and making it impossible to filter log levels or capture structured context.

Added tracing and tracing-subscriber (with env-filter) as dependencies. Initialized a fmt subscriber in main() writing to stderr with a default filter of "ogygia=info,warn", so ogygia's own info messages appear while transitive deps (zookeeper, mio) are filtered to warn+. Converted the eprintln! in the error path to error!(%error) and all five println! calls in status/mod.rs to info!/warn! with structured fields (namespace, config, error). The tracing-log bridge (default feature of tracing-subscriber) automatically captures log events from transitive dependencies.

Routing diagnostics through tracing to stderr preserves pipe-friendliness for the table output on stdout, gives users RUST_LOG control over verbosity, and positions the codebase for future structured logging (spans, JSON output, OTLP).

Test plan:
- CI