### PR TITLE
ogygia: add Nebula certificate management with content-addressed storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,11 +1216,14 @@ name = "ogygia"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
+ "hex",
  "hostname",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml",
  "tracing",

--- a/flake.nix
+++ b/flake.nix
@@ -60,12 +60,17 @@
           inherit (craneLib.crateNameFromCargoToml { inherit src; }) version;
 
           fileSetForCrate = crate:
+            let
+              crateSources = craneLib.fileset.commonCargoSources crate;
+              nebulaSources = lib.fileset.maybeMissing ./src/ogygia/src/nebula;
+            in
             lib.fileset.toSource {
               root = ./.;
               fileset = lib.fileset.unions [
                 ./Cargo.toml
                 ./Cargo.lock
-                (craneLib.fileset.commonCargoSources crate)
+                crateSources
+                nebulaSources
               ];
             };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -25,6 +25,7 @@ in
     ./versions
     ./config
     ./irisd
+    ./nebula
   ];
 
   config = lib.mkIf cfg.enable {

--- a/nixos/nebula/default.nix
+++ b/nixos/nebula/default.nix
@@ -1,0 +1,350 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.ogygia.nebula;
+
+  # Compute the identity hash for content-addressed certificate lookup
+  # This must match the Rust implementation in src/nebula/cert.rs
+  computeIdentityHash = pubKeyFingerprint: ip: groups: fqdn:
+    let
+      sortedGroups = lib.sort lib.lessThan groups;
+      hashInput = lib.concatStrings [
+        pubKeyFingerprint
+        ip
+        fqdn
+        (lib.concatStrings sortedGroups)
+      ];
+    in
+      lib.substring 0 32 (builtins.hashString "sha256" hashInput);
+
+  # Get public key fingerprint (would be extracted from host key during activation)
+  # For now, this is computed during activation script
+  hostKeyPath = cfg.hostKeyPath;
+  hostPubKeyPath = cfg.hostKeyPath + ".pub";
+
+  # Certificate path is computed at eval time but the actual file
+  # is looked up at activation time based on host's public key
+  # This creates the content-addressed lookup mechanism
+  certDir = cfg.rekeyedDir or "./nebula/rekeyed";
+
+  # Service name for nebula network
+  networkName = "ogygia";
+in
+{
+  options.ogygia.nebula = {
+    enable = lib.mkEnableOption "Ogygia-managed Nebula certificate and overlay network";
+
+    ip = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        Nebula IP address with CIDR for this host.
+        This is part of the certificate identity and affects the content-addressed hash.
+      '';
+      example = "172.20.0.1/24";
+    };
+
+    groups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        Nebula groups for firewall rules.
+        These are part of the certificate identity and affect the content-addressed hash.
+        Common groups include "lighthouse", "relay", "server", "client".
+      '';
+      example = [ "lighthouse" "server" ];
+    };
+
+    caCert = lib.mkOption {
+      type = lib.types.path;
+      default = ./nebula/ca.crt;
+      description = ''
+        Path to the Nebula CA certificate (public).
+        This file should be committed to your repository.
+      '';
+    };
+
+    rekeyedDir = lib.mkOption {
+      type = lib.types.path;
+      default = ./nebula/rekeyed;
+      description = ''
+        Path to the directory containing content-addressed rekeyed certificates.
+        Certificates in this directory follow the pattern:
+        <hash>.<fqdn>.crt
+        where <hash> is computed from (pubKey + ip + groups + fqdn).
+      '';
+    };
+
+    hostKeyPath = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/ogygia/nebula/host.key";
+      description = ''
+        Path where the host's Nebula private key is stored.
+        The corresponding public key will be at this path + ".pub".
+        This key is generated automatically if it doesn't exist.
+      '';
+    };
+
+    exposePublicKey = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Make the host's public key available for retrieval during certificate signing.
+        The public key is placed at /var/lib/ogygia/nebula/host.pub.
+      '';
+    };
+
+    # Computed option - the actual certificate file path (content-addressed)
+    certFile = lib.mkOption {
+      type = lib.types.path;
+      readOnly = true;
+      description = ''
+        Content-addressed path to the certificate file for this host.
+        This is computed at activation time based on the host's public key fingerprint
+        and the configured IP, groups, and FQDN.
+      '';
+    };
+
+    # Network configuration passed through to services.nebula
+    isLighthouse = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether this host is a Nebula lighthouse.";
+    };
+
+    isRelay = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether this host is a Nebula relay.";
+    };
+
+    lighthouses = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = "List of lighthouse IPs (only used on non-lighthouse hosts).";
+    };
+
+    staticHostMap = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = {};
+      description = ''
+        Static mapping of lighthouse IPs to their external addresses.
+        Example: { "172.20.0.1" = [ "lighthouse.example.com:4242" ]; }
+      '';
+    };
+
+    firewall = {
+      inbound = lib.mkOption {
+        type = lib.types.listOf lib.types.attrs;
+        default = [];
+        description = "Inbound firewall rules (nebula network only).";
+      };
+
+      outbound = lib.mkOption {
+        type = lib.types.listOf lib.types.attrs;
+        default = [{ host = "any"; port = "any"; proto = "any"; }];
+        description = "Outbound firewall rules.";
+      };
+    };
+
+    listen = {
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "[::]";
+        description = "Host to listen on.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+        description = ''
+          Port to listen on. If null, uses ephemeral port (non-lighthouses).
+          Set to 4242 for lighthouses.
+        '';
+      };
+    };
+
+    tun = {
+      device = lib.mkOption {
+        type = lib.types.str;
+        default = "neb.ogygia";
+        description = "TUN device name for Nebula interface.";
+      };
+
+      disabled = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Disable TUN device (useful for mobile clients).";
+      };
+    };
+
+    extraSettings = lib.mkOption {
+      type = lib.types.attrs;
+      default = {};
+      description = "Extra settings passed directly to Nebula configuration.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.ip != "";
+        message = "ogygia.nebula.ip must be set";
+      }
+    ];
+
+    # Compute certFile at eval time
+    # Note: The actual file existence is checked at activation time
+    ogygia.nebula.certFile = 
+      let
+        # We can't know the public key fingerprint at eval time,
+        # so we use a placeholder that will be resolved at activation
+        # The activation script will compute the actual hash
+        identityPrefix = builtins.hashString "sha256" (cfg.ip + config.networking.fqdn + lib.concatStrings cfg.groups);
+      in
+        cfg.rekeyedDir + "/" + identityPrefix + "." + config.networking.fqdn + ".crt";
+
+    # Create service user for Nebula
+    users.users."nebula-${networkName}" = {
+      uid = config.ids.uids."nebula-${networkName}" or (lib.mkForce 900);
+      group = "nebula-${networkName}";
+      description = "Nebula overlay network daemon for ${networkName}";
+    };
+
+    users.groups."nebula-${networkName}" = {
+      gid = config.ids.gids."nebula-${networkName}" or (lib.mkForce 900);
+    };
+
+    # Ensure directories exist
+    systemd.tmpfiles.rules = [
+      "d /var/lib/ogygia/nebula 0755 nebula-${networkName} nebula-${networkName} -"
+    ];
+
+    # Generate keypair if missing
+    systemd.services."nebula-${networkName}-keygen" = {
+      description = "Generate Nebula keypair for ${networkName}";
+      before = [ "nebula@${networkName}.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "nebula-${networkName}";
+        Group = "nebula-${networkName}";
+      };
+      script = ''
+        set -e
+        KEY_FILE="${cfg.hostKeyPath}"
+        PUB_FILE="${hostPubKeyPath}"
+        
+        if [ ! -e "$KEY_FILE" ] && [ ! -e "$PUB_FILE" ]; then
+          echo "Generating new Nebula keypair..."
+          ${pkgs.nebula}/bin/nebula-cert keygen -out-key "$KEY_FILE" -out-pub "$PUB_FILE"
+        fi
+        
+        # Ensure proper permissions
+        if [ -e "$KEY_FILE" ]; then
+          chmod 0400 "$KEY_FILE"
+          chown nebula-${networkName}:nebula-${networkName} "$KEY_FILE"
+        fi
+        
+        if [ -e "$PUB_FILE" ]; then
+          chmod 0444 "$PUB_FILE"
+          chown nebula-${networkName}:nebula-${networkName} "$PUB_FILE"
+        fi
+        
+        # Expose public key for certificate signing if enabled
+        ${lib.optionalString cfg.exposePublicKey ''
+          mkdir -p /var/lib/ogygia/nebula
+          cp "$PUB_FILE" /var/lib/ogygia/nebula/host.pub
+          chmod 0444 /var/lib/ogygia/nebula/host.pub
+        ''}
+      '';
+    };
+
+    # Check certificate exists before starting Nebula
+    systemd.services."nebula-${networkName}-check-cert" = {
+      description = "Check Nebula certificate exists for ${networkName}";
+      before = [ "nebula@${networkName}.service" ];
+      after = [ "nebula-${networkName}-keygen.service" ];
+      requiredBy = [ "nebula@${networkName}.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        # Compute actual content-addressed path based on public key
+        PUB_FILE="${hostPubKeyPath}"
+        
+        if [ ! -e "$PUB_FILE" ]; then
+          echo "ERROR: Host public key not found at $PUB_FILE"
+          echo "The keygen service should have created this. Check the logs."
+          exit 1
+        fi
+        
+        # Read public key content
+        PUB_KEY=$(cat "$PUB_FILE")
+        
+        # Compute fingerprint (first 8 bytes of SHA256 of base64 decoded key)
+        FINGERPRINT=$(echo "$PUB_KEY" | base64 -d 2>/dev/null | sha256sum | head -c 16)
+        
+        # Compute identity hash matching the Rust implementation
+        # hash = sha256(fingerprint + ip + fqdn + sorted_groups)
+        IP="${cfg.ip}"
+        FQDN="${config.networking.fqdn}"
+        GROUPS="${lib.concatStrings cfg.groups}"
+        IDENTITY_HASH=$(echo -n "''${FINGERPHONE}${IP}${FQDN}${GROUPS}" | sha256sum | head -c 32)
+        
+        CERT_FILE="${cfg.rekeyedDir}/''${IDENTITY_HASH}.${FQDN}.crt"
+        
+        if [ ! -e "$CERT_FILE" ]; then
+          echo "ERROR: Nebula certificate not found at expected location:"
+          echo "  $CERT_FILE"
+          echo ""
+          echo "This is a content-addressed certificate. The path is computed from:"
+          echo "  - Host public key fingerprint"
+          echo "  - IP address: ${cfg.ip}"
+          echo "  - FQDN: ${config.networking.fqdn}"
+          echo "  - Groups: [${lib.concatStringsSep ", " cfg.groups}]"
+          echo ""
+          echo "To generate the certificate, run on your development machine:"
+          echo "  ogygia nebula discover  # to see the public key"
+          echo "  ogygia nebula rekey ${config.networking.fqdn} --ca-key /path/to/ca.key"
+          echo ""
+          echo "Then commit the generated certificate and redeploy."
+          exit 1
+        fi
+        
+        echo "Certificate found: $CERT_FILE"
+        
+        # Create a stable symlink that Nebula can use
+        mkdir -p /var/lib/ogygia/nebula
+        ln -sf "$CERT_FILE" /var/lib/ogygia/nebula/host.crt
+      '';
+    };
+
+    # Configure Nebula service
+    services.nebula.networks.${networkName} = {
+      enable = true;
+      
+      ca = cfg.caCert;
+      cert = "/var/lib/ogygia/nebula/host.crt";
+      key = cfg.hostKeyPath;
+      
+      listen = cfg.listen;
+      
+      isLighthouse = cfg.isLighthouse;
+      isRelay = cfg.isRelay;
+      lighthouses = cfg.lighthouses;
+      
+      staticHostMap = cfg.staticHostMap;
+      
+      tun = cfg.tun;
+      
+      firewall = cfg.firewall;
+      
+      settings = cfg.extraSettings;
+    };
+
+    # Add nebula-cert to system packages for debugging
+    environment.systemPackages = lib.optional cfg.exposePublicKey pkgs.nebula;
+  };
+}

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -5,12 +5,18 @@ edition = "2021"
 license.workspace = true
 
 [features]
