### PR TITLE
ogygia-irisd: encode NarHash in NAR URLs to remove narinfo cache

### DIFF
--- a/src/ogygia-irisd/src/nix/narinfo.rs
+++ b/src/ogygia-irisd/src/nix/narinfo.rs
@@ -4,6 +4,29 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use anyhow::anyhow;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+
+/// Convert a NarHash from SRI base64 format (`sha256-BASE64==`) to bare hex.
+/// Hashes without the SRI prefix are returned unchanged.
+pub fn nar_hash_to_hex(hash: &str) -> String {
+    if let Some(b64) = hash.strip_prefix("sha256-") {
+        let bytes = STANDARD.decode(b64).expect("invalid base64 in NarHash");
+        hex::encode(bytes)
+    } else {
+        hash.to_string()
+    }
+}
+
+/// Convert a bare hex NarHash back to SRI base64 format (`sha256-BASE64==`).
+/// Hashes already in SRI format are returned unchanged.
+pub fn nar_hash_to_sri(hash: &str) -> String {
+    if hash.starts_with("sha256-") {
+        return hash.to_string();
+    }
+    let bytes = hex::decode(hash).expect("invalid hex in NarHash");
+    format!("sha256-{}", STANDARD.encode(bytes))
+}
 
 /// Parsed narinfo file
 #[derive(Debug, Clone)]

--- a/src/ogygia-irisd/src/nix/store.rs
+++ b/src/ogygia-irisd/src/nix/store.rs
@@ -15,6 +15,7 @@ use tokio::process::Command;
 
 use crate::nix::narinfo::Compression;
 use crate::nix::narinfo::NarInfo;
+use crate::nix::narinfo::nar_hash_to_hex;
 
 /// Information about a store path from `nix path-info --json`
 #[derive(Debug, Clone)]
@@ -126,8 +127,14 @@ impl PathInfo {
         // Extract just the store path name (without /nix/store/ prefix)
         let store_name = self.path.strip_prefix("/nix/store/").unwrap_or(&self.path);
 
-        // Generate URL for NAR file (use zstd compression)
-        let url = format!("nar/{}.nar.zst", store_name);
+        // Generate URL for NAR file (use zstd compression).
+        // Encode the NarHash in the URL so NAR requests are self-describing
+        // and we don't need server-side state to match narinfo to NAR.
+        let url = format!(
+            "nar/{}/{}.nar.zst",
+            nar_hash_to_hex(&self.nar_hash),
+            store_name
+        );
 
         // For now, use placeholder values for FileHash and FileSize
         // since we compress on-the-fly and don't know these until first generation
@@ -193,7 +200,7 @@ mod tests {
     fn test_path_info_to_narinfo() {
         let path_info = PathInfo {
             path: "/nix/store/abc123def456ghi789jkl012mno345pq-hello-2.10".to_string(),
-            nar_hash: "sha256:0123456789abcdef".to_string(),
+            nar_hash: "sha256-ASNFZ4mrze8=".to_string(),
             nar_size: 12345,
             references: vec!["/nix/store/xyz789abc123def456ghi012jkl345mno-glibc-2.35".to_string()],
             deriver: Some(
@@ -211,10 +218,10 @@ mod tests {
         );
         assert_eq!(
             narinfo.url,
-            "nar/abc123def456ghi789jkl012mno345pq-hello-2.10.nar.zst"
+            "nar/0123456789abcdef/abc123def456ghi789jkl012mno345pq-hello-2.10.nar.zst"
         );
         assert_eq!(narinfo.compression, Compression::Zstd);
-        assert_eq!(narinfo.nar_hash, "sha256:0123456789abcdef");
+        assert_eq!(narinfo.nar_hash, "sha256-ASNFZ4mrze8=");
         assert_eq!(narinfo.nar_size, 12345);
         assert_eq!(narinfo.references.len(), 1);
         assert_eq!(narinfo.signatures.len(), 1);

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use super::AppState;
 use crate::nix::nar::generate_nar_stream;
 use crate::nix::narinfo::NarInfo;
+use crate::nix::narinfo::nar_hash_to_hex;
 use crate::nix::store::PathInfo;
 use crate::nix::store::find_store_path;
 
@@ -77,7 +78,11 @@ pub async fn get_narinfo(
     }
 
     // 2. Try peers via bloom lookup
-    if let Some((narinfo, _)) = state.try_peer_narinfo(hash).await {
+    if let Some((mut narinfo, _)) = state.try_peer_narinfo(hash).await {
+        // Rewrite the URL to use our format with the NarHash encoded as hex,
+        // so the NAR request will be self-describing regardless of the peer's format.
+        let filename = narinfo.url.rsplit('/').next().unwrap_or(&narinfo.url);
+        narinfo.url = format!("nar/{}/{}", nar_hash_to_hex(&narinfo.nar_hash), filename);
         return (
             StatusCode::OK,
             [("content-type", "text/x-nix-narinfo")],
@@ -114,10 +119,21 @@ async fn try_local_store_narinfo(hash: &str) -> Option<NarInfo> {
 }
 
 /// GET /nar/{path}
+///
+/// Path format: `nar/{nar_hash}/{store_hash}-{name}.nar.zst`
+/// The NarHash in the URL makes requests self-describing so we don't need
+/// server-side state to match narinfo responses to NAR content.
 pub async fn get_nar(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
-    let filename = path.rsplit('/').next().unwrap_or(&path);
+    // Split into nar_hash and filename segments
+    let (nar_hash, filename) = match path.split_once('/') {
+        Some((nar_hash, filename)) => (nar_hash, filename),
+        None => {
+            tracing::warn!("Invalid NAR path format: {}", path);
+            return (StatusCode::NOT_FOUND, "Not found").into_response();
+        }
+    };
 
-    // Extract hash from filename (format: {hash}-{name}.nar.{compression})
+    // Extract store hash from filename (format: {hash}-{name}.nar.{compression})
     let hash = match filename.split('-').next() {
         Some(h) if h.len() == 32 => h,
         _ => {
@@ -145,7 +161,7 @@ pub async fn get_nar(State(state): State<Arc<AppState>>, Path(path): Path<String
     }
 
     // Try peers via bloom lookup
-    state.try_peer_nar(hash).await
+    state.try_peer_nar(hash, nar_hash).await
 }
 
 /// Query parameters for GET /providers/{hash}

--- a/src/ogygia-irisd/src/server/mod.rs
+++ b/src/ogygia-irisd/src/server/mod.rs
@@ -4,13 +4,11 @@ mod handlers;
 mod routes;
 mod state;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
 pub use routes::create_router;
 pub use state::AppState;
-use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use tower_http::trace::DefaultMakeSpan;
 use tower_http::trace::DefaultOnResponse;
@@ -34,7 +32,6 @@ pub async fn start(
         local_bloom,
         peer_blooms,
         http_client,
-        narinfo_cache: RwLock::new(HashMap::new()),
     });
 
     let app = create_router(state).layer(

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -1,6 +1,5 @@
 //! Shared application state and peer lookup logic.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -10,12 +9,12 @@ use axum::response::Response;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::FuturesUnordered;
-use tokio::sync::RwLock;
 
 use crate::bloom::local::LocalBloom;
 use crate::bloom::peers::PeerBlooms;
 use crate::config::Config;
 use crate::nix::narinfo::NarInfo;
+use crate::nix::narinfo::nar_hash_to_sri;
 
 /// Shared application state
 pub struct AppState {
@@ -23,8 +22,6 @@ pub struct AppState {
     pub local_bloom: Arc<LocalBloom>,
     pub peer_blooms: Arc<PeerBlooms>,
     pub http_client: reqwest::Client,
-    /// Maps store path hash → NarHash for narinfos we've served to clients.
-    pub narinfo_cache: RwLock<HashMap<String, String>>,
 }
 
 impl AppState {
@@ -33,10 +30,6 @@ impl AppState {
     /// Streams bloom lookups concurrently with narinfo fetches: as each
     /// peer's bloom becomes available and matches the hash, a narinfo fetch
     /// is started immediately — without waiting for all blooms to arrive.
-    ///
-    /// Uses hash-affinity: if we previously served a narinfo for this hash, prefer
-    /// a peer whose NarHash matches. This ensures consistency between narinfo and
-    /// NAR responses for the same store path.
     pub(super) async fn try_peer_narinfo(&self, hash: &str) -> Option<(NarInfo, String)> {
         let peer_urls = &self.config.peers.urls;
         if peer_urls.is_empty() {
@@ -50,11 +43,8 @@ impl AppState {
             .lookup_stream(peer_urls, hash, &self.http_client)
             .await;
 
-        let expected = self.narinfo_cache.read().await.get(hash).cloned();
-
         let client = self.http_client.clone();
         let mut narinfo_futs = FuturesUnordered::new();
-        let mut first_valid: Option<(NarInfo, String)> = None;
 
         loop {
             tokio::select! {
@@ -74,18 +64,8 @@ impl AppState {
                         continue;
                     }
 
-                    if expected.as_ref().is_some_and(|h| h == &narinfo.nar_hash) {
-                        tracing::info!(
-                            "narinfo {} fetched from peer {} (NarHash matches cache)",
-                            hash,
-                            peer_url
-                        );
-                        return Some((narinfo, peer_url));
-                    }
-
-                    if first_valid.is_none() {
-                        first_valid = Some((narinfo, peer_url));
-                    }
+                    tracing::info!("narinfo {} fetched from peer {}", hash, peer_url);
+                    return Some((narinfo, peer_url));
                 }
 
                 Some(peer_url) = candidate_rx.recv() => {
@@ -100,15 +80,7 @@ impl AppState {
             }
         }
 
-        if let Some((ref narinfo, ref peer_url)) = first_valid {
-            tracing::info!("narinfo {} fetched from peer {}", hash, peer_url);
-            self.narinfo_cache
-                .write()
-                .await
-                .insert(hash.to_string(), narinfo.nar_hash.clone());
-        }
-
-        first_valid
+        None
     }
 
     /// Try to proxy a NAR from a peer found via bloom filter lookup.
@@ -117,10 +89,9 @@ impl AppState {
     /// peer's bloom becomes available and matches the hash, a narinfo fetch
     /// is started immediately — without waiting for all blooms to arrive.
     ///
-    /// Uses hash-affinity: looks up the expected NarHash from the narinfo cache
-    /// and skips peers whose NarHash doesn't match. This ensures the NAR content
-    /// is consistent with the narinfo we previously served.
-    pub(super) async fn try_peer_nar(&self, hash: &str) -> Response {
+    /// The expected NarHash is extracted from the request URL, so peers whose
+    /// NarHash doesn't match are skipped without needing server-side state.
+    pub(super) async fn try_peer_nar(&self, hash: &str, expected_nar_hash: &str) -> Response {
         let peer_urls = &self.config.peers.urls;
         if peer_urls.is_empty() {
             return (StatusCode::NOT_FOUND, "Not found").into_response();
@@ -133,7 +104,9 @@ impl AppState {
             .lookup_stream(peer_urls, hash, &self.http_client)
             .await;
 
-        let expected = self.narinfo_cache.read().await.get(hash).cloned();
+        // Convert the hex hash from the URL to SRI format once, so we can
+        // compare directly against each peer's NarHash without repeated conversion.
+        let expected_sri = nar_hash_to_sri(expected_nar_hash);
 
         let client = self.http_client.clone();
         let mut narinfo_futs = FuturesUnordered::new();
@@ -156,8 +129,8 @@ impl AppState {
                         continue;
                     }
 
-                    // Skip peers whose NarHash doesn't match our cached value
-                    if expected.as_ref().is_some_and(|h| h != &narinfo.nar_hash) {
+                    // Skip peers whose NarHash doesn't match the one in the URL
+                    if narinfo.nar_hash != expected_sri {
                         continue;
                     }
 


### PR DESCRIPTION
The server maintained an in-memory narinfo_cache mapping store path hashes to NarHash values, solely to ensure consistency between narinfo responses and subsequent NAR downloads when proxying from peers. This was unnecessary server-side state.

Embedded the NarHash directly in the NAR URL (changing the format from `nar/{store_name}.nar.zst` to `nar/{nar_hash}/{store_name}.nar.zst`). Updated the NAR handler to parse the NarHash from the URL and pass it to try_peer_nar, and simplified try_peer_narinfo by removing hash-affinity logic. Removed the narinfo_cache field from AppState along with its HashMap/RwLock imports.

NAR requests are now self-describing — the URL encodes exactly which content is expected — so no server-side state is needed to match narinfo promises to NAR content.

Test plan:
- Existing test_path_info_to_narinfo updated to assert new URL format
- All 15 ogygia-irisd tests pass