### PR TITLE
ogygia-irisd: add range requests and multi-peer downloader

### DIFF
--- a/nixos/irisd/default.nix
+++ b/nixos/irisd/default.nix
@@ -77,6 +77,12 @@ in
         - `cache.max_size_bytes` (int) — maximum total cache size
           in bytes. Default: 10737418240 (10 GiB). Set to 0 for
           unlimited.
+
+        - `cache.chunk_size_mb` (int) — chunk size in megabytes for
+          parallel peer downloads. Default: 4.
+
+        - `cache.escalation_delay_ms` (int) — milliseconds to wait
+          before escalating to multi-peer download. Default: 100.
       '';
     };
 

--- a/src/ogygia-irisd/src/config.rs
+++ b/src/ogygia-irisd/src/config.rs
@@ -100,6 +100,12 @@ pub struct CacheConfig {
     /// Maximum total size in bytes of all cached NAR files (0 = unlimited)
     #[serde(default = "default_max_size_bytes")]
     pub max_size_bytes: u64,
+    /// Chunk size for parallel peer downloads in megabytes
+    #[serde(default = "default_chunk_size_mb")]
+    pub chunk_size_mb: u64,
+    /// Delay before escalating to multi-peer download (milliseconds)
+    #[serde(default = "default_escalation_delay_ms")]
+    pub escalation_delay_ms: u64,
 }
 
 fn default_cache_dir() -> PathBuf {
@@ -114,12 +120,22 @@ fn default_max_size_bytes() -> u64 {
     10 * 1024 * 1024 * 1024 // 10 GiB
 }
 
+fn default_chunk_size_mb() -> u64 {
+    4
+}
+
+fn default_escalation_delay_ms() -> u64 {
+    100
+}
+
 impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             dir: default_cache_dir(),
             time_to_idle_secs: default_time_to_idle_secs(),
             max_size_bytes: default_max_size_bytes(),
+            chunk_size_mb: default_chunk_size_mb(),
+            escalation_delay_ms: default_escalation_delay_ms(),
         }
     }
 }
@@ -223,6 +239,8 @@ listen = ["127.0.0.1:35742"]
         );
         assert_eq!(config.cache.time_to_idle_secs, 3600);
         assert_eq!(config.cache.max_size_bytes, 10 * 1024 * 1024 * 1024);
+        assert_eq!(config.cache.chunk_size_mb, 4);
+        assert_eq!(config.cache.escalation_delay_ms, 100);
     }
 
     #[test]

