### PR TITLE
treefmt: use nightly rustfmt to enable unstable format options

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,12 +32,16 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           lib = pkgs.lib;
-          toolchain = fenix.packages.${system}.stable.withComponents [
-            "cargo"
-            "clippy"
-            "rust-src"
-            "rustc"
-            "rustfmt"
+          toolchain = fenix.packages.${system}.combine [
+            (fenix.packages.${system}.stable.withComponents [
+              "cargo"
+              "clippy"
+              "rust-src"
+              "rustc"
+            ])
+            (fenix.packages.${system}.complete.withComponents [
+              "rustfmt"
+            ])
           ];
           craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
 

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -24,8 +24,9 @@
 
 mod status;
 
-use clap::Parser;
 use std::process;
+
+use clap::Parser;
 use tracing::error;
 use tracing_subscriber::EnvFilter;
 

--- a/src/ogygia/src/status/display.rs
+++ b/src/ogygia/src/status/display.rs
@@ -3,7 +3,9 @@
 //! This module handles all formatting, truncation, and table rendering.
 //! It takes raw state data and formats it for human-readable display.
 
-use super::state::{HostState, STATE_COUNT, StateValues};
+use super::state::HostState;
+use super::state::STATE_COUNT;
+use super::state::StateValues;
 
 /// Number of characters to display from revision hashes (e.g., git SHA).
 const REVISION_DISPLAY_LENGTH: usize = 12;

--- a/src/ogygia/src/status/mod.rs
+++ b/src/ogygia/src/status/mod.rs
@@ -44,12 +44,14 @@ mod tests;
 
 use anyhow::Result;
 use clap::Subcommand;
-use tracing::{info, warn};
-
 use display::print_host_table;
-use state::{
-    HostMatcher, collect_local_state, detect_hostname, fetch_zookeeper_state, load_cli_config,
-};
+use state::HostMatcher;
+use state::collect_local_state;
+use state::detect_hostname;
+use state::fetch_zookeeper_state;
+use state::load_cli_config;
+use tracing::info;
+use tracing::warn;
 
 #[derive(Subcommand)]
 pub enum Command {

--- a/src/ogygia/src/status/state.rs
+++ b/src/ogygia/src/status/state.rs
@@ -11,14 +11,20 @@
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
 use hostname::get as get_hostname;
 use serde::Deserialize;
-use zookeeper::{WatchedEvent, Watcher, ZkError, ZooKeeper};
+use zookeeper::WatchedEvent;
+use zookeeper::Watcher;
+use zookeeper::ZkError;
+use zookeeper::ZooKeeper;
 
 /// Number of system states tracked per host (current, booted, next boot).
 pub const STATE_COUNT: usize = 3;

--- a/src/ogygia/src/status/tests.rs
+++ b/src/ogygia/src/status/tests.rs
@@ -1,10 +1,14 @@
 //! Unit tests for status module.
 
-use super::display::{trim_domain_suffix, truncate_revision};
-use super::state::{
-    HostMatcher, HostState, STATE_COUNT, empty_state_values, join_zk_path, normalize_domain,
-    normalize_namespace,
-};
+use super::display::trim_domain_suffix;
+use super::display::truncate_revision;
+use super::state::HostMatcher;
+use super::state::HostState;
+use super::state::STATE_COUNT;
+use super::state::empty_state_values;
+use super::state::join_zk_path;
+use super::state::normalize_domain;
+use super::state::normalize_namespace;
 
 // ============================================================================
 // HostMatcher tests


### PR DESCRIPTION
The rustfmt.toml settings group_imports and imports_granularity are nightly-only features. The stable rustfmt bundled via fenix silently ignored them, so nix fmt had no effect on import formatting.

Switched the fenix toolchain to a combined derivation that pairs stable cargo/clippy/rustc with nightly rustfmt from fenix complete. Ran nix fmt to apply the previously ignored rustfmt.toml rules across all Rust source files.

Nightly rustfmt recognises the unstable options and enforces them, making treefmt's formatting check consistent with the declared style.

Test plan:
- CI