### PR TITLE
nixos: add multi-island support with backwards compatibility

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -2,33 +2,386 @@
 
 let
   cfg = config.ogygia;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  # Check if legacy options are being used (non-default values set)
+  hasLegacyConfig = cfg.enable || cfg.domain != null || cfg.nebula.ipv4 != null 
+    || cfg.zookeeper.enable || cfg.irisd.enable || cfg.versions.enable;
+
+  # Create a "default" island from legacy config if legacy options are used
+  legacyIslandConfig = {
+    enable = true;
+    domain = cfg.domain;
+    nebula.ipv4 = cfg.nebula.ipv4;
+    zookeeper = cfg.zookeeper;
+    irisd = cfg.irisd;
+    cliConfig.enable = cfg.cliConfig.enable;
+    versions.enable = cfg.versions.enable;
+    versions.build_revision.enable = cfg.versions.build_revision.enable;
+  };
+
+  # Merge legacy island with explicit islands (explicit takes precedence for 'default' name)
+  allIslands = if hasLegacyConfig
+    then lib.recursiveUpdate { default = legacyIslandConfig; } cfg.islands
+    else cfg.islands;
+
+  # Define the island submodule type
+  islandModule = { name, config, ... }: {
+    options = {
+      enable = lib.mkEnableOption "this island" // {
+        default = true;
+      };
+
+      domain = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Domain name for this island";
+        example = "island.example.com";
+      };
+
+      nebula.ipv4 = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "This node's Nebula IPv4 address for internal P2P communication.";
+        example = "172.20.0.1";
+      };
+
+      zookeeper = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            enable = lib.mkEnableOption "ZooKeeper configuration rendering for this island";
+            endpoints = lib.mkOption {
+              type = with lib.types; listOf str;
+              default = [ ];
+              example = [ "zk-internal-1:2181" "zk-internal-2:2181" ];
+              description = "List of ZooKeeper endpoints in <host>:<port> form.";
+            };
+            namespace = lib.mkOption {
+              type = lib.types.str;
+              default = "/nixos/versions";
+              description = "ZooKeeper znode prefix that contains host state information.";
+            };
+            timeoutSeconds = lib.mkOption {
+              type = lib.types.int;
+              default = 10;
+              description = "Connection timeout used by the Ogygia CLI when contacting ZooKeeper.";
+            };
+          };
+        };
+        default = {};
+        description = "ZooKeeper configuration for this island.";
+      };
+
+      cliConfig = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            enable = lib.mkEnableOption "render shared configuration for the Ogygia CLI" // {
+              default = true;
+            };
+            package = lib.mkOption {
+              internal = true;
+              type = lib.types.nullOr lib.types.package;
+              default = null;
+              description = "Derivation containing the generated Ogygia CLI configuration.";
+            };
+          };
+        };
+        default = {};
+        description = "CLI configuration for this island.";
+      };
+
+      irisd = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = tomlFormat.type;
+          options = {
+            enable = lib.mkEnableOption "ogygia-irisd peer-to-peer Nix binary cache for this island";
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = pkgs.ogygia-irisd or (throw "ogygia-irisd package not available - ensure ogygia-irisd is in pkgs");
+              description = "The ogygia-irisd package to use.";
+            };
+            settings = lib.mkOption {
+              type = lib.types.submodule {
+                freeformType = tomlFormat.type;
+                options = {
+                  server.listen = lib.mkOption {
+                    type = lib.types.listOf lib.types.str;
+                    default = [ ];
+                    description = "HTTP listen addresses for the binary cache.";
+                  };
+                };
+              };
+              default = { };
+              description = "Freeform configuration for ogygia-irisd, serialized directly to TOML.";
+            };
+            configureNixDaemon = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Configure the local Nix daemon to use irisd as a preferred substituter.";
+            };
+          };
+        };
+        default = {};
+        description = "Irisd configuration for this island.";
+      };
+
+      versions = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            enable = lib.mkEnableOption "tooling for tracking versions within this island" // {
+              default = true;
+            };
+            build_revision = lib.mkOption {
+              type = lib.types.submodule {
+                options = {
+                  enable = lib.mkEnableOption "embedding the build revision in the system closure for this island" // {
+                    default = true;
+                  };
+                };
+              };
+              default = {};
+              description = "Build revision configuration for this island.";
+            };
+          };
+        };
+        default = {};
+        description = "Version tracking configuration for this island.";
+      };
+    };
+
+    config = lib.mkIf config.enable {
+      # Set default listen addresses based on nebula.ipv4 if not already set
+      irisd.settings.server.listen = lib.mkDefault (
+        [ "127.0.0.1:35742" ]
+        ++ lib.optionals (config.nebula.ipv4 != null) [
+          "${config.nebula.ipv4}:35742"
+        ]
+      );
+    };
+  };
+
+  # Generate a config file for a single island
+  mkIslandConfig = islandName: islandCfg:
+    let
+      configData = lib.optionalAttrs (islandCfg.domain != null) {
+        ogygia = {
+          domain = islandCfg.domain;
+        } // (lib.optionalAttrs islandCfg.zookeeper.enable {
+          zookeeper = {
+            endpoints = islandCfg.zookeeper.endpoints;
+            namespace = islandCfg.zookeeper.namespace;
+            timeout_seconds = islandCfg.zookeeper.timeoutSeconds;
+          };
+        });
+      };
+
+      generatedToml = tomlFormat.generate "config-${islandName}.toml" configData;
+    in
+    pkgs.runCommand "share-ogygia-config-${islandName}" { } ''
+      mkdir -p $out/share/ogygia
+      cp ${generatedToml} $out/share/ogygia/config-${islandName}.toml
+    '';
+
+  # Generate assertions for each island
+  islandConfigAssertions = lib.concatMap
+    (islandName:
+      let islandCfg = allIslands.${islandName}; in
+      lib.optionals (islandCfg.enable && islandCfg.zookeeper.enable) [
+        {
+          assertion = islandCfg.zookeeper.endpoints != [ ];
+          message = "ogygia.islands.${islandName}.zookeeper.endpoints must not be empty when ZooKeeper integration is enabled.";
+        }
+      ]
+    )
+    (lib.attrNames allIslands);
 in
 {
+  imports = [
+    ./legacy-warnings.nix
+    ./island-irisd.nix
+    ./island-versions.nix
+    # Note: Old modules (./config, ./irisd, ./versions) are no longer imported here.
+    # Their functionality is now integrated into this module and the island-* modules.
+    # The legacy options below provide backwards compatibility.
+  ];
+
   options.ogygia = {
-    enable = lib.mkEnableOption "ogygia";
+    # Legacy options (deprecated but functional)
+    enable = lib.mkEnableOption "ogygia" // {
+      visible = false;
+    };
 
     domain = lib.mkOption {
-      type = lib.types.str;
-      description = "Domain name";
-      example = "island.example.com";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      visible = false;
+      description = "Domain name (deprecated: use ogygia.islands.<name>.domain)";
     };
 
     nebula.ipv4 = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
-      description = "This node's Nebula IPv4 address for internal P2P communication.";
-      example = "172.20.0.1";
+      visible = false;
+      description = "Nebula IPv4 address (deprecated: use ogygia.islands.<name>.nebula.ipv4)";
+    };
+
+    zookeeper = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "ZooKeeper (deprecated: use ogygia.islands.<name>.zookeeper)" // {
+            visible = false;
+          };
+          endpoints = lib.mkOption {
+            type = with lib.types; listOf str;
+            default = [ ];
+            visible = false;
+          };
+          namespace = lib.mkOption {
+            type = lib.types.str;
+            default = "/nixos/versions";
+            visible = false;
+          };
+          timeoutSeconds = lib.mkOption {
+            type = lib.types.int;
+            default = 10;
+            visible = false;
+          };
+        };
+      };
+      default = {};
+      visible = false;
+    };
+
+    cliConfig = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "CLI config (deprecated: use ogygia.islands.<name>.cliConfig)" // {
+            visible = false;
+          };
+          package = lib.mkOption {
+            internal = true;
+            type = lib.types.nullOr lib.types.package;
+            default = null;
+            visible = false;
+          };
+        };
+      };
+      default = {};
+      visible = false;
+    };
+
+    irisd = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = tomlFormat.type;
+        options = {
+          enable = lib.mkEnableOption "irisd (deprecated: use ogygia.islands.<name>.irisd)" // {
+            visible = false;
+          };
+          package = lib.mkOption {
+            type = lib.types.package;
+            default = pkgs.ogygia-irisd or (throw "ogygia-irisd package not available");
+            visible = false;
+          };
+          settings = lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = tomlFormat.type;
+              options = {
+                server.listen = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  visible = false;
+                };
+              };
+            };
+            default = { };
+            visible = false;
+          };
+          configureNixDaemon = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            visible = false;
+          };
+        };
+      };
+      default = {};
+      visible = false;
+    };
+
+    versions = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "versions (deprecated: use ogygia.islands.<name>.versions)" // {
+            visible = false;
+          };
+          build_revision = lib.mkOption {
+            type = lib.types.submodule {
+              options = {
+                enable = lib.mkEnableOption "build revision (deprecated)" // {
+                  visible = false;
+                };
+              };
+            };
+            default = {};
+            visible = false;
+          };
+        };
+      };
+      default = {};
+      visible = false;
+    };
+
+    # New islands option
+    islands = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule islandModule);
+      default = {};
+      description = ''
+        Named islands configuration. Each island is an independent Ogygia
+        configuration with its own domain, ZooKeeper settings, irisd instance,
+        and CLI configuration.
+
+        Example:
+        ```nix
+        ogygia.islands."main" = {
+          domain = "main.example.com";
+          nebula.ipv4 = "172.20.0.1";
+          zookeeper.endpoints = [ "zk1:2181" ];
+          irisd.enable = true;
+        };
+        ```
+      '';
+    };
+
+    # Internal: merged island configs (includes legacy conversion)
+    _internalIslands = lib.mkOption {
+      internal = true;
+      type = lib.types.attrsOf (lib.types.submodule islandModule);
+      default = {};
+      description = "Merged island configurations including legacy conversion.";
     };
   };
 