--- a/src/ogygia-irisd/src/downloader.rs
+++ b/src/ogygia-irisd/src/downloader.rs
@@ -1,0 +1,420 @@
+//! Multi-peer parallel NAR downloader.
+//!
+//! Downloads compressed NARs from multiple peers using adaptive parallelism:
+//! small files complete from a single peer, large files scale to dozens of
+//! peers using HTTP Range requests.
+
+use std::collections::VecDeque;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use tokio::io::AsyncSeekExt;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+
+use crate::config::CacheConfig;
+
+/// Result of downloading a NAR from peers.
+pub struct DownloadedNar {
+    /// Path to the temporary file containing the compressed NAR.
+    pub path: PathBuf,
+    /// Compressed file size in bytes.
+    pub size: u64,
+}
+
+/// Multi-peer parallel NAR downloader.
+pub struct PeerDownloader {
+    chunk_size: u64,
+    escalation_delay: Duration,
+    temp_dir: PathBuf,
+}
+
+impl PeerDownloader {
+    pub fn new(config: &CacheConfig) -> Self {
+        Self {
+            chunk_size: config.chunk_size_mb * 1024 * 1024,
+            escalation_delay: Duration::from_millis(config.escalation_delay_ms),
+            temp_dir: config.dir.join("downloads"),
+        }
+    }
+
+    /// Download a NAR from peers to a temporary file.
+    ///
+    /// Accepts a stream of validated peer NAR URLs. Starts with a single
+    /// peer and escalates to parallel range-based downloading for large
+    /// files after `escalation_delay`.
+    pub async fn download(
+        &self,
+        client: &reqwest::Client,
+        mut peer_urls: mpsc::UnboundedReceiver<String>,
+    ) -> Result<DownloadedNar> {
+        // Wait for the first peer URL
+        let first_url = peer_urls
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("No peers available for NAR download"))?;
+
+        // Send initial GET to determine Content-Length
+        let response = client
+            .get(&first_url)
+            .send()
+            .await
+            .context("Failed to connect to peer")?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("Peer returned {} for NAR download", response.status());
+        }
+
+        let content_length = response.content_length();
+
+        // Create temp file
+        let temp_path = self
+            .temp_dir
+            .join(format!("download-{}.nar.zst.tmp", rand::random::<u64>()));
+
+        let result = match content_length {
+            Some(total_size) if total_size > self.chunk_size => {
+                self.download_parallel(
+                    client, response, &first_url, total_size, &temp_path, peer_urls,
+                )
+                .await
+            }
+            _ => {
+                // Small file or unknown size: single peer, stream through
+                self.download_single(response, &temp_path).await
+            }
+        };
+
+        match result {
+            Ok(nar) => Ok(nar),
+            Err(e) => {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Download from a single peer, streaming the full response.
+    async fn download_single(
+        &self,
+        response: reqwest::Response,
+        temp_path: &Path,
+    ) -> Result<DownloadedNar> {
+        let mut file = tokio::fs::File::create(temp_path).await?;
+        let mut total_size: u64 = 0;
+
+        let mut stream = response.bytes_stream();
+        use futures::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.context("Failed to read from peer")?;
+            file.write_all(&chunk).await?;
+            total_size += chunk.len() as u64;
+        }
+
+        file.flush().await?;
+
+        Ok(DownloadedNar {
+            path: temp_path.to_path_buf(),
+            size: total_size,
+        })
+    }
+
+    /// Download from multiple peers using range requests.
+    async fn download_parallel(
+        &self,
+        client: &reqwest::Client,
+        first_response: reqwest::Response,
+        first_url: &str,
+        total_size: u64,
+        temp_path: &Path,
+        mut peer_urls: mpsc::UnboundedReceiver<String>,
+    ) -> Result<DownloadedNar> {
+        // Pre-allocate the output file
+        let file = tokio::fs::File::create(temp_path).await?;
+        file.set_len(total_size).await?;
+        let file = std::sync::Arc::new(tokio::sync::Mutex::new(file));
+
+        // Build the work queue: first chunk is being handled by the initial
+        // response, remaining chunks go into the queue
+        let queue = std::sync::Arc::new(WorkQueue::new(total_size, self.chunk_size));
+
+        // Take chunk 0 for the first peer (it's already streaming)
+        let chunk0 = queue.take_chunk();
+
+        // Spawn the first peer's streaming download for chunk 0
+        let file_clone = file.clone();
+        let chunk0_handle = tokio::spawn(async move {
+            if let Some((offset, length)) = chunk0 {
+                write_response_chunk(first_response, file_clone, offset, length).await
+            } else {
+                Ok(0)
+            }
+        });
+
+        // After escalation delay OR chunk 0 completion, start parallel workers
+        let escalation_delay = self.escalation_delay;
+        let client = client.clone();
+        let queue_clone = queue.clone();
+        let file_clone = file.clone();
+        let expected_size = total_size;
+
+        let mut worker_handles = Vec::new();
+
+        // Wait for either escalation delay or chunk 0 completion
+        let chunk0_result = tokio::select! {
+            result = chunk0_handle => {
+                // Chunk 0 finished before escalation timer — might be done
+                Some(result.context("chunk 0 task panicked")??)
+            }
+            _ = tokio::time::sleep(escalation_delay) => {
+                None // Timer fired, start parallel workers
+            }
+        };
+
+        // Collect available peer URLs and spawn workers
+        let mut available_peers: Vec<String> = Vec::new();
+
+        // Drain any immediately available peer URLs
+        while let Ok(url) = peer_urls.try_recv() {
+            available_peers.push(url);
+        }
+
+        // Also add the first peer for subsequent chunks (it supports ranges
+        // if it returned Content-Length)
+        let first_url_owned = first_url.to_string();
+
+        // Spawn workers for available peers
+        for peer_url in available_peers {
+            let client = client.clone();
+            let queue = queue_clone.clone();
+            let file = file_clone.clone();
+            worker_handles.push(tokio::spawn(async move {
+                peer_worker(client, peer_url, queue, file, expected_size).await;
+            }));
+        }
+
+        // If chunk 0 hasn't finished yet, wait for it and also continue
+        // accepting new peers
+        if chunk0_result.is_none() {
+            // First peer can also work on subsequent chunks
+            let client2 = client.clone();
+            let queue2 = queue_clone.clone();
+            let file2 = file_clone.clone();
+            worker_handles.push(tokio::spawn(async move {
+                peer_worker(client2, first_url_owned, queue2, file2, expected_size).await;
+            }));
+
+            // Continue accepting peer URLs until the channel closes
+            // or all work is done
+            let queue3 = queue_clone.clone();
+            let client3 = client.clone();
+            let file3 = file_clone.clone();
+            worker_handles.push(tokio::spawn(async move {
+                while let Some(url) = peer_urls.recv().await {
+                    if queue3.is_complete() {
+                        break;
+                    }
+                    let client = client3.clone();
+                    let queue = queue3.clone();
+                    let file = file3.clone();
+                    tokio::spawn(async move {
+                        peer_worker(client, url, queue, file, expected_size).await;
+                    });
+                }
+            }));
+        }
+
+        // Wait for all workers to finish
+        for handle in worker_handles {
+            let _ = handle.await;
+        }
+
+        if !queue.is_complete() {
+            anyhow::bail!("NAR download incomplete: not all chunks were fetched");
+        }
+
+        Ok(DownloadedNar {
+            path: temp_path.to_path_buf(),
+            size: total_size,
+        })
+    }
+}
+
+/// Write a response body to a file at a specific offset, up to `length` bytes.
+async fn write_response_chunk(
+    response: reqwest::Response,
+    file: std::sync::Arc<tokio::sync::Mutex<tokio::fs::File>>,
+    offset: u64,
+    length: u64,
+) -> Result<u64> {
+    let mut written: u64 = 0;
+    let mut stream = response.bytes_stream();
+    use futures::StreamExt;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("Failed to read from peer")?;
+        let remaining = length - written;
+        let to_write = chunk.len().min(remaining as usize);
+
+        {
+            let mut f = file.lock().await;
+            f.seek(std::io::SeekFrom::Start(offset + written)).await?;
+            f.write_all(&chunk[..to_write]).await?;
+        }
+
+        written += to_write as u64;
+        if written >= length {
+            break;
+        }
+    }
+
+    Ok(written)
+}
+
+/// Worker loop for a single peer: take chunks from the queue and download them.
+async fn peer_worker(
+    client: reqwest::Client,
+    peer_url: String,
+    queue: std::sync::Arc<WorkQueue>,
+    file: std::sync::Arc<tokio::sync::Mutex<tokio::fs::File>>,
+    expected_total_size: u64,
+) {
+    let mut failures = 0u32;
+    const MAX_FAILURES: u32 = 3;
+
+    loop {
+        let Some((offset, length)) = queue.take_chunk() else {
+            break;
+        };
+
+        let end = offset + length - 1;
+        let range_header = format!("bytes={offset}-{end}");
+
+        let result = async {
+            let resp = client
+                .get(&peer_url)
+                .header("Range", &range_header)
+                .send()
+                .await?;
+
+            if resp.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+                // Peer supports range requests
+                write_response_chunk(resp, file.clone(), offset, length).await?;
+                Ok(true)
+            } else if resp.status().is_success() {
+                // Peer returned 200 — doesn't support ranges. Check
+                // Content-Length matches to detect compression mismatch.
+                if let Some(cl) = resp.content_length()
+                    && cl != expected_total_size
+                {
+                    tracing::error!(
+                        "Peer {} has different compressed size: expected {}, got {}",
+                        peer_url,
+                        expected_total_size,
+                        cl
+                    );
+                    return Ok(false);
+                }
+                // Consume full response writing from offset 0
+                write_response_chunk(resp, file.clone(), 0, expected_total_size).await?;
+                // Mark all chunks as complete
+                queue.mark_all_complete();
+                Ok(true)
+            } else {
+                anyhow::bail!("Peer returned {}", resp.status());
+            }
+        }
+        .await;
+
+        match result {
+            Ok(true) => {
+                failures = 0;
+            }
+            Ok(false) => {
+                // Compression mismatch — reject this peer entirely
+                queue.return_chunk(offset, length);
+                break;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Peer {} failed on chunk at offset {}: {}",
+                    peer_url,
+                    offset,
+                    e
+                );
+                queue.return_chunk(offset, length);
+                failures += 1;
+
+                if failures >= MAX_FAILURES && !queue.is_only_worker() {
+                    tracing::warn!("Peer {} banned after {} failures", peer_url, failures);
+                    break;
+                }
+
+                // If this is the only peer, retry with backoff
+                tokio::time::sleep(Duration::from_millis(100 * failures as u64)).await;
+            }
+        }
+    }
+}
+
+/// Shared work queue for parallel chunk downloading.
+struct WorkQueue {
+    chunks: Mutex<VecDeque<(u64, u64)>>,
+    completed_bytes: AtomicU64,
+    total_size: u64,
+    active_workers: AtomicU64,
+}
+
+impl WorkQueue {
+    fn new(total_size: u64, chunk_size: u64) -> Self {
+        let mut chunks = VecDeque::new();
+        let mut offset = 0;
+        while offset < total_size {
+            let length = (total_size - offset).min(chunk_size);
+            chunks.push_back((offset, length));
+            offset += length;
+        }
+        Self {
+            chunks: Mutex::new(chunks),
+            completed_bytes: AtomicU64::new(0),
+            total_size,
+            active_workers: AtomicU64::new(0),
+        }
+    }
+
+    fn take_chunk(&self) -> Option<(u64, u64)> {
+        let mut chunks = self.chunks.blocking_lock();
+        let chunk = chunks.pop_front();
+        if chunk.is_some() {
+            self.active_workers.fetch_add(1, Ordering::Relaxed);
+        }
+        chunk
+    }
+
+    fn return_chunk(&self, offset: u64, length: u64) {
+        let mut chunks = self.chunks.blocking_lock();
+        chunks.push_back((offset, length));
+        self.active_workers.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    fn mark_all_complete(&self) {
+        self.completed_bytes
+            .store(self.total_size, Ordering::Relaxed);
+        let mut chunks = self.chunks.blocking_lock();
+        chunks.clear();
+    }
+
+    fn is_complete(&self) -> bool {
+        self.completed_bytes.load(Ordering::Relaxed) >= self.total_size
+    }
+
+    fn is_only_worker(&self) -> bool {
+        self.active_workers.load(Ordering::Relaxed) <= 1
+    }
+}

--- a/src/ogygia-irisd/src/main.rs
+++ b/src/ogygia-irisd/src/main.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::EnvFilter;
 
 mod bloom;
 mod config;
+mod downloader;
 mod nix;
 mod server;
 mod store;
@@ -155,6 +156,13 @@ async fn main() -> Result<()> {
         }));
     }
 
+    // Initialize multi-peer downloader
+    let downloads_dir = config.cache.dir.join("downloads");
+    tokio::fs::create_dir_all(&downloads_dir)
+        .await
+        .context("Failed to create downloads directory")?;
+    let downloader = Arc::new(downloader::PeerDownloader::new(&config.cache));
+
     // HTTP server (runs until token is cancelled)
     tasks.push(tokio::spawn(server::start(
         config,
@@ -162,6 +170,7 @@ async fn main() -> Result<()> {
         peer_blooms,
         http_client,
         nar_cache,
+        downloader,
         token.clone(),
     )));
 

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -7,14 +7,18 @@ use axum::Json;
 use axum::body::Body;
 use axum::extract::Path;
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncSeekExt;
 use tokio_util::io::ReaderStream;
 
 use super::AppState;
+use super::range::ByteRange;
 use crate::nix::cache::NarCache;
 use crate::nix::narinfo::NarInfo;
 use crate::nix::narinfo::nar_hash_to_hex;
@@ -164,35 +168,42 @@ async fn try_local_store_narinfo(hash: &str, nar_cache: &NarCache) -> Option<Nar
 /// Path format: `nar/{nar_hash}/{store_hash}-{name}.nar.zst`
 /// The NarHash in the URL makes requests self-describing so we don't need
 /// server-side state to match narinfo responses to NAR content.
-pub async fn get_nar(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
-    let Some((nar_hash, hash)) = parse_nar_path(&path) else {
-        tracing::warn!("Invalid NAR path format: {}", path);
-        return (StatusCode::NOT_FOUND, "Not found").into_response();
-    };
-
-    let local = try_local_store_nar(hash, nar_hash, &state.nar_cache).await;
-    if local.status() != StatusCode::NOT_FOUND {
-        return local;
-    }
-
-    // Try peers via bloom lookup
-    state.try_peer_nar(hash, nar_hash).await
-}
-
-/// GET /local/nar/{path} — local-only NAR download (no peer fan-out)
-///
-/// Used by peers to fetch NARs from this node's local store without
-/// triggering cascading fan-out across the cluster.
-pub async fn get_local_nar(
+pub async fn get_nar(
     State(state): State<Arc<AppState>>,
     Path(path): Path<String>,
+    headers: HeaderMap,
 ) -> Response {
     let Some((nar_hash, hash)) = parse_nar_path(&path) else {
         tracing::warn!("Invalid NAR path format: {}", path);
         return (StatusCode::NOT_FOUND, "Not found").into_response();
     };
 
-    try_local_store_nar(hash, nar_hash, &state.nar_cache).await
+    // Try local first (cache-backed, range-capable)
+    let local = try_local_store_nar(hash, nar_hash, &state.nar_cache, &headers).await;
+    if local.status() != StatusCode::NOT_FOUND {
+        return local;
+    }
+
+    // Try peers via multi-peer downloader (not cached)
+    state.try_peer_nar(hash, nar_hash).await
+}
+
+/// GET /local/nar/{path} — local-only NAR download (no peer fan-out)
+///
+/// Used by peers to fetch NARs from this node's local store without
+/// triggering cascading fan-out across the cluster. Supports range
+/// requests for parallel chunk downloading.
+pub async fn get_local_nar(
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    let Some((nar_hash, hash)) = parse_nar_path(&path) else {
+        tracing::warn!("Invalid NAR path format: {}", path);
+        return (StatusCode::NOT_FOUND, "Not found").into_response();
+    };
+
+    try_local_store_nar(hash, nar_hash, &state.nar_cache, &headers).await
 }
 
 /// Parse a NAR path into `(nar_hash, store_hash)`.
@@ -205,10 +216,14 @@ fn parse_nar_path(path: &str) -> Option<(&str, &str)> {
 }
 
 /// Try to serve a NAR from the local store via the disk cache.
+///
+/// Generates the compressed NAR to cache on first access, then serves
+/// from cache with range request support.
 async fn try_local_store_nar(
     hash: &str,
     expected_nar_hash: &str,
     nar_cache: &NarCache,
+    headers: &HeaderMap,
 ) -> Response {
     let Some(store_path) = find_store_path(hash).await else {
         return (StatusCode::NOT_FOUND, "Not found").into_response();
@@ -250,17 +265,69 @@ async fn try_local_store_nar(
     };
 
     tracing::info!("Serving cached NAR for {}", store_path.display());
-    let body = Body::from_stream(ReaderStream::new(file));
-    let content_length = cached.file_size.to_string();
-    (
-        StatusCode::OK,
-        [
-            ("content-type", "application/zstd"),
-            ("content-length", content_length.as_str()),
-        ],
-        body,
-    )
-        .into_response()
+    serve_cached_nar(file, cached.file_size, headers).await
+}
+
+/// Serve a cached NAR file, supporting HTTP Range requests.
+async fn serve_cached_nar(
+    mut file: tokio::fs::File,
+    total_size: u64,
+    headers: &HeaderMap,
+) -> Response {
+    // Check for Range header
+    let range: Option<ByteRange> = headers
+        .get("range")
+        .and_then(|v| v.to_str().ok())
+        .and_then(ByteRange::parse);
+
+    if let Some(range) = range {
+        let Some((offset, length)) = range.resolve(total_size) else {
+            return (
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                [("content-range", format!("bytes */{total_size}").as_str())],
+            )
+                .into_response();
+        };
+
+        if let Err(e) = file.seek(std::io::SeekFrom::Start(offset)).await {
+            tracing::error!("Failed to seek in cached NAR: {}", e);
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Seek failed").into_response();
+        }
+
+        let limited = file.take(length);
+        let stream = ReaderStream::new(limited);
+        let body = Body::from_stream(stream);
+
+        let end = offset + length - 1;
+        let content_range = format!("bytes {offset}-{end}/{total_size}");
+
+        (
+            StatusCode::PARTIAL_CONTENT,
+            [
+                ("content-type", "application/zstd".to_string()),
+                ("content-length", length.to_string()),
+                ("content-range", content_range),
+                ("accept-ranges", "bytes".to_string()),
+            ],
+            body,
+        )
+            .into_response()
+    } else {
+        // Full file
+        let stream = ReaderStream::new(file);
+        let body = Body::from_stream(stream);
+
+        (
+            StatusCode::OK,
+            [
+                ("content-type", "application/zstd".to_string()),
+                ("content-length", total_size.to_string()),
+                ("accept-ranges", "bytes".to_string()),
+            ],
+            body,
+        )
+            .into_response()
+    }
 }
 
 /// Query parameters for GET /providers/{hash}

--- a/src/ogygia-irisd/src/server/mod.rs
+++ b/src/ogygia-irisd/src/server/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP server for Nix binary cache protocol
 
 mod handlers;
+pub(crate) mod range;
 mod routes;
 mod state;
 
@@ -18,6 +19,7 @@ use tracing::Level;
 use crate::bloom::local::LocalBloom;
 use crate::bloom::peers::PeerBlooms;
 use crate::config::Config;
+use crate::downloader::PeerDownloader;
 use crate::nix::cache::NarCache;
 
 /// Start HTTP servers on all configured listen addresses with graceful shutdown.
@@ -27,6 +29,7 @@ pub async fn start(
     peer_blooms: Arc<PeerBlooms>,
     http_client: reqwest::Client,
     nar_cache: Arc<NarCache>,
+    downloader: Arc<PeerDownloader>,
     token: CancellationToken,
 ) -> Result<()> {
     let state = Arc::new(AppState {
@@ -35,6 +38,7 @@ pub async fn start(
         peer_blooms,
         http_client,
         nar_cache,
+        downloader,
     });
 
     let app = create_router(state).layer(

--- a/src/ogygia-irisd/src/server/range.rs
+++ b/src/ogygia-irisd/src/server/range.rs
@@ -1,0 +1,139 @@
+//! HTTP Range header parsing (RFC 7233, single byte ranges only).
+
+/// A parsed single byte range from an HTTP `Range` header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ByteRange {
+    /// `bytes=START-END` (inclusive on both ends)
+    FromTo(u64, u64),
+    /// `bytes=START-` (from offset to end of file)
+    From(u64),
+    /// `bytes=-N` (last N bytes)
+    Suffix(u64),
+}
+
+impl ByteRange {
+    /// Parse a `Range` header value. Only single byte ranges are supported.
+    ///
+    /// Returns `None` for malformed or multi-range headers.
+    pub fn parse(header: &str) -> Option<Self> {
+        let spec = header.strip_prefix("bytes=")?;
+
+        // Reject multi-range
+        if spec.contains(',') {
+            return None;
+        }
+
+        let (start, end) = spec.split_once('-')?;
+
+        if start.is_empty() {
+            // bytes=-N (suffix)
+            let n: u64 = end.parse().ok()?;
+            if n == 0 {
+                return None;
+            }
+            Some(ByteRange::Suffix(n))
+        } else if end.is_empty() {
+            // bytes=START-
+            let start: u64 = start.parse().ok()?;
+            Some(ByteRange::From(start))
+        } else {
+            // bytes=START-END
+            let start: u64 = start.parse().ok()?;
+            let end: u64 = end.parse().ok()?;
+            if start > end {
+                return None;
+            }
+            Some(ByteRange::FromTo(start, end))
+        }
+    }
+
+    /// Resolve this range against a known file size.
+    ///
+    /// Returns `(offset, length)` or `None` if the range is unsatisfiable.
+    pub fn resolve(self, total_size: u64) -> Option<(u64, u64)> {
+        if total_size == 0 {
+            return None;
+        }
+        match self {
+            ByteRange::FromTo(start, end) => {
+                if start >= total_size {
+                    return None;
+                }
+                let end = end.min(total_size - 1);
+                Some((start, end - start + 1))
+            }
+            ByteRange::From(start) => {
+                if start >= total_size {
+                    return None;
+                }
+                Some((start, total_size - start))
+            }
+            ByteRange::Suffix(n) => {
+                let offset = total_size.saturating_sub(n);
+                Some((offset, total_size - offset))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_from_to() {
+        assert_eq!(
+            ByteRange::parse("bytes=0-499"),
+            Some(ByteRange::FromTo(0, 499))
+        );
+        assert_eq!(
+            ByteRange::parse("bytes=500-999"),
+            Some(ByteRange::FromTo(500, 999))
+        );
+    }
+
+    #[test]
+    fn test_parse_from() {
+        assert_eq!(ByteRange::parse("bytes=500-"), Some(ByteRange::From(500)));
+    }
+
+    #[test]
+    fn test_parse_suffix() {
+        assert_eq!(ByteRange::parse("bytes=-500"), Some(ByteRange::Suffix(500)));
+    }
+
+    #[test]
+    fn test_parse_invalid() {
+        assert_eq!(ByteRange::parse("bytes="), None);
+        assert_eq!(ByteRange::parse("bytes=500-200"), None); // start > end
+        assert_eq!(ByteRange::parse("bytes=-0"), None); // suffix of 0
+        assert_eq!(ByteRange::parse("bytes=0-100,200-300"), None); // multi-range
+        assert_eq!(ByteRange::parse("items=0-100"), None); // wrong unit
+    }
+
+    #[test]
+    fn test_resolve_from_to() {
+        assert_eq!(ByteRange::FromTo(0, 499).resolve(1000), Some((0, 500)));
+        assert_eq!(ByteRange::FromTo(0, 1999).resolve(1000), Some((0, 1000)));
+        assert_eq!(ByteRange::FromTo(1000, 1999).resolve(1000), None);
+    }
+
+    #[test]
+    fn test_resolve_from() {
+        assert_eq!(ByteRange::From(500).resolve(1000), Some((500, 500)));
+        assert_eq!(ByteRange::From(0).resolve(1000), Some((0, 1000)));
+        assert_eq!(ByteRange::From(1000).resolve(1000), None);
+    }
+
+    #[test]
+    fn test_resolve_suffix() {
+        assert_eq!(ByteRange::Suffix(500).resolve(1000), Some((500, 500)));
+        assert_eq!(ByteRange::Suffix(2000).resolve(1000), Some((0, 1000)));
+    }
+
+    #[test]
+    fn test_resolve_empty_file() {
+        assert_eq!(ByteRange::From(0).resolve(0), None);
+        assert_eq!(ByteRange::Suffix(100).resolve(0), None);
+    }
+}

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -9,10 +9,13 @@ use axum::response::Response;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream::FuturesUnordered;
+use tokio::sync::mpsc;
+use tokio_util::io::ReaderStream;
 
 use crate::bloom::local::LocalBloom;
 use crate::bloom::peers::PeerBlooms;
 use crate::config::Config;
+use crate::downloader::PeerDownloader;
 use crate::nix::cache::NarCache;
 use crate::nix::narinfo::NarInfo;
 use crate::nix::narinfo::nar_hash_to_sri;
@@ -24,6 +27,7 @@ pub struct AppState {
     pub peer_blooms: Arc<PeerBlooms>,
     pub http_client: reqwest::Client,
     pub nar_cache: Arc<NarCache>,
+    pub downloader: Arc<PeerDownloader>,
 }
 
 impl AppState {
@@ -85,14 +89,14 @@ impl AppState {
         None
     }
 
-    /// Try to proxy a NAR from a peer found via bloom filter lookup.
+    /// Try to download a NAR from peers using the multi-peer downloader.
     ///
-    /// Streams bloom lookups concurrently with narinfo fetches: as each
-    /// peer's bloom becomes available and matches the hash, a narinfo fetch
-    /// is started immediately — without waiting for all blooms to arrive.
+    /// Validates bloom lookups and narinfo concurrently, producing a stream
+    /// of validated peer NAR URLs. The downloader fetches chunks from
+    /// multiple peers in parallel for large files.
     ///
-    /// The expected NarHash is extracted from the request URL, so peers whose
-    /// NarHash doesn't match are skipped without needing server-side state.
+    /// The downloaded NAR is NOT cached — `/nix/store` is the cache for
+    /// remote content. The temp file is streamed to the client then deleted.
     pub(super) async fn try_peer_nar(&self, hash: &str, expected_nar_hash: &str) -> Response {
         let peer_urls = &self.config.peers.urls;
         if peer_urls.is_empty() {
@@ -106,60 +110,124 @@ impl AppState {
             .lookup_stream(peer_urls, hash, &self.http_client)
             .await;
 
-        // Convert the hex hash from the URL to SRI format once, so we can
-        // compare directly against each peer's NarHash without repeated conversion.
         let expected_sri = nar_hash_to_sri(expected_nar_hash);
 
         let client = self.http_client.clone();
         let mut narinfo_futs = FuturesUnordered::new();
 
-        loop {
-            tokio::select! {
-                biased;
+        // Channel for sending validated peer NAR URLs to the downloader
+        let (url_tx, url_rx) = mpsc::unbounded_channel::<String>();
 
-                Some(result) = narinfo_futs.next() => {
-                    let Some((peer_url, narinfo)): Option<(String, NarInfo)> = result else {
-                        continue;
-                    };
+        // Spawn the URL producer: validate bloom+narinfo, send URLs to downloader
+        let producer_handle = {
+            let hash = hash.to_string();
+            let expected_sri = expected_sri.clone();
+            let trusted_keys = trusted_keys.clone();
+            let client = client.clone();
 
-                    if !trusted_keys.is_empty() && !narinfo.has_trusted_signature(trusted_keys) {
-                        tracing::debug!(
-                            "narinfo {} from {} has no trusted signature, skipping",
-                            hash,
-                            peer_url
-                        );
-                        continue;
-                    }
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        biased;
 
-                    // Skip peers whose NarHash doesn't match the one in the URL
-                    if narinfo.nar_hash != expected_sri {
-                        continue;
-                    }
+                        Some(result) = narinfo_futs.next() => {
+                            let Some((peer_url, narinfo)): Option<(String, NarInfo)> = result else {
+                                continue;
+                            };
 
-                    let nar_url = format!("{}/local/{}", peer_url.trim_end_matches('/'), narinfo.url);
-                    match stream_nar_from_url(&self.http_client, &nar_url).await {
-                        Some(response) => {
-                            tracing::info!("Proxying NAR {} from peer {}", hash, peer_url);
-                            return response;
+                            if !trusted_keys.is_empty() && !narinfo.has_trusted_signature(&trusted_keys) {
+                                tracing::debug!(
+                                    "narinfo {} from {} has no trusted signature, skipping",
+                                    hash,
+                                    peer_url
+                                );
+                                continue;
+                            }
+
+                            if narinfo.nar_hash != expected_sri {
+                                continue;
+                            }
+
+                            let nar_url = format!(
+                                "{}/local/{}",
+                                peer_url.trim_end_matches('/'),
+                                narinfo.url
+                            );
+                            if url_tx.send(nar_url).is_err() {
+                                break; // Downloader dropped the receiver
+                            }
                         }
-                        None => continue,
+
+                        Some(peer_url) = candidate_rx.recv() => {
+                            narinfo_futs.push(fetch_narinfo_from_peer(
+                                client.clone(),
+                                peer_url,
+                                hash.clone(),
+                            ));
+                        }
+
+                        else => break,
                     }
                 }
+            })
+        };
 
-                Some(peer_url) = candidate_rx.recv() => {
-                    narinfo_futs.push(fetch_narinfo_from_peer(
-                        client.clone(),
-                        peer_url,
-                        hash.to_string(),
-                    ));
-                }
+        // Run the multi-peer downloader
+        let download_result = self.downloader.download(&self.http_client, url_rx).await;
 
-                else => break,
+        // Clean up the producer
+        producer_handle.abort();
+
+        match download_result {
+            Ok(downloaded) => {
+                tracing::info!(
+                    "Downloaded NAR {} from peers ({} bytes)",
+                    hash,
+                    downloaded.size
+                );
+                serve_temp_file(downloaded.path, downloaded.size).await
+            }
+            Err(e) => {
+                tracing::warn!("Failed to download NAR {} from peers: {}", hash, e);
+                (StatusCode::NOT_FOUND, "Not found").into_response()
             }
         }
-
-        (StatusCode::NOT_FOUND, "Not found").into_response()
     }
+}
+
+/// Serve a temp file as a streaming response, then delete it.
+async fn serve_temp_file(path: std::path::PathBuf, size: u64) -> Response {
+    let file = match tokio::fs::File::open(&path).await {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::error!("Failed to open downloaded NAR: {}", e);
+            let _ = tokio::fs::remove_file(&path).await;
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Failed to read NAR").into_response();
+        }
+    };
+
+    let stream = ReaderStream::new(file);
+    let body = Body::from_stream(stream.map_err(|e| std::io::Error::other(e.to_string())));
+
+    // Spawn cleanup to delete the temp file after the response is sent.
+    // We can't delete it immediately since the body is streaming from it.
+    // Instead, we rely on the file handle keeping it alive on Linux (unlink
+    // while open is safe). Delete after a delay to ensure the stream has
+    // time to start.
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+        let _ = tokio::fs::remove_file(&path).await;
+    });
+
+    (
+        StatusCode::OK,
+        [
+            ("content-type", "application/zstd"),
+            ("content-length", &size.to_string()),
+        ],
+        body,
+    )
+        .into_response()
 }
 
 /// Fetch and parse a narinfo from a single peer.
@@ -199,34 +267,4 @@ async fn fetch_narinfo_from_peer(
             None
         }
     }
-}
-
-/// Fetch a NAR from a URL and return it as a streaming response.
-async fn stream_nar_from_url(client: &reqwest::Client, url: &str) -> Option<Response> {
-    let response = client.get(url).send().await.ok()?;
-    if !response.status().is_success() {
-        return None;
-    }
-
-    let content_type = response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/x-nix-nar")
-        .to_string();
-
-    let body = Body::from_stream(
-        response
-            .bytes_stream()
-            .map_err(|e| std::io::Error::other(e.to_string())),
-    );
-
-    Some(
-        (
-            StatusCode::OK,
-            [("content-type", content_type.as_str())],
-            body,
-        )
-            .into_response(),
-    )
 }


### PR DESCRIPTION
ogygia-irisd fetches NARs from a single peer — the first to respond via
bloom filter lookup. This is optimal for small NARs but suboptimal for
large ones: a slow or flaky peer becomes a bottleneck with no recovery.

Add HTTP Range request support on local NAR endpoints and a multi-peer
parallel downloader that adaptively scales from one peer for small files
to many peers for large ones using chunked range requests. The downloader
validates Content-Length consistency across peers to detect compression
mismatches, tracks peer failures (banning after 3), and uses a shared
work queue for chunk distribution. Download temp files are isolated in a
dedicated subdirectory to avoid interference with the NAR cache recovery.

This enables resilient, parallel NAR fetching for large store paths while
preserving the fast single-peer path for small ones.

Test plan:
- CI
- Existing config parsing tests extended with new default assertions
- Range parser has comprehensive unit tests