### PR TITLE
nixos: replace deprecated system argument with nixpkgs.hostPlatform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
             });
 
             ogygia-cli-config = import ./nixos/tests/cli-config.nix {
-              inherit pkgs system;
+              inherit pkgs;
               inherit (nixpkgs) lib;
               ogygiaModule = self.nixosModules.default;
             };

--- a/nixos/tests/cli-config.nix
+++ b/nixos/tests/cli-config.nix
@@ -1,9 +1,9 @@
-{ pkgs, lib, system, ogygiaModule }:
+{ pkgs, lib, ogygiaModule }:
 
 let
   configTestSystem = lib.nixosSystem {
-    inherit system;
     modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
       ogygiaModule
       {
         ogygia.enable = true;


### PR DESCRIPTION
The NixOS module test passed `system` directly to `lib.nixosSystem`, which triggers the "'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'" evaluation warning on modern nixpkgs.

Updated `nixos/tests/cli-config.nix` to derive the platform from `pkgs.stdenv.hostPlatform.system` and set it via the `nixpkgs.hostPlatform` module option instead of passing `system` to `lib.nixosSystem`. Removed the now-unnecessary `system` parameter from the test invocation in `flake.nix`.

This eliminates the deprecation warning by using the modern hostPlatform-based approach that nixpkgs expects.

Test plan:
- nix flake check passes with no deprecation warnings.