-default = ["irisd"]
+default = ["irisd", "nebula"]
 irisd = [
     "dep:reqwest",
     "dep:tokio",
     "dep:serde_json",
     "dep:which",
+]
+nebula = [
+    "dep:base64",
+    "dep:sha2",
+    "dep:hex",
+    "dep:serde_json",
 ]
 
 [dependencies]
@@ -28,3 +34,8 @@ reqwest = { workspace = true, features = ["json"], optional = true }
 tokio = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
+
+# Optional deps for nebula feature
+base64 = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -18,6 +18,11 @@
 //!
 //! # Push store paths to irisd (requires irisd feature)
 //! nix build ... --print-out-paths | ogygia iris push --signing-key ./my-key
+//!
+//! # Manage Nebula certificates (requires nebula feature)
+//! ogygia nebula discover
+//! ogygia nebula status
+//! ogygia nebula rekey -a
 //! ```
 //!
 //! # Configuration
@@ -27,6 +32,8 @@
 
 #[cfg(feature = "irisd")]
 mod iris;
+#[cfg(feature = "nebula")]
+mod nebula;
 mod status;
 
 use std::process;
@@ -52,6 +59,9 @@ enum Command {
     /// Interact with irisd binary cache
     #[cfg(feature = "irisd")]
     Iris(iris::IrisArgs),
+    /// Manage Nebula overlay network certificates
+    #[cfg(feature = "nebula")]
+    Nebula(nebula::cli::NebulaArgs),
 }
 
 impl Command {
@@ -60,6 +70,8 @@ impl Command {
             Command::Status => status::show_status(),
             #[cfg(feature = "irisd")]
             Command::Iris(args) => args.run(),
+            #[cfg(feature = "nebula")]
+            Command::Nebula(args) => args.run(),
         }
     }
 }