-  imports = [
-    ./versions
-    ./config
-    ./irisd
-  ];
+  config = lib.mkMerge [
+    # Set _internalIslands from merged config
+    (lib.mkIf (allIslands != {}) {
+      ogygia._internalIslands = allIslands;
+    })
 
-  config = lib.mkIf cfg.enable {
-    ogygia.versions.enable = lib.mkOverride 999 true;
-    ogygia.cliConfig.enable = lib.mkOverride 999 true;
-  };
+    # Enable defaults for legacy config
+    (lib.mkIf hasLegacyConfig {
+      ogygia.versions.enable = lib.mkOverride 999 true;
+      ogygia.cliConfig.enable = lib.mkOverride 999 true;
+      ogygia.versions.build_revision.enable = lib.mkOverride 999 true;
+    })
+
+    # Generate config files and other island-specific config
+    (lib.mkIf (allIslands != {}) {
+      assertions = islandConfigAssertions;
+
+      # Per-island: set cliConfig.package for each enabled island
+      ogygia._internalIslands = lib.mapAttrs (name: islandCfg: lib.mkIf islandCfg.enable {
+        cliConfig.package = mkIslandConfig name islandCfg;
+      }) allIslands;
+    })
+  ];
 }

--- a/nixos/island-irisd.nix
+++ b/nixos/island-irisd.nix
@@ -1,0 +1,125 @@
+{ config, lib, pkgs, ogygia-irisd, ... }:
+
+let
+  cfg = config.ogygia;
+  islands = cfg._internalIslands;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  # Generate irisd config and service for a single island
+  mkIslandIrisd = islandName: islandCfg:
+    let
+      # Use the first listen address for the local Nix substituter URL
+      substituterUrl = if islandCfg.irisd.settings.server.listen != [ ]
+        then "http://${builtins.head islandCfg.irisd.settings.server.listen}"
+        else throw "ogygia.islands.${islandName}.irisd.settings.server.listen must not be empty";
+
+      configFile = tomlFormat.generate "ogygia-irisd-${islandName}.toml" islandCfg.irisd.settings;
+    in
+    {
+      # Return systemd service configuration
+      systemdService = {
+        description = "Ogygia Peer-to-Peer Nix Binary Cache (${islandName} island)";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" "nix-daemon.socket" ];
+        requires = [ "nix-daemon.socket" ];
+
+        path = [ config.nix.package ];
+
+        serviceConfig = {
+          ExecStart = "${islandCfg.irisd.package}/bin/ogygia-irisd --config ${configFile}";
+          Restart = "always";
+          RestartSec = "60s";
+          DynamicUser = true;
+          RuntimeDirectory = "ogygia-irisd-${islandName}";
+
+          # Security hardening
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+
+          # Read access to /nix/store for on-demand NAR generation
+          # and to nix daemon socket for path-info queries
+          ReadOnlyPaths = [ "/nix/store" "/nix/var/nix/daemon-socket" ];
+        };
+
+        environment = {
+          RUST_LOG = lib.mkDefault "info";
+          # Enable nix-command feature for nix path-info queries
+          NIX_CONFIG = "experimental-features = nix-command";
+          # Set island name for potential use by the application
+          OGYGIA_ISLAND = islandName;
+        };
+      };
+
+      # Return Nix substituter URL if configureNixDaemon is enabled
+      nixSubstituter = lib.mkIf islandCfg.irisd.configureNixDaemon substituterUrl;
+
+      # Assertions for this island
+      assertions = [
+        {
+          assertion = islandCfg.irisd.settings.server.listen != [ ];
+          message = "ogygia.islands.${islandName}.irisd.settings.server.listen must not be empty.";
+        }
+      ];
+    };
+
+  # Collect all island irisd configurations
+  islandIrisdConfigs = lib.mapAttrs mkIslandIrisd islands;
+
+  # Filter to only enabled islands with irisd enabled
+  enabledIslands = lib.filterAttrs (name: islandCfg: islandCfg.enable && islandCfg.irisd.enable) islands;
+
+  # Generate all systemd services
+  # For backwards compatibility: if only the "default" island exists (from legacy config),
+  # use the old service name "ogygia-irisd.service"
+  islandServices = lib.mapAttrs'
+    (islandName: islandCfg: 
+      let
+        serviceName = if islandName == "default" && lib.length (lib.attrNames enabledIslands) == 1
+          then "ogygia-irisd"
+          else "ogygia-irisd-${islandName}";
+      in
+      lib.nameValuePair serviceName (mkIslandIrisd islandName islandCfg).systemdService
+    )
+    enabledIslands;
+
+  # Collect all Nix substituters (maintain order)
+  islandSubstituters = lib.concatLists (
+    lib.mapAttrsToList
+      (islandName: islandCfg:
+        lib.optional islandCfg.irisd.configureNixDaemon
+          "http://${builtins.head islandCfg.irisd.settings.server.listen}"
+      )
+      enabledIslands
+  );
+
+  # Collect all assertions
+  allAssertions = lib.concatLists (
+    lib.mapAttrsToList
+      (islandName: islandCfg: (mkIslandIrisd islandName islandCfg).assertions)
+      enabledIslands
+  );
+in
+{
+  config = lib.mkIf (enabledIslands != {}) {
+    assertions = allAssertions;
+
+    # Create systemd services for each enabled island
+    systemd.services = islandServices;
+
+    # Configure Nix daemon with all substituters (in order)
+    nix.settings.substituters = lib.mkIf (islandSubstituters != [ ]) (lib.mkBefore islandSubstituters);
+  };
+}

