### PR TITLE
ogygia-irisd: stream bloom filter response instead of buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1256,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-compression",
+ "async-stream",
  "axum",
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Async streams
+async-stream = "0.3"
+
 # Utilities
 bytes = "1"
 futures = "0.3"

--- a/src/ogygia-irisd/Cargo.toml
+++ b/src/ogygia-irisd/Cargo.toml
@@ -49,6 +49,9 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+# Async streams
+async-stream = { workspace = true }
+
 # Utilities
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/src/ogygia-irisd/src/bloom/local.rs
+++ b/src/ogygia-irisd/src/bloom/local.rs
@@ -8,13 +8,14 @@
 //! estimate is a compile-time constant today; future work will replace
 //! it with a cluster-derived measurement.
 
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-use anyhow::Result;
 use arc_swap::ArcSwap;
+use bytes::Bytes;
 use fastbloom::AtomicBloomFilter;
 
 use super::BLOOM_SEED;
@@ -25,6 +26,9 @@ use super::BLOOM_SEED;
 /// bloom filter at startup. This is a rough constant for now — future
 /// work will derive an accurate count from cluster-wide store metadata.
 const ESTIMATED_ENTRIES: usize = 400_000;
+
+/// Batch size (in u64 words) for streaming bloom serialization (~8KB per batch).
+const WORD_BATCH: usize = 1024;
 
 /// Compute optimal bloom filter dimensions for `n` elements at the
 /// given false-positive rate.
@@ -144,16 +148,38 @@ impl LocalBloom {
         (deletions as f64 / elements as f64) > self.rebuild_threshold
     }
 
-    /// Serialize the bloom filter for the `/bloom` HTTP endpoint.
+    /// Serialize the bloom filter as a streaming response body.
     ///
-    /// Uses the shared wire format from `bloom::wire`.
-    pub fn serialize(&self) -> Result<Vec<u8>> {
+    /// Returns a stream that yields the wire-format header first, then
+    /// batched word chunks read directly from the filter's in-memory
+    /// `iter()`. The `Arc<AtomicBloomFilter>` is cloned and moved into
+    /// the stream generator to keep the filter alive for the duration
+    /// of iteration.
+    pub fn serialize_stream(
+        &self,
+    ) -> impl futures::Stream<Item = Result<Bytes, Infallible>> + Send {
         let header = super::wire::BloomHeader {
             num_hashes: self.num_hashes,
             num_bits: self.num_bits as u64,
         };
-        let filter = self.read_bloom.load();
-        Ok(super::wire::serialize(&header, filter.iter()))
+        let header_bytes = super::wire::serialize_header(&header);
+        let filter: Arc<AtomicBloomFilter> = Arc::clone(&*self.read_bloom.load());
+
+        async_stream::try_stream! {
+            yield Bytes::from(header_bytes);
+
+            let mut buf = Vec::with_capacity(WORD_BATCH * 8);
+            for word in filter.iter() {
+                buf.extend_from_slice(&word.to_be_bytes());
+                if buf.len() >= WORD_BATCH * 8 {
+                    yield Bytes::from(std::mem::take(&mut buf));
+                    buf = Vec::with_capacity(WORD_BATCH * 8);
+                }
+            }
+            if !buf.is_empty() {
+                yield Bytes::from(buf);
+            }
+        }
     }
 
     /// Begin a rebuild: swap the write slot to a fresh empty state.
@@ -203,13 +229,18 @@ impl LocalBloom {
 mod tests {
     use super::*;
 
-    #[test]
-    fn serialize_roundtrip() {
+    #[tokio::test]
+    async fn serialize_stream_roundtrip() {
+        use futures::TryStreamExt;
+
         let bloom = LocalBloom::new(0.01, 0.1);
         bloom.insert("abc123def456ghi789jkl012mno345pq");
         bloom.insert("xyz789abc123def456ghi012jkl345mno");
 
-        let data = bloom.serialize().unwrap();
+        // Collect stream chunks into a single byte buffer.
+        let chunks: Vec<Bytes> = bloom.serialize_stream().try_collect().await.unwrap();
+        let data: Vec<u8> = chunks.iter().flat_map(|b| b.iter().copied()).collect();
+
         let (num_bits, num_hashes) = bloom_params(0.01, ESTIMATED_ENTRIES);
 
         // Deserialize via the wire module and validate header.

--- a/src/ogygia-irisd/src/bloom/peers.rs
+++ b/src/ogygia-irisd/src/bloom/peers.rs
@@ -331,13 +331,17 @@ mod tests {
     use super::*;
     use crate::bloom::local::LocalBloom;
 
-    #[test]
-    fn test_serialize_deserialize_roundtrip() {
+    #[tokio::test]
+    async fn test_serialize_deserialize_roundtrip() {
+        use bytes::Bytes;
+        use futures::TryStreamExt;
+
         let local = LocalBloom::new(0.01, 0.1);
         local.insert("abc123def456ghi789jkl012mno345pq");
         local.insert("xyz789abc123def456ghi012jkl345mno");
 
-        let data = local.serialize().unwrap();
+        let chunks: Vec<Bytes> = local.serialize_stream().try_collect().await.unwrap();
+        let data: Vec<u8> = chunks.iter().flat_map(|b| b.iter().copied()).collect();
         let bloom = deserialize_bloom(&data, local.num_bits(), local.num_hashes()).unwrap();
 
         assert!(bloom.contains("abc123def456ghi789jkl012mno345pq"));

--- a/src/ogygia-irisd/src/bloom/wire.rs
+++ b/src/ogygia-irisd/src/bloom/wire.rs
@@ -36,10 +36,26 @@ impl BloomHeader {
     }
 }
 
+/// Serialize just the bloom wire-format header (hash + bincode header).
+///
+/// Returns the small header prefix (~20 bytes). Used by the streaming
+/// serialization path where the body is yielded separately.
+pub(super) fn serialize_header(header: &BloomHeader) -> Vec<u8> {
+    let hash = header.sip_hash();
+    let header_bytes = bincode::serialize(header).expect("BloomHeader serialization cannot fail");
+    let mut buf = Vec::with_capacity(8 + header_bytes.len());
+    buf.extend_from_slice(&hash.to_be_bytes());
+    buf.extend_from_slice(&header_bytes);
+    buf
+}
+
 /// Serialize a bloom header and bit-vector body into the wire format.
 ///
 /// Consumes the word iterator directly — no intermediate collection.
-pub fn serialize(header: &BloomHeader, words: impl Iterator<Item = u64>) -> Vec<u8> {
+/// Used only in tests; the production path streams via `serialize_header`
+/// plus batched word iteration.
+#[cfg(test)]
+fn serialize(header: &BloomHeader, words: impl Iterator<Item = u64>) -> Vec<u8> {
     let hash = header.sip_hash();
     let header_bytes = bincode::serialize(header).expect("BloomHeader serialization cannot fail");
     let word_count = (header.num_bits as usize).div_ceil(64);

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -36,22 +36,14 @@ pub async fn nix_cache_info(State(state): State<Arc<AppState>>) -> impl IntoResp
 
 /// GET /bloom — return serialized local bloom filter
 pub async fn get_bloom(State(state): State<Arc<AppState>>) -> Response {
-    match state.local_bloom.serialize() {
-        Ok(data) => (
-            StatusCode::OK,
-            [("content-type", "application/octet-stream")],
-            data,
-        )
-            .into_response(),
-        Err(e) => {
-            tracing::error!("Failed to serialize bloom: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to serialize bloom",
-            )
-                .into_response()
-        }
-    }
+    let stream = state.local_bloom.serialize_stream();
+    let body = Body::from_stream(stream);
+    (
+        StatusCode::OK,
+        [("content-type", "application/octet-stream")],
+        body,
+    )
+        .into_response()
 }
 
 /// GET /{hash}.narinfo


### PR DESCRIPTION
The /bloom endpoint collected the entire bloom filter (~500KB) into a Vec<u8> before handing it to Axum, requiring a large contiguous allocation for every request.

Replaced LocalBloom::serialize() with serialize_stream(), which uses async_stream::try_stream! to yield the wire-format header followed by ~8KB batches of word bytes read directly from the filter's in-memory iterator. Added wire::serialize_header() to produce just the header prefix for the streaming path, and scoped the old wire::serialize() to #[cfg(test)].

This streams the response from the filter's memory representation without an intermediate buffer, reducing peak per-request allocation from ~500KB to ~8KB.

Test plan:
- Updated serialize_roundtrip tests in local.rs and peers.rs to collect the stream and verify wire-format roundtrip; all 15 tests pass.