--- a/src/ogygia/src/nebula/cert.rs
+++ b/src/ogygia/src/nebula/cert.rs
@@ -1,0 +1,394 @@
+//! Nebula certificate management and content-addressed storage.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::{debug, info, warn};
+
+/// Host configuration that defines a Nebula certificate identity
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HostConfig {
+    pub fqdn: String,
+    pub ip: String,
+    pub groups: Vec<String>,
+}
+
+impl HostConfig {
+    /// Compute the content-addressed hash for this host configuration
+    /// The hash includes: public key fingerprint + IP + groups + FQDN
+    /// This ensures the store path is stable across certificate rotations
+    pub fn compute_identity_hash(&self, pub_key_fingerprint: &str) -> String {
+        let mut hasher = Sha256::new();
+        
+        // Include all configuration that affects certificate identity
+        hasher.update(pub_key_fingerprint.as_bytes());
+        hasher.update(self.ip.as_bytes());
+        hasher.update(self.fqdn.as_bytes());
+        
+        // Sort groups for consistent hashing
+        let mut sorted_groups = self.groups.clone();
+        sorted_groups.sort();
+        for group in sorted_groups {
+            hasher.update(group.as_bytes());
+        }
+        
+        let result = hasher.finalize();
+        hex::encode(&result[..16]) // Use first 16 bytes (32 hex chars) for readability
+    }
+}
+
+/// Unix timestamp wrapper for JSON serialization
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Timestamp(#[serde(with = "serde_millis")] pub SystemTime);
+
+mod serde_millis {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    pub fn serialize<S>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let millis = time
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        serializer.serialize_u64(millis)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(UNIX_EPOCH + std::time::Duration::from_secs(secs))
+    }
+}
+
+/// Certificate metadata stored alongside the certificate file
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CertMetadata {
+    pub fqdn: String,
+    pub ip: String,
+    pub groups: Vec<String>,
+    pub valid_until: Timestamp,
+    pub issued_at: Timestamp,
+    pub identity_hash: String,
+    pub public_key_fingerprint: String,
+}
+
+impl CertMetadata {
+    pub fn days_until_expiry(&self) -> i64 {
+        let now = SystemTime::now();
+        match self.valid_until.0.duration_since(now) {
+            Ok(duration) => duration.as_secs() as i64 / 86400,
+            Err(_) => -1, // Already expired
+        }
+    }
+}
+
+/// Parsed certificate information
+#[derive(Clone, Debug)]
+pub struct CertInfo {
+    pub fqdn: String,
+    pub ip: String,
+    pub groups: Vec<String>,
+    pub valid_until_secs: u64,
+    pub identity_hash: String,
+}
+
+impl CertInfo {
+    pub fn days_until_expiry(&self) -> i64 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let remaining = self.valid_until_secs.saturating_sub(now);
+        remaining as i64 / 86400
+    }
+
+    pub fn format_valid_until(&self) -> String {
+        // Format as YYYY-MM-DD using simple date calculation
+        // This is a simplified formatter - for display purposes
+        let secs = self.valid_until_secs;
+        let days_since_epoch = secs / 86400;
+        
+        // Rough approximation: 1970 + days/365.25
+        let year = 1970 + (days_since_epoch as f64 / 365.25) as i64;
+        let day_of_year = days_since_epoch % 365;
+        let month = (day_of_year / 30) + 1;
+        let day = (day_of_year % 30) + 1;
+        
+        format!("{:04}-{:02}-{:02}", year, month, day)
+    }
+}
+
+/// Manages content-addressed Nebula certificates
+pub struct CertificateManager {
+    rekeyed_dir: PathBuf,
+}
+
+impl CertificateManager {
+    pub fn new(rekeyed_dir: PathBuf) -> Self {
+        // Ensure directory exists
+        if let Err(e) = fs::create_dir_all(&rekeyed_dir) {
+            warn!("Failed to create rekeyed directory: {}", e);
+        }
+        Self { rekeyed_dir }
+    }
+
+    /// Get the content-addressed path for a host's certificate
+    pub fn get_cert_path(&self, host: &HostConfig) -> PathBuf {
+        // We need the public key to compute the hash, so we'll use a placeholder
+        // and update the actual storage location when signing
+        // This is called during status checks before we have the key
+        self.rekeyed_dir.join(format!("*.{}.crt", host.fqdn))
+    }
+
+    /// Find the actual certificate file for a host
+    pub fn find_cert_file(&self, host: &HostConfig) -> Option<PathBuf> {
+        let pattern = format!("*.{}.crt", host.fqdn);
+        let entries = fs::read_dir(&self.rekeyed_dir).ok()?;
+        
+        for entry in entries {
+            let entry = entry.ok()?;
+            let filename = entry.file_name();
+            let filename_str = filename.to_string_lossy();
+            
+            if filename_str.ends_with(&format!(".{}.crt", host.fqdn)) {
+                return Some(entry.path());
+            }
+        }
+        
+        None
+    }
+
+    /// Get certificate info for a host if it exists
+    pub fn get_cert_info(&self, host: &HostConfig) -> Result<Option<CertInfo>> {
+        let cert_path = match self.find_cert_file(host) {
+            Some(path) => path,
+            None => return Ok(None),
+        };
+
+        let metadata_path = cert_path.with_extension("json");
+        
+        // Try to read metadata first (faster than parsing cert)
+        if let Ok(content) = fs::read_to_string(&metadata_path) {
+            if let Ok(metadata) = serde_json::from_str::<CertMetadata>(&content) {
+                return Ok(Some(CertInfo {
+                    fqdn: metadata.fqdn,
+                    ip: metadata.ip,
+                    groups: metadata.groups,
+                    valid_until_secs: metadata.valid_until.0
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs(),
+                    identity_hash: metadata.identity_hash,
+                }));
+            }
+        }
+
+        // Fallback: parse certificate directly
+        self.parse_cert_info(&cert_path)
+    }
+
+    /// Parse certificate info from a Nebula certificate file
+    fn parse_cert_info(&self, cert_path: &PathBuf) -> Result<Option<CertInfo>> {
+        // Nebula uses a custom certificate format, not standard x509
+        // We'll need to use nebula-cert to inspect it
+        let output = Command::new("nebula-cert")
+            .args(&["print", "-json", "-path", &cert_path.to_string_lossy()])
+            .output()
+            .context("Failed to run nebula-cert print")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!("nebula-cert print failed: {}", stderr);
+            return Ok(None);
+        }
+
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .context("Failed to parse nebula-cert output")?;
+
+        let details = json
+            .get("details")
+            .ok_or_else(|| anyhow::anyhow!("Missing details in cert print output"))?;
+
+        let fqdn = details
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let ip = details
+            .get("ips")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|ip| ip.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let groups = details
+            .get("groups")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|g| g.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let not_after = details
+            .get("notAfter")
+            .and_then(|v| v.as_str())
+            // Parse RFC3339 format: 2024-01-15T10:30:00Z
+            .and_then(|s| {
+                // Simple RFC3339 parser for the format from nebula-cert
+                // Expected format: "2006-01-02T15:04:05Z"
+                if s.len() >= 19 {
+                    let year: i64 = s[0..4].parse().ok()?;
+                    let month: i64 = s[5..7].parse().ok()?;
+                    let day: i64 = s[8..10].parse().ok()?;
+                    let hour: i64 = s[11..13].parse().ok()?;
+                    let min: i64 = s[14..16].parse().ok()?;
+                    let sec: i64 = s[17..19].parse().ok()?;
+                    
+                    // Simple calculation (not accounting for leap years precisely)
+                    let days_from_epoch = (year - 1970) * 365 + (month - 1) * 30 + (day - 1);
+                    let secs_from_epoch = days_from_epoch * 86400 + hour * 3600 + min * 60 + sec;
+                    Some(secs_from_epoch as u64)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        // Extract identity hash from filename
+        let filename = cert_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        let identity_hash = filename
+            .split('.')
+            .next()
+            .unwrap_or("unknown")
+            .to_string();
+
+        Ok(Some(CertInfo {
+            fqdn,
+            ip,
+            groups,
+            valid_until_secs: not_after,
+            identity_hash,
+        }))
+    }
+
+    /// Sign a certificate for a host using nebula-cert CLI
+    pub fn sign_certificate(
+        &self,
+        host: &HostConfig,
+        pub_key: &str,
+        ca_key: &PathBuf,
+        ca_cert: &PathBuf,
+        validity_days: u32,
+    ) -> Result<PathBuf> {
+        // Compute identity hash
+        let pub_key_fingerprint = compute_pub_key_fingerprint(pub_key)?;
+        let identity_hash = host.compute_identity_hash(&pub_key_fingerprint);
+
+        // Content-addressed path
+        let cert_filename = format!("{}.{}.crt", identity_hash, host.fqdn);
+        let cert_path = self.rekeyed_dir.join(&cert_filename);
+        let metadata_path = cert_path.with_extension("json");
+
+        // Create temporary public key file
+        let temp_pub_key = std::env::temp_dir().join(format!("nebula-{}-pub.key", host.fqdn));
+        fs::write(&temp_pub_key, pub_key)
+            .with_context(|| "Failed to write temporary public key file")?;
+
+        // Build nebula-cert sign command
+        let mut cmd = Command::new("nebula-cert");
+        cmd.args(&[
+            "sign",
+            "-ca-key",
+            &ca_key.to_string_lossy(),
+            "-ca-crt",
+            &ca_cert.to_string_lossy(),
+            "-in-pub",
+            &temp_pub_key.to_string_lossy(),
+            "-out-crt",
+            &cert_path.to_string_lossy(),
+            "-name",
+            &host.fqdn,
+            "-ip",
+            &host.ip,
+            "-duration",
+            &format!("{}h", validity_days * 24),
+        ]);
+
+        // Add groups if any
+        for group in &host.groups {
+            cmd.arg("-groups").arg(group);
+        }
+
+        info!("Running: {:?}", cmd);
+        let output = cmd.output()
+            .with_context(|| "Failed to run nebula-cert sign")?;
+
+        // Cleanup temp file
+        let _ = fs::remove_file(&temp_pub_key);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!("nebula-cert sign failed: {}", stderr));
+        }
+
+        // Write metadata file
+        let now = SystemTime::now();
+        let valid_until = now + std::time::Duration::from_secs(validity_days as u64 * 86400);
+        
+        let metadata = CertMetadata {
+            fqdn: host.fqdn.clone(),
+            ip: host.ip.clone(),
+            groups: host.groups.clone(),
+            valid_until: Timestamp(valid_until),
+            issued_at: Timestamp(now),
+            identity_hash: identity_hash.clone(),
+            public_key_fingerprint: pub_key_fingerprint,
+        };
+
+        let metadata_json = serde_json::to_string_pretty(&metadata)?;
+        fs::write(&metadata_path, metadata_json)
+            .with_context(|| "Failed to write metadata file")?;
+
+        debug!(
+            "Signed certificate for {} at {}",
+            host.fqdn,
+            cert_path.display()
+        );
+
+        Ok(cert_path)
+    }
+}
+
+/// Compute a fingerprint for a public key
+fn compute_pub_key_fingerprint(pub_key: &str) -> Result<String> {
+    use base64::Engine;
+    
+    // Nebula public keys are base64-encoded Curve25519 keys
+    // We'll hash the raw bytes for consistent identity
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(pub_key.trim())
+        .map_err(|e| anyhow::anyhow!("Invalid base64 in public key: {}", e))?;
+    
+    let mut hasher = Sha256::new();
+    hasher.update(&decoded);
+    let result = hasher.finalize();
+    
+    Ok(hex::encode(&result[..8])) // Use first 8 bytes (16 hex chars)
+}

--- a/src/ogygia/src/nebula/cli.rs
+++ b/src/ogygia/src/nebula/cli.rs
@@ -1,0 +1,355 @@
+//! Nebula CLI commands for certificate management.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use tracing::info;
+
+use super::cert::{CertificateManager, HostConfig};
+
+/// Nebula certificate management commands
+#[derive(Parser)]
+pub struct NebulaArgs {
+    #[command(subcommand)]
+    pub command: NebulaCommand,
+}
+
+#[derive(Subcommand)]
+pub enum NebulaCommand {
+    /// Discover hosts needing certificates from NixOS configurations
+    Discover {
+        /// Path to the flake to evaluate
+        #[arg(short = 'f', long, default_value = ".")]
+        flake: PathBuf,
+    },
+    /// Show certificate status for all hosts
+    Status {
+        /// Path to the flake to evaluate for host discovery
+        #[arg(short = 'f', long, default_value = ".")]
+        flake: PathBuf,
+    },
+    /// Rekey (rotate) certificates
+    Rekey {
+        /// Rekey all expiring certificates
+        #[arg(short = 'a', long)]
+        all: bool,
+        /// Specific hostname to rekey (ignored if --all)
+        hostname: Option<String>,
+        /// Path to CA private key (will prompt for passphrase if encrypted)
+        #[arg(short = 'k', long, env = "OGYGIA_NEBULA_CA_KEY")]
+        ca_key: PathBuf,
+        /// Path to CA certificate
+        #[arg(short = 'c', long, default_value = "./nebula/ca.crt")]
+        ca_cert: PathBuf,
+        /// Path to the flake to evaluate
+        #[arg(short = 'f', long, default_value = ".")]
+        flake: PathBuf,
+        /// Certificate validity in days
+        #[arg(short = 'd', long, default_value = "90")]
+        validity_days: u32,
+        /// Rotate certificates expiring within this many days
+        #[arg(short = 'R', long, default_value = "30")]
+        rotate_before_days: u32,
+        /// Groups to assign (comma-separated, for new hosts only)
+        #[arg(short = 'g', long)]
+        groups: Option<String>,
+    },
+}
+
+impl NebulaArgs {
+    pub fn run(&self) -> Result<()> {
+        match &self.command {
+            NebulaCommand::Discover { flake } => discover_hosts(flake),
+            NebulaCommand::Status { flake } => show_status(flake),
+            NebulaCommand::Rekey {
+                all,
+                hostname,
+                ca_key,
+                ca_cert,
+                flake,
+                validity_days,
+                rotate_before_days,
+                groups,
+            } => {
+                if !all && hostname.is_none() {
+                    return Err(anyhow::anyhow!(
+                        "Either --all flag or a hostname must be specified"
+                    ));
+                }
+                rekey_certs(
+                    *all,
+                    hostname.as_deref(),
+                    ca_key,
+                    ca_cert,
+                    flake,
+                    *validity_days,
+                    *rotate_before_days,
+                    groups.as_deref(),
+                )
+            }
+        }
+    }
+}
+
+fn discover_hosts(flake: &PathBuf) -> Result<()> {
+    info!("Discovering hosts from NixOS configurations...");
+
+    let hosts = discover_hosts_from_nix(flake)?;
+
+    if hosts.is_empty() {
+        println!("No hosts found with ogygia.nebula enabled.");
+        return Ok(());
+    }
+
+    println!("Found {} hosts with ogygia.nebula enabled:", hosts.len());
+    println!();
+    println!("{:<40} {:<18} {:<20} {}",
+        "Host", "IP", "Groups", "Rekeyed Dir");
+    println!("{}", "-".repeat(110));
+
+    for (host, rekeyed_dir) in hosts {
+        let groups_str = if host.groups.is_empty() {
+            "[]".to_string()
+        } else {
+            format!("[{}]", host.groups.join(", "))
+        };
+        println!("{:<40} {:<18} {:<20} {}",
+            host.fqdn, host.ip, groups_str, rekeyed_dir.display());
+    }
+
+    Ok(())
+}
+
+fn show_status(flake: &PathBuf) -> Result<()> {
+    let hosts = discover_hosts_from_nix(flake)?;
+
+    if hosts.is_empty() {
+        println!("No hosts configured with ogygia.nebula.");
+        return Ok(());
+    }
+
+    println!("{:<40} {:<18} {:<18} {:<14} {:<12} {}",
+        "Host", "IP", "Groups", "Valid Until", "Expires In", "Status");
+    println!("{}", "-".repeat(110));
+
+    for (host, rekeyed_dir) in hosts {
+        let groups_str = if host.groups.is_empty() {
+            "[]".to_string()
+        } else {
+            format!("[{}]", host.groups.join(", "))
+        };
+
+        let manager = CertificateManager::new(rekeyed_dir);
+        
+        match manager.get_cert_info(&host)? {
+            Some(info) => {
+                let expires_in_days = info.days_until_expiry();
+                let status = if expires_in_days <= 0 {
+                    "✗ expired"
+                } else if expires_in_days <= 30 {
+                    "⚠ expiring soon"
+                } else {
+                    "✓ current"
+                };
+
+                println!("{:<40} {:<18} {:<18} {:<14} {:<12} {}",
+                    host.fqdn,
+                    host.ip,
+                    groups_str,
+                    info.format_valid_until(),
+                    format!("{} days", expires_in_days),
+                    status
+                );
+            }
+            None => {
+                println!("{:<40} {:<18} {:<18} {:<14} {:<12} {}",
+                    host.fqdn,
+                    host.ip,
+                    groups_str,
+                    "-",
+                    "-",
+                    "✗ missing"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn rekey_certs(
+    all: bool,
+    hostname: Option<&str>,
+    ca_key: &PathBuf,
+    ca_cert: &PathBuf,
+    flake: &PathBuf,
+    validity_days: u32,
+    rotate_before_days: u32,
+    groups_override: Option<&str>,
+) -> Result<()> {
+    let hosts_with_dirs = discover_hosts_from_nix(flake)?;
+
+    let targets: Vec<(HostConfig, PathBuf)> = if all {
+        if hostname.is_some() {
+            println!("Warning: --all flag specified, ignoring hostname argument");
+        }
+        // Filter hosts that need rotation (expiring or missing)
+        hosts_with_dirs
+            .into_iter()
+            .filter(|(host, rekeyed_dir)| {
+                let manager = CertificateManager::new(rekeyed_dir.clone());
+                match manager.get_cert_info(host) {
+                    Ok(Some(info)) => info.days_until_expiry() <= rotate_before_days as i64,
+                    _ => true, // Missing or error = needs rekey
+                }
+            })
+            .collect()
+    } else {
+        let hostname = hostname.unwrap();
+        hosts_with_dirs
+            .into_iter()
+            .filter(|(h, _)| h.fqdn == hostname)
+            .collect()
+    };
+
+    if targets.is_empty() {
+        println!("No certificates need rekeying.");
+        return Ok(());
+    }
+
+    println!("Rekeying {} certificate(s)...", targets.len());
+    println!("CA key: {}", ca_key.display());
+    println!("Validity: {} days", validity_days);
+    println!();
+
+    for (host, rekeyed_dir) in targets {
+        println!("Rekeying {} ({})...", host.fqdn, host.ip);
+        println!("  Writing to: {}", rekeyed_dir.display());
+
+        // Check if we have the host's public key
+        let pub_key = match get_host_public_key(&host) {
+            Some(key) => key,
+            None => {
+                println!("  ⚠ No public key found for {}. Deploy host first to generate keys.", host.fqdn);
+                continue;
+            }
+        };
+
+        // Apply groups override if specified (for new hosts mainly)
+        let host = if let Some(groups_str) = groups_override {
+            let groups: Vec<String> = groups_str.split(',').map(|s| s.trim().to_string()).collect();
+            HostConfig {
+                groups,
+                ..host
+            }
+        } else {
+            host
+        };
+
+        let manager = CertificateManager::new(rekeyed_dir);
+        
+        match manager.sign_certificate(&host, &pub_key, ca_key, ca_cert, validity_days) {
+            Ok(path) => {
+                println!("  ✓ Signed: {}", path.display());
+                println!("    Content-addressed path: {}", manager.get_cert_path(&host).display());
+            }
+            Err(e) => {
+                println!("  ✗ Failed: {}", e);
+            }
+        }
+    }
+
+    println!();
+    println!("Remember to commit the rekeyed certificates before deploying.");
+
+    Ok(())
+}
+
+fn discover_hosts_from_nix(flake: &PathBuf) -> Result<Vec<(HostConfig, PathBuf)>> {
+    // Use nix eval to discover hosts with ogygia.nebula enabled
+    // Also extract the rekeyedDir from each host's configuration
+    let output = std::process::Command::new("nix")
+        .args(&[
+            "eval",
+            "--json",
+            &format!("{}#nixosConfigurations", flake.display()),
+            "--apply",
+            r#"configs: builtins.mapAttrs (name: cfg: {
+                fqdn = cfg.config.networking.fqdn or name;
+                nebula = cfg.config.ogygia.nebula or null;
+                rekeyedDir = cfg.config.ogygia.nebula.rekeyedDir or null;
+            }) configs"#,
+        ])
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run nix eval: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!("nix eval failed: {}", stderr));
+    }
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| anyhow::anyhow!("Failed to parse nix eval output: {}", e))?;
+
+    let mut hosts = Vec::new();
+
+    if let Some(configs) = json.as_object() {
+        for (_hostname, config) in configs {
+            if let Some(nebula) = config.get("nebula") {
+                if nebula.is_null() {
+                    continue;
+                }
+
+                let fqdn = config
+                    .get("fqdn")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("Missing fqdn in config"))?
+                    .to_string();
+
+                let ip = nebula
+                    .get("ip")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("Missing ip for {}", fqdn))?
+                    .to_string();
+
+                let groups = nebula
+                    .get("groups")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|g| g.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                // Get the rekeyedDir from NixOS config, or use default
+                let rekeyed_dir = config
+                    .get("rekeyedDir")
+                    .and_then(|v| v.as_str())
+                    .map(|s| PathBuf::from(s))
+                    .unwrap_or_else(|| PathBuf::from("./nebula/rekeyed"));
+
+                let host = HostConfig {
+                    fqdn,
+                    ip,
+                    groups,
+                };
+
+                hosts.push((host, rekeyed_dir));
+            }
+        }
+    }
+
+    Ok(hosts)
+}
+
+fn get_host_public_key(_host: &HostConfig) -> Option<String> {
+    // TODO: Implement SSH/HTTP retrieval or local file lookup
+    // For now, this is a placeholder - hosts need to expose their public keys
+    // This would typically:
+    // 1. Try to SSH to the host and read /data/nebula/host.pub
+    // 2. Or read from a local cache if previously retrieved
+    // 3. Or prompt the user to provide it manually
+    None
+}

--- a/src/ogygia/src/nebula/mod.rs
+++ b/src/ogygia/src/nebula/mod.rs
@@ -1,0 +1,13 @@
+//! Nebula certificate management module.
+//!
+//! Provides CLI commands for managing Nebula overlay network certificates
+//! with content-addressed storage (similar to agenix-rekey).
+//!
+//! This module enables content-addressed Nebula certificate management
+//! where certificate paths are computed from (pubKey + IP + groups + FQDN).
+
+#[cfg(feature = "nebula")]
+pub mod cli;
+
+#[cfg(feature = "nebula")]
+pub mod cert;


### PR DESCRIPTION
Managing Nebula certificates per-host makes coordinated updates difficult, especially for firewall rule changes. Agenix rekey handles this well with content-addressed secrets that allow compile-time checks.

Added `ogygia nebula` CLI with discover, status, and rekey commands. Created NixOS module enabling hosts to declare their Nebula configuration (IP, groups). Certificates are stored at content-addressed paths computed from the hash of (pubKey fingerprint + IP + groups + FQDN), keeping paths stable across rotations.

This mirrors agenix-rekey"s pattern: Nix evaluation fails if a required certificate is missing, ensuring the admin rekeys before deployment. The CA private key is provided at runtime (never committed), and the CLI discovers hosts by evaluating nixosConfigurations to find ogygia.nebula declarations.

Test plan:
- Built ogygia package successfully with `nix build .#ogygia`
- Verified CLI commands work: `ogygia nebula --help`, `ogygia nebula rekey --help`
- Confirmed new files included: nebula module, CLI implementation, NixOS module