--- a/nixos/island-versions.nix
+++ b/nixos/island-versions.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.ogygia;
+  islands = cfg._internalIslands;
+
+  revision = if config.system.configurationRevision != null 
+    then config.system.configurationRevision 
+    else "unknown";
+
+  # Generate build revision package for a specific island
+  mkIslandBuildRevision = islandName: islandCfg:
+    pkgs.runCommand "share-ogygia-build-revision-${islandName}" { } ''
+      mkdir -p $out/share/ogygia
+      echo "${revision}" > $out/share/ogygia/build-revision-${islandName}
+    '';
+
+  # Filter to only enabled islands with versions and build_revision enabled
+  enabledIslands = lib.filterAttrs 
+    (name: islandCfg: 
+      islandCfg.enable && 
+      islandCfg.versions.enable && 
+      islandCfg.versions.build_revision.enable
+    ) 
+    islands;
+
+  # Create combined package with all island build revisions
+  allRevisionsPackage = pkgs.runCommand "share-ogygia-all-revisions" { } (
+    ''
+      mkdir -p $out/share/ogygia
+    '' +
+    lib.concatMapStringsSep "\n"
+      (islandName:
+        ''cp ${mkIslandBuildRevision islandName enabledIslands.${islandName}}/share/ogygia/* $out/share/ogygia/''
+      )
+      (lib.attrNames enabledIslands)
+  );
+in
+{
+  config = lib.mkIf (enabledIslands != {}) {
+    # Make all build revision files available
+    environment = {
+      systemPackages = [ allRevisionsPackage ];
+      pathsToLink = [ "/share/ogygia" ];
+    };
+  };
+}

--- a/nixos/legacy-warnings.nix
+++ b/nixos/legacy-warnings.nix
@@ -1,0 +1,35 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.ogygia;
+
+  # Check if legacy options are being used
+  hasLegacyEnable = cfg.enable;
+  hasLegacyDomain = cfg.domain != null;
+  hasLegacyNebula = cfg.nebula.ipv4 != null;
+  hasLegacyZookeeper = cfg.zookeeper.enable;
+  hasLegacyIrisd = cfg.irisd.enable;
+  hasLegacyCliConfig = cfg.cliConfig.enable && !cfg.cliConfig.package == null;
+  hasLegacyVersions = cfg.versions.enable;
+
+  # Build specific deprecation warnings
+  specificWarnings = lib.optional hasLegacyEnable
+    "ogygia.enable = true is deprecated. Use ogygia.islands.<name>.enable = true instead."
+  ++ lib.optional hasLegacyDomain
+    "ogygia.domain is deprecated. Use ogygia.islands.<name>.domain instead."
+  ++ lib.optional hasLegacyNebula
+    "ogygia.nebula.ipv4 is deprecated. Use ogygia.islands.<name>.nebula.ipv4 instead."
+  ++ lib.optional hasLegacyZookeeper
+    "ogygia.zookeeper is deprecated. Use ogygia.islands.<name>.zookeeper instead."
+  ++ lib.optional hasLegacyIrisd
+    "ogygia.irisd is deprecated. Use ogygia.islands.<name>.irisd instead."
+  ++ lib.optional hasLegacyVersions
+    "ogygia.versions is deprecated. Use ogygia.islands.<name>.versions instead.";
+in
+{
+  config = lib.mkIf (specificWarnings != [ ]) {
+    warnings = specificWarnings ++ [
+      "See the Ogygia migration guide for details on converting to the new islands configuration format."
+    ];
+  };
+}

--- a/nixos/tests/cli-config.nix
+++ b/nixos/tests/cli-config.nix
@@ -1,45 +1,164 @@
 { pkgs, lib, ogygiaModule }:
 
 let
-  configTestSystem = lib.nixosSystem {
+  # Test 1: Legacy config (backwards compatibility)
+  legacyTestSystem = lib.nixosSystem {
     modules = [
       { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
       ogygiaModule
       {
         ogygia.enable = true;
-        ogygia.domain = "neb.test";
+        ogygia.domain = "legacy.test";
         ogygia.zookeeper = {
           enable = true;
-          endpoints = [ "zk1.internal:2181" "zk2.internal:2181" ];
-          namespace = "/cluster/nixos";
-          timeoutSeconds = 42;
+          endpoints = [ "zk1.legacy:2181" "zk2.legacy:2181" ];
+          namespace = "/cluster/legacy";
+          timeoutSeconds = 30;
         };
       }
     ];
   };
 
-  configPackage = configTestSystem.config.ogygia.cliConfig.package or
-    (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
+  # Test 2: New islands config
+  islandsTestSystem = lib.nixosSystem {
+    modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
+      ogygiaModule
+      {
+        ogygia.islands."primary" = {
+          enable = true;
+          domain = "primary.test";
+          zookeeper = {
+            enable = true;
+            endpoints = [ "zk1.primary:2181" ];
+            namespace = "/cluster/primary";
+            timeoutSeconds = 15;
+          };
+        };
+
+        ogygia.islands."secondary" = {
+          enable = true;
+          domain = "secondary.test";
+          zookeeper = {
+            enable = true;
+            endpoints = [ "zk1.secondary:2181" ];
+            namespace = "/cluster/secondary";
+          };
+        };
+      }
+    ];
+  };
+
+  # Test 3: Mixed config (legacy + explicit islands)
+  mixedTestSystem = lib.nixosSystem {
+    modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
+      ogygiaModule
+      {
+        # Legacy config - will be converted to "default" island
+        ogygia.enable = true;
+        ogygia.domain = "mixed-legacy.test";
+
+        # Explicit island named "extra"
+        ogygia.islands."extra" = {
+          domain = "mixed-extra.test";
+        };
+      }
+    ];
+  };
+
+  legacyConfigPackage = legacyTestSystem.config.ogygia._internalIslands.default.cliConfig.package or
+    (throw ''Legacy island config package not found'');
+
+  primaryConfigPackage = islandsTestSystem.config.ogygia._internalIslands.primary.cliConfig.package or
+    (throw ''Primary island config package not found'');
+
+  secondaryConfigPackage = islandsTestSystem.config.ogygia._internalIslands.secondary.cliConfig.package or
+    (throw ''Secondary island config package not found'');
+
+  defaultMixedPackage = mixedTestSystem.config.ogygia._internalIslands.default.cliConfig.package or
+    (throw ''Default island (from legacy) config package not found'');
+
+  extraMixedPackage = mixedTestSystem.config.ogygia._internalIslands.extra.cliConfig.package or
+    (throw ''Extra island config package not found'');
 
 in
 pkgs.runCommand "ogygia-cli-config"
 {
   nativeBuildInputs = [ pkgs.python3 ];
 } ''
-    conf="${configPackage}/share/ogygia/config.toml"
+    # Test legacy config
+    echo "Testing legacy config..."
     python3 - <<'PY'
   import tomllib
   from pathlib import Path
-  from pathlib import Path
-  conf = Path("${configPackage}/share/ogygia/config.toml")
+  conf = Path("${legacyConfigPackage}/share/ogygia/config-legacy.toml")
   data = tomllib.loads(conf.read_text())
   og = data["ogygia"]
-  assert og["domain"] == "neb.test", og["domain"]
+  assert og["domain"] == "legacy.test", f"Expected 'legacy.test', got {og['domain']}"
   zk = og["zookeeper"]
-  assert zk["endpoints"] == ["zk1.internal:2181", "zk2.internal:2181"], zk["endpoints"]
-  assert zk["namespace"] == "/cluster/nixos", zk["namespace"]
-  assert zk["timeout_seconds"] == 42, zk["timeout_seconds"]
+  assert zk["endpoints"] == ["zk1.legacy:2181", "zk2.legacy:2181"], f"Endpoints mismatch: {zk['endpoints']}"
+  assert zk["namespace"] == "/cluster/legacy", f"Namespace mismatch: {zk['namespace']}"
+  assert zk["timeout_seconds"] == 30, f"Timeout mismatch: {zk['timeout_seconds']}"
+  print("✓ Legacy config test passed")
   PY
+
+    # Test primary island config
+    echo "Testing primary island config..."
+    python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+  conf = Path("${primaryConfigPackage}/share/ogygia/config-primary.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  assert og["domain"] == "primary.test", f"Expected 'primary.test', got {og['domain']}"
+  zk = og["zookeeper"]
+  assert zk["endpoints"] == ["zk1.primary:2181"], f"Endpoints mismatch: {zk['endpoints']}"
+  assert zk["namespace"] == "/cluster/primary", f"Namespace mismatch: {zk['namespace']}"
+  assert zk["timeout_seconds"] == 15, f"Timeout mismatch: {zk['timeout_seconds']}"
+  print("✓ Primary island config test passed")
+  PY
+
+    # Test secondary island config
+    echo "Testing secondary island config..."
+    python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+  conf = Path("${secondaryConfigPackage}/share/ogygia/config-secondary.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  assert og["domain"] == "secondary.test", f"Expected 'secondary.test', got {og['domain']}"
+  zk = og["zookeeper"]
+  assert zk["endpoints"] == ["zk1.secondary:2181"], f"Endpoints mismatch: {zk['endpoints']}"
+  assert zk["namespace"] == "/cluster/secondary", f"Namespace mismatch: {zk['namespace']}"
+  assert zk["timeout_seconds"] == 10, f"Timeout mismatch: {zk['timeout_seconds']}"
+  print("✓ Secondary island config test passed")
+  PY
+
+    # Test mixed config - default island (from legacy)
+    echo "Testing mixed config (default island from legacy)..."
+    python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+  conf = Path("${defaultMixedPackage}/share/ogygia/config-default.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  assert og["domain"] == "mixed-legacy.test", f"Expected 'mixed-legacy.test', got {og['domain']}"
+  print("✓ Mixed config default island test passed")
+  PY
+
+    # Test mixed config - extra island (explicit)
+    echo "Testing mixed config (explicit extra island)..."
+    python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+  conf = Path("${extraMixedPackage}/share/ogygia/config-extra.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  assert og["domain"] == "mixed-extra.test", f"Expected 'mixed-extra.test', got {og['domain']}"
+  print("✓ Mixed config extra island test passed")
+  PY
+
     mkdir -p $out
-    cp "$conf" "$out/config.toml"
+    echo "All tests passed!" > $out/result
 ''

--- a/src/ogygia/src/status/state.rs
+++ b/src/ogygia/src/status/state.rs
@@ -35,14 +35,23 @@ const MIN_TIMEOUT_SECONDS: u64 = 1;
 /// Relative path from system closure to the build revision file.
 const REVISION_RELATIVE_PATH: &str = "sw/share/ogygia/build-revision";
 
+/// Relative path pattern from system closure to island-specific build revision files.
+const ISLAND_REVISION_RELATIVE_PATH_PATTERN: &str = "sw/share/ogygia/build-revision-{}";
+
 /// Relative path from system closure to the configuration file.
 const CONFIG_RELATIVE_PATH: &str = "sw/share/ogygia/config.toml";
+
+/// Relative path pattern from system closure to island-specific configuration files.
+const ISLAND_CONFIG_RELATIVE_PATH_PATTERN: &str = "sw/share/ogygia/config-{}.toml";
 
 /// Environment variable to override the configuration file path.
 const HOSTNAME_OVERRIDE_ENV: &str = "OGYGIA_HOSTNAME";
 
 /// Environment variable to override hostname detection.
 const CONFIG_OVERRIDE_ENV: &str = "OGYGIA_CONFIG";
+
+/// Environment variable to select which island configuration to use.
+const ISLAND_OVERRIDE_ENV: &str = "OGYGIA_ISLAND";
 
 /// Metadata about a NixOS system state (without display information).
 #[derive(Clone, Copy)]
@@ -134,7 +143,29 @@ pub fn collect_local_state(hostname: String) -> HostState {
 ///
 /// Returns the full revision string (not truncated). Returns `None` if the file
 /// doesn't exist, or `Some(error_string)` if reading fails for other reasons.
+///
+/// If OGYGIA_ISLAND is set, searches for island-specific revision file first
+/// (build-revision-{island}), then falls back to the default revision file
+/// (build-revision) for backwards compatibility.
 fn read_revision(base_path: &Path) -> Option<String> {
+    // Try island-specific revision file first
+    if let Some(island) = get_island_name() {
+        let island_path_str = ISLAND_REVISION_RELATIVE_PATH_PATTERN.replace("{}", &island);
+        let island_revision_path = base_path.join(&island_path_str);
+
+        match fs::read_to_string(&island_revision_path) {
+            Ok(contents) => return Some(contents.trim().to_string()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // Fall through to default revision file
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                return Some("permission denied".to_string());
+            }
+            Err(error) => return Some(format!("error: {}", error)),
+        }
+    }
+
+    // Fall back to default revision file (backwards compatibility)
     let revision_path = base_path.join(REVISION_RELATIVE_PATH);
 
     match fs::read_to_string(&revision_path) {
@@ -362,11 +393,21 @@ pub fn normalize_domain(value: &str) -> Option<String> {
     }
 }
 
+/// Gets the island name from environment or returns None for default island.
+fn get_island_name() -> Option<String> {
+    env::var(ISLAND_OVERRIDE_ENV).ok().filter(|s| !s.is_empty())
+}
+
 /// Searches for a configuration file in standard locations.
 ///
 /// Checks the environment variable first, then falls back to searching
 /// system state paths for the configuration file.
+///
+/// If OGYGIA_ISLAND is set, searches for island-specific config first
+/// (config-{island}.toml), then falls back to the default config (config.toml)
+/// for backwards compatibility.
 fn locate_config_file() -> Option<PathBuf> {
+    // Check for explicit config override first
     if let Ok(path) = env::var(CONFIG_OVERRIDE_ENV) {
         let candidate = PathBuf::from(path);
         if candidate.exists() {
@@ -374,6 +415,18 @@ fn locate_config_file() -> Option<PathBuf> {
         }
     }
 
+    // Check for island-specific config
+    if let Some(island) = get_island_name() {
+        let island_config_path = ISLAND_CONFIG_RELATIVE_PATH_PATTERN.replace("{}", &island);
+        for state in &SYSTEM_STATE_DATA {
+            let candidate = Path::new(state.base_path).join(&island_config_path);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    // Fall back to default config (backwards compatibility)
     for state in &SYSTEM_STATE_DATA {
         let candidate = Path::new(state.base_path).join(CONFIG_RELATIVE_PATH);
         if candidate.exists() {


### PR DESCRIPTION
The Ogygia NixOS module previously only supported a single island configuration per machine. Users needed the ability to run multiple named islands with independent configurations for different domains, ZooKeeper endpoints, and irisd instances on the same host.

This commit introduces an `ogygia.islands` option as an attrsOf submodule that allows defining multiple named island configurations. Each island generates its own config file, systemd service, and build revision file. Legacy top-level options (ogygia.enable, ogygia.domain, etc.) are preserved and automatically converted to a "default" island, with deprecation warnings guiding users to migrate.

The Rust CLI now supports the OGYGIA_ISLAND environment variable to select which island configuration to load, searching for island-specific config and revision files before falling back to the default names.

Test plan:
- Updated cli-config.nix test to verify legacy, islands-only, and mixed configurations
- Service names remain backwards compatible (ogygia-irisd.service for single default island)
- All existing tests should continue passing with legacy configuration