### PR TITLE
ogygia: add etcd support alongside ZooKeeper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,10 +95,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes 1.11.1",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "axum"
@@ -106,7 +172,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes 1.11.1",
  "form_urlencoded",
  "futures-util",
@@ -116,7 +182,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -127,10 +193,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes 1.11.1",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -386,6 +472,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0452bcc559431b16f472b7ab86e2f9ccd5f3c2da3795afbd6b773665e047fe"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
 name = "fastbloom"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,9 +496,15 @@ dependencies = [
  "foldhash",
  "libm",
  "portable-atomic",
- "rand",
+ "rand 0.9.2",
  "siphasher",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -414,6 +522,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -608,12 +722,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -729,6 +849,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,7 +878,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -856,12 +989,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -923,6 +1066,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1082,6 +1234,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1164,6 +1322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "net2"
 version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1381,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "etcd-client",
  "hostname",
  "reqwest",
  "serde",
@@ -1236,7 +1401,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-compression",
- "axum",
+ "axum 0.8.8",
  "base64",
  "bincode",
  "bytes 1.11.1",
@@ -1248,7 +1413,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "notify",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -1259,7 +1424,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1307,6 +1472,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.1",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,12 +1544,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes 1.11.1",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1370,7 +1627,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -1386,7 +1643,7 @@ dependencies = [
  "bytes 1.11.1",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1407,7 +1664,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1429,12 +1686,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1444,7 +1722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1472,6 +1759,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1521,7 +1820,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1770,6 +2069,16 @@ checksum = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -1860,6 +2169,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,7 +2247,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1948,6 +2270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1991,7 +2324,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2004,6 +2337,70 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes 1.11.1",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -2039,7 +2436,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 zookeeper = "0.8"
+etcd-client = "0.14"
 hostname = "0.4"
 strum = { version = "0.27", features = ["derive"] }
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Ogygia extracts these battle-tested patterns into standalone, reusable component
 
 - **📝 Configuration Revision Tracking**: Automatically embed Git revision information into your NixOS system closure
 - **🔍 System Status Inspection**: CLI tool to view build revisions across different system states
+- **🌐 Fleet Visibility**: Query etcd to see build revisions across all hosts in your infrastructure
 - **⚙️ NixOS Module Integration**: Easy integration into existing NixOS configurations via flake
 - **📦 Cachix Support**: Pre-built binaries available via Cachix for faster installations
 - **🦀 Built with Rust**: Fast, reliable CLI written in Rust using Clap
@@ -119,12 +120,12 @@ Host      ⚡ current    🥾 booted      🔜 next boot
 hostname  a1b2c3d4e5f6  a1b2c3d4e5f6  g7h8i9j0k1l2
 ```
 
-#### Fleet Mode with ZooKeeper
+#### Fleet Mode with etcd
 
-When ZooKeeper is configured, the status command shows all hosts in your fleet:
+When etcd is configured, the status command shows all hosts in your fleet:
 
 ```
-ZooKeeper fleet state (/nixos/versions via /run/current-system/sw/share/ogygia/config.toml):
+etcd fleet state (/nixos/versions via /run/current-system/sw/share/ogygia/config.toml):
 Host              ⚡ current    🥾 booted      🔜 next boot
 ------------------------------------------------------------
 * web01.dc1 (local) a1b2c3d4e5f6  a1b2c3d4e5f6  g7h8i9j0k1l2
@@ -139,27 +140,27 @@ The status command shows:
 - **`*` marker**: Indicates the local host
 - **unknown**: Indicates the revision file is missing or the state hasn't been published yet
 
-### ZooKeeper Fleet Visibility
+### etcd Fleet Visibility
 
-Ogygia can connect to ZooKeeper to provide fleet-wide visibility of system build revisions. This allows you to see the current, booted, and next boot revisions for all hosts in your infrastructure from any machine.
+Ogygia can connect to etcd to provide fleet-wide visibility of system build revisions. This allows you to see the current, booted, and next boot revisions for all hosts in your infrastructure from any machine.
 
 #### Configuration
 
-To enable ZooKeeper integration, add the following to your NixOS configuration:
+To enable etcd integration, add the following to your NixOS configuration:
 
 ```nix
 {
   ogygia = {
     enable = true;
     domain = "example.com";  # Optional: base domain suffix to trim from hostnames in display
-    zookeeper = {
+    etcd = {
       enable = true;
       endpoints = [
-        "zk1.internal:2181"
-        "zk2.internal:2181"
-        "zk3.internal:2181"
+        "http://etcd1.internal:2379"
+        "http://etcd2.internal:2379"
+        "http://etcd3.internal:2379"
       ];
-      namespace = "/nixos/versions";  # Optional: ZooKeeper path prefix (default shown)
+      namespace = "/nixos/versions";  # Optional: etcd key prefix (default shown)
       timeoutSeconds = 10;            # Optional: connection timeout (default: 10)
     };
   };
@@ -172,8 +173,8 @@ This generates a configuration file at `/run/current-system/sw/share/ogygia/conf
 [ogygia]
 domain = "example.com"
 
-[ogygia.zookeeper]
-endpoints = ["zk1.internal:2181", "zk2.internal:2181", "zk3.internal:2181"]
+[ogygia.etcd]
+endpoints = ["http://etcd1.internal:2379", "http://etcd2.internal:2379", "http://etcd3.internal:2379"]
 namespace = "/nixos/versions"
 timeout_seconds = 10
 ```
@@ -192,11 +193,11 @@ You can override the CLI behavior with environment variables:
   OGYGIA_HOSTNAME=web01.example.com ogygia status
   ```
 
-#### ZooKeeper Data Structure
+#### etcd Data Structure
 
-**Note:** This implementation is read-only. To populate ZooKeeper with host data, you need a separate publisher daemon (not included in this feature). The publisher would monitor system state changes and write revision data to the znodes described below.
+**Note:** This implementation is read-only. To populate etcd with host data, you need a separate publisher daemon (not included in this feature). The publisher would monitor system state changes and write revision data to the keys described below.
 
-Ogygia expects data in ZooKeeper under the configured namespace with the following structure:
+Ogygia expects data in etcd under the configured namespace with the following structure:
 
 ```
 /nixos/versions/          # namespace (configurable)
@@ -218,28 +219,64 @@ Ogygia expects data in ZooKeeper under the configured namespace with the followi
 
 **Connection Failures**
 
-If the CLI cannot connect to ZooKeeper, it will display an error and fall back to local-only mode:
+If the CLI cannot connect to etcd, it will display an error and fall back to local-only mode:
 
 ```
-ZooKeeper fleet state (/nixos/versions via /run/current-system/sw/share/ogygia/config.toml):
-Failed to read ZooKeeper from /run/current-system/sw/share/ogygia/config.toml: failed to connect to ZooKeeper at zk1:2181,zk2:2181. Check that the endpoints are reachable and the ZooKeeper service is running. Connection timeout: 10s. Showing local data only.
+etcd fleet state (/nixos/versions via /run/current-system/sw/share/ogygia/config.toml):
+Failed to read etcd from /run/current-system/sw/share/ogygia/config.toml: failed to connect to etcd at ["http://etcd1:2379"]. Check that the endpoints are reachable and the etcd service is running. Connection timeout: 10s. Showing local data only.
 Host           ⚡ current    🥾 booted      🔜 next boot
 -------------------------------------------------------
 * web01 (local) a1b2c3d4e5f6  a1b2c3d4e5f6  g7h8i9j0k1l2
 ```
 
 **Common Issues:**
-- **ZooKeeper not running**: Ensure the ZooKeeper service is running on the configured endpoints
-- **Network connectivity**: Verify the host can reach the ZooKeeper endpoints (check firewall rules)
-- **Namespace doesn't exist**: This is normal before the publisher daemon creates the znodes
-- **Permission denied**: Check ZooKeeper ACLs if authentication is enabled
+- **etcd not running**: Ensure the etcd service is running on the configured endpoints
+- **Network connectivity**: Verify the host can reach the etcd endpoints (check firewall rules)
+- **Namespace doesn't exist**: This is normal before the publisher daemon creates the keys
+- **Permission denied**: Check etcd ACLs if authentication is enabled
 
 **"unknown" Revisions**
 
 The status display shows "unknown" in these cases:
 - The build revision file doesn't exist (system not built with Ogygia enabled)
-- The ZooKeeper znode is missing (publisher hasn't written data yet)
+- The etcd key is missing (publisher hasn't written data yet)
 - The system state path doesn't exist yet (e.g., before first reboot)
+
+### ZooKeeper Fleet Visibility
+
+Ogygia can also connect to ZooKeeper to provide fleet-wide visibility. The status command will prefer etcd if both are configured.
+
+#### Configuration
+
+```nix
+{
+  ogygia = {
+    enable = true;
+    domain = "example.com";
+    zookeeper = {
+      enable = true;
+      endpoints = [
+        "zk1.internal:2181"
+        "zk2.internal:2181"
+        "zk3.internal:2181"
+      ];
+      namespace = "/nixos/versions";
+      timeoutSeconds = 10;
+    };
+  };
+}
+```
+
+#### ZooKeeper Data Structure
+
+Same structure as etcd:
+```
+/nixos/versions/
+├── web01/
+│   ├── current
+│   ├── booted
+│   └── nextboot
+```
 
 **Hostname Detection Issues**
 

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
             inherit src;
             strictDeps = true;
             buildInputs = [ ];
-            nativeBuildInputs = [ ];
+            nativeBuildInputs = [ pkgs.protobuf ];
           };
 
           individualCrateArgs = commonArgs // {

--- a/nixos/config-generator/default.nix
+++ b/nixos/config-generator/default.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.ogygia;
+  cliCfg = cfg.cliConfig;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  # Build config data from all enabled backends
+  configData = {
+    ogygia = {
+      domain = cfg.domain;
+    } // lib.optionalAttrs cfg.etcd.enable {
+      etcd = {
+        endpoints = cfg.etcd.endpoints;
+        namespace = cfg.etcd.namespace;
+        timeout_seconds = cfg.etcd.timeoutSeconds;
+      };
+    } // lib.optionalAttrs cfg.zookeeper.enable {
+      zookeeper = {
+        endpoints = cfg.zookeeper.endpoints;
+        namespace = cfg.zookeeper.namespace;
+        timeout_seconds = cfg.zookeeper.timeoutSeconds;
+      };
+    };
+  };
+
+  generatedToml = tomlFormat.generate "config.toml" configData;
+
+  configPackage = pkgs.runCommand "share-ogygia-config" { } ''
+    mkdir -p $out/share/ogygia
+    cp ${generatedToml} $out/share/ogygia/config.toml
+  '';
+in
+{
+  # This module provides the shared config package that all backends contribute to
+  config = lib.mkIf (cfg.enable && cliCfg.enable && (cfg.etcd.enable || cfg.zookeeper.enable)) {
+    ogygia.cliConfig.package = configPackage;
+
+    environment = {
+      systemPackages = [ configPackage ];
+      pathsToLink = [ "/share/ogygia" ];
+    };
+  };
+}

--- a/nixos/config/default.nix
+++ b/nixos/config/default.nix
@@ -2,30 +2,7 @@
 
 let
   cfg = config.ogygia;
-  cliCfg = cfg.cliConfig;
   zkCfg = cfg.zookeeper;
-
-  tomlFormat = pkgs.formats.toml { };
-
-  configData =
-    {
-      ogygia =
-        { domain = cfg.domain; } //
-        (lib.optionalAttrs zkCfg.enable {
-          zookeeper = {
-            endpoints = zkCfg.endpoints;
-            namespace = zkCfg.namespace;
-            timeout_seconds = zkCfg.timeoutSeconds;
-          };
-        });
-    };
-
-  generatedToml = tomlFormat.generate "config.toml" configData;
-
-  configPackage = pkgs.runCommand "share-ogygia-config" { } ''
-    mkdir -p $out/share/ogygia
-    cp ${generatedToml} $out/share/ogygia/config.toml
-  '';
 in
 {
   options.ogygia.cliConfig = {
@@ -65,19 +42,12 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enable && cliCfg.enable) {
+  config = lib.mkIf (cfg.enable && cfg.cliConfig.enable && zkCfg.enable) {
     assertions = lib.optionals zkCfg.enable [
       {
         assertion = zkCfg.endpoints != [ ];
         message = "ogygia.zookeeper.endpoints must not be empty when ZooKeeper integration is enabled.";
       }
     ];
-
-    ogygia.cliConfig.package = configPackage;
-
-    environment = {
-      systemPackages = [ configPackage ];
-      pathsToLink = [ "/share/ogygia" ];
-    };
   };
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -24,6 +24,8 @@ in
   imports = [
     ./versions
     ./config
+    ./config-generator
+    ./etcd
     ./irisd
   ];
 

--- a/nixos/etcd/default.nix
+++ b/nixos/etcd/default.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.ogygia;
+  etcdCfg = cfg.etcd;
+in
+{
+  options.ogygia.etcd = {
+    enable = lib.mkEnableOption "etcd configuration rendering for Ogygia tooling";
+
+    endpoints = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = [ "http://etcd-internal-1:2379" "http://etcd-internal-2:2379" ];
+      description = ''
+        List of etcd endpoints in URL form that publish host state
+        information. The CLI uses these endpoints to read global status data.
+      '';
+    };
+
+    namespace = lib.mkOption {
+      type = lib.types.str;
+      default = "/ogygia/nixos/versions";
+      description = "etcd key prefix that contains host state information.";
+    };
+
+    timeoutSeconds = lib.mkOption {
+      type = lib.types.int;
+      default = 10;
+      description = "Connection timeout used by the Ogygia CLI when contacting etcd.";
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.cliConfig.enable && etcdCfg.enable) {
+    assertions = [
+      {
+        assertion = etcdCfg.endpoints != [ ];
+        message = "ogygia.etcd.endpoints must not be empty when etcd integration is enabled.";
+      }
+    ];
+  };
+}

--- a/nixos/tests/cli-config.nix
+++ b/nixos/tests/cli-config.nix
@@ -1,7 +1,29 @@
 { pkgs, lib, ogygiaModule }:
 
 let
-  configTestSystem = lib.nixosSystem {
+  # Test etcd only configuration
+  etcdOnlySystem = lib.nixosSystem {
+    modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
+      ogygiaModule
+      {
+        ogygia.enable = true;
+        ogygia.domain = "neb.test";
+        ogygia.etcd = {
+          enable = true;
+          endpoints = [ "http://etcd1.internal:2379" "http://etcd2.internal:2379" ];
+          namespace = "/cluster/nixos";
+          timeoutSeconds = 42;
+        };
+      }
+    ];
+  };
+
+  etcdOnlyConfigPackage = etcdOnlySystem.config.ogygia.cliConfig.package or
+    (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
+
+  # Test zookeeper only configuration
+  zkOnlySystem = lib.nixosSystem {
     modules = [
       { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
       ogygiaModule
@@ -18,7 +40,34 @@ let
     ];
   };
 
-  configPackage = configTestSystem.config.ogygia.cliConfig.package or
+  zkOnlyConfigPackage = zkOnlySystem.config.ogygia.cliConfig.package or
+    (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
+
+  # Test both etcd and zookeeper configuration
+  bothSystem = lib.nixosSystem {
+    modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
+      ogygiaModule
+      {
+        ogygia.enable = true;
+        ogygia.domain = "neb.test";
+        ogygia.etcd = {
+          enable = true;
+          endpoints = [ "http://etcd1.internal:2379" "http://etcd2.internal:2379" ];
+          namespace = "/cluster/nixos";
+          timeoutSeconds = 42;
+        };
+        ogygia.zookeeper = {
+          enable = true;
+          endpoints = [ "zk1.internal:2181" "zk2.internal:2181" ];
+          namespace = "/cluster/nixos";
+          timeoutSeconds = 42;
+        };
+      }
+    ];
+  };
+
+  bothConfigPackage = bothSystem.config.ogygia.cliConfig.package or
     (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
 
 in
@@ -26,12 +75,29 @@ pkgs.runCommand "ogygia-cli-config"
 {
   nativeBuildInputs = [ pkgs.python3 ];
 } ''
-    conf="${configPackage}/share/ogygia/config.toml"
+    # Test etcd only configuration
+    etcdConf="${etcdOnlyConfigPackage}/share/ogygia/config.toml"
     python3 - <<'PY'
   import tomllib
   from pathlib import Path
+  conf = Path("${etcdOnlyConfigPackage}/share/ogygia/config.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  assert og["domain"] == "neb.test", og["domain"]
+  etcd = og["etcd"]
+  assert etcd["endpoints"] == ["http://etcd1.internal:2379", "http://etcd2.internal:2379"], etcd["endpoints"]
+  assert etcd["namespace"] == "/cluster/nixos", etcd["namespace"]
+  assert etcd["timeout_seconds"] == 42, etcd["timeout_seconds"]
+  # ZooKeeper should not be present when only etcd is configured
+  assert "zookeeper" not in og, "zookeeper should not be in config when only etcd is enabled"
+  PY
+
+    # Test zookeeper only configuration
+    zkConf="${zkOnlyConfigPackage}/share/ogygia/config.toml"
+    python3 - <<'PY'
+  import tomllib
   from pathlib import Path
-  conf = Path("${configPackage}/share/ogygia/config.toml")
+  conf = Path("${zkOnlyConfigPackage}/share/ogygia/config.toml")
   data = tomllib.loads(conf.read_text())
   og = data["ogygia"]
   assert og["domain"] == "neb.test", og["domain"]
@@ -39,7 +105,32 @@ pkgs.runCommand "ogygia-cli-config"
   assert zk["endpoints"] == ["zk1.internal:2181", "zk2.internal:2181"], zk["endpoints"]
   assert zk["namespace"] == "/cluster/nixos", zk["namespace"]
   assert zk["timeout_seconds"] == 42, zk["timeout_seconds"]
+  # etcd should not be present when only zookeeper is configured
+  assert "etcd" not in og, "etcd should not be in config when only zookeeper is enabled"
   PY
+
+    # Test both etcd and zookeeper configuration
+    bothConf="${bothConfigPackage}/share/ogygia/config.toml"
+    python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+  conf = Path("${bothConfigPackage}/share/ogygia/config.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  assert og["domain"] == "neb.test", og["domain"]
+  # Both etcd and zookeeper should be present
+  etcd = og["etcd"]
+  assert etcd["endpoints"] == ["http://etcd1.internal:2379", "http://etcd2.internal:2379"], etcd["endpoints"]
+  assert etcd["namespace"] == "/cluster/nixos", etcd["namespace"]
+  assert etcd["timeout_seconds"] == 42, etcd["timeout_seconds"]
+  zk = og["zookeeper"]
+  assert zk["endpoints"] == ["zk1.internal:2181", "zk2.internal:2181"], zk["endpoints"]
+  assert zk["namespace"] == "/cluster/nixos", zk["namespace"]
+  assert zk["timeout_seconds"] == 42, zk["timeout_seconds"]
+  PY
+
     mkdir -p $out
-    cp "$conf" "$out/config.toml"
+    cp "$etcdConf" "$out/config-etcd.toml"
+    cp "$zkConf" "$out/config-zk.toml"
+    cp "$bothConf" "$out/config-both.toml"
 ''

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 default = ["irisd"]
 irisd = [
     "dep:reqwest",
-    "dep:tokio",
     "dep:serde_json",
     "dep:which",
 ]
@@ -19,12 +18,13 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
 zookeeper = { workspace = true }
+etcd-client = { workspace = true }
 hostname = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 # Optional deps for irisd feature
 reqwest = { workspace = true, features = ["json"], optional = true }
-tokio = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 which = { workspace = true, optional = true }

--- a/src/ogygia/src/status/mod.rs
+++ b/src/ogygia/src/status/mod.rs
@@ -6,8 +6,8 @@
 //! 1. **Local-only mode**: Shows revision information for the current host by
 //!    reading from standard NixOS system state paths.
 //!
-//! 2. **Fleet mode**: Connects to ZooKeeper to display revision information for
-//!    all hosts in the fleet that have published their state.
+//! 2. **Fleet mode**: Connects to etcd or ZooKeeper to display
+//!    revision information for all hosts in the fleet that have published their state.
 //!
 //! ## Architecture
 //!
@@ -16,7 +16,7 @@
 //! - **Booted**: The system that was booted (`/run/booted-system`)
 //! - **Next boot**: The system that will boot next (`/nix/var/nix/profiles/system`)
 //!
-//! In fleet mode, the CLI fetches equivalent data from ZooKeeper znodes under
+//! In fleet mode, the CLI fetches equivalent data from etcd keys under
 //! a configured namespace (default: `/nixos/versions/{hostname}/{state}`).
 //!
 //! ## Configuration
@@ -27,12 +27,12 @@
 //!
 //! ## Note on Write Side
 //!
-//! This module only **reads** from ZooKeeper. A separate publisher daemon
-//! (not included here) is responsible for writing host state to ZooKeeper.
+//! This module only **reads** from etcd/ZooKeeper. A separate publisher daemon
+//! (not included here) is responsible for writing host state.
 //!
 //! ## Module Organization
 //!
-//! - `state`: State gathering logic (filesystem, ZooKeeper, config loading)
+//! - `state`: State gathering logic (filesystem, etcd, ZooKeeper, config loading)
 //! - `display`: Rendering and formatting logic (tables, truncation, trimming)
 //! - `tests`: Unit tests for both state and display modules
 
@@ -47,6 +47,7 @@ use display::print_host_table;
 use state::HostMatcher;
 use state::collect_local_state;
 use state::detect_hostname;
+use state::fetch_etcd_state;
 use state::fetch_zookeeper_state;
 use state::load_cli_config;
 use tracing::info;
@@ -58,10 +59,10 @@ use tracing::warn;
 /// 1. Loading configuration (if available)
 /// 2. Detecting the local hostname
 /// 3. Collecting local system state
-/// 4. Optionally fetching fleet state from ZooKeeper
+/// 4. Optionally fetching fleet state from etcd or ZooKeeper
 /// 5. Rendering the status table
 ///
-/// If ZooKeeper is not configured or connection fails, gracefully falls back
+/// If no backend is configured or connection fails, gracefully falls back
 /// to displaying only local host data.
 pub fn show_status() -> Result<()> {
     let cli_config = load_cli_config()?;
@@ -75,7 +76,38 @@ pub fn show_status() -> Result<()> {
 
     match cli_config.as_ref() {
         Some(cli_config) => {
-            if let Some(zookeeper) = cli_config.zookeeper.as_ref() {
+            // Prefer etcd, fallback to ZooKeeper (deprecated)
+            if let Some(etcd) = cli_config.etcd.as_ref() {
+                info!(
+                    namespace = %etcd.namespace,
+                    config = %cli_config.path.display(),
+                    "etcd fleet state"
+                );
+
+                // Create tokio runtime for async etcd operations
+                let rt = tokio::runtime::Runtime::new()?;
+                match rt.block_on(fetch_etcd_state(etcd, Some(&host_matcher))) {
+                    Ok(remote_states) => {
+                        // Combine local and remote states
+                        let mut all_states = vec![local_state];
+                        all_states.extend(remote_states);
+
+                        if all_states.len() == 1 {
+                            info!("only the local host is currently registered in etcd");
+                        }
+
+                        print_host_table(&all_states, domain_suffix);
+                    }
+                    Err(error) => {
+                        warn!(
+                            config = %cli_config.path.display(),
+                            %error,
+                            "failed to read etcd, showing local data only"
+                        );
+                        print_host_table(&[local_state], domain_suffix);
+                    }
+                }
+            } else if let Some(zookeeper) = cli_config.zookeeper.as_ref() {
                 info!(
                     namespace = %zookeeper.namespace,
                     config = %cli_config.path.display(),
@@ -106,7 +138,7 @@ pub fn show_status() -> Result<()> {
             } else {
                 info!(
                     config = %cli_config.path.display(),
-                    "ZooKeeper settings not found, showing local data only"
+                    "etcd/ZooKeeper settings not found, showing local data only"
                 );
                 print_host_table(&[local_state], domain_suffix);
             }

--- a/src/ogygia/src/status/state.rs
+++ b/src/ogygia/src/status/state.rs
@@ -2,6 +2,7 @@
 //!
 //! This module handles all data collection from:
 //! - Local filesystem (reading system state paths and build revision files)
+//! - etcd (fetching fleet-wide host state)
 //! - ZooKeeper (fetching fleet-wide host state)
 //! - Configuration files (loading TOML config)
 //! - Hostname detection (environment, commands, syscalls)
@@ -19,6 +20,9 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use etcd_client::Client as EtcdClient;
+use etcd_client::ConnectOptions;
+use etcd_client::GetOptions;
 use hostname::get as get_hostname;
 use serde::Deserialize;
 use zookeeper::WatchedEvent;
@@ -49,23 +53,23 @@ const CONFIG_OVERRIDE_ENV: &str = "OGYGIA_CONFIG";
 pub struct SystemStateData {
     /// Absolute path on the local filesystem where this system state is stored.
     pub base_path: &'static str,
-    /// Name of the ZooKeeper znode under the host's namespace that stores this state.
-    pub znode_name: &'static str,
+    /// Name of the key in etcd/ZooKeeper under the host's namespace that stores this state.
+    pub key_name: &'static str,
 }
 
 /// The three system states we track for each NixOS host.
 pub const SYSTEM_STATE_DATA: [SystemStateData; STATE_COUNT] = [
     SystemStateData {
         base_path: "/run/current-system",
-        znode_name: "current",
+        key_name: "current",
     },
     SystemStateData {
         base_path: "/run/booted-system",
-        znode_name: "booted",
+        key_name: "booted",
     },
     SystemStateData {
         base_path: "/nix/var/nix/profiles/system",
-        znode_name: "nextboot",
+        key_name: "nextboot",
     },
 ];
 
@@ -78,7 +82,7 @@ pub type StateValues = [Option<String>; STATE_COUNT];
 /// Display formatting (truncation, domain trimming) is handled elsewhere.
 #[derive(Clone, Debug)]
 pub struct HostState {
-    /// Full hostname (FQDN or short name, as stored in ZooKeeper or detected locally).
+    /// Full hostname (FQDN or short name, as stored in etcd/ZooKeeper or detected locally).
     pub host: String,
     /// Build revisions for current, booted, and next boot states (full strings, not truncated).
     pub values: StateValues,
@@ -93,8 +97,21 @@ pub struct CliConfig {
     pub path: PathBuf,
     /// Optional domain suffix to trim from hostnames (normalized).
     pub domain_suffix: Option<String>,
+    /// Optional etcd connection configuration.
+    pub etcd: Option<EtcdCliConfig>,
     /// Optional ZooKeeper connection configuration.
     pub zookeeper: Option<ZookeeperCliConfig>,
+}
+
+/// Processed etcd configuration ready for connection.
+#[derive(Debug)]
+pub struct EtcdCliConfig {
+    /// List of etcd endpoints in "http://host:port" format.
+    pub endpoints: Vec<String>,
+    /// Normalized namespace path (starts with /, no trailing /).
+    pub namespace: String,
+    /// Connection timeout duration.
+    pub timeout: Duration,
 }
 
 /// Processed ZooKeeper configuration ready for connection.
@@ -201,7 +218,7 @@ pub fn fetch_zookeeper_state(
         let host_path = join_zk_path(&config.namespace, &host);
 
         for (idx, state) in SYSTEM_STATE_DATA.iter().enumerate() {
-            let path = join_zk_path(&host_path, state.znode_name);
+            let path = join_zk_path(&host_path, state.key_name);
             match zk.get_data(&path, false) {
                 Ok((data, _)) => {
                     if let Some(value) = parse_zk_revision_bytes(&data) {
@@ -224,6 +241,155 @@ pub fn fetch_zookeeper_state(
 
     rows.sort_by(|a, b| a.host.cmp(&b.host));
     Ok(rows)
+}
+
+/// Fetches host state data from etcd.
+///
+/// Connects to etcd, lists all hosts under the configured namespace,
+/// and reads their build revisions for all three system states.
+///
+/// Returns raw data with full hostnames (no domain trimming) and full revision
+/// strings (no truncation).
+///
+/// # Arguments
+///
+/// * `config` - etcd connection and namespace configuration
+/// * `exclude_host` - Optional hostname matcher to exclude (typically the local host)
+///
+/// # Returns
+///
+/// A vector of host state rows, sorted alphabetically by hostname.
+/// Missing keys are represented as `None`.
+pub async fn fetch_etcd_state(
+    config: &EtcdCliConfig,
+    exclude_host: Option<&HostMatcher>,
+) -> Result<Vec<HostState>> {
+    let opts = ConnectOptions::new().with_timeout(config.timeout);
+    let mut client = EtcdClient::connect(&config.endpoints, Some(opts))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to connect to etcd at {:?}. \
+                 Check that the endpoints are reachable and the etcd service is running. \
+                 Connection timeout: {:?}",
+                config.endpoints, config.timeout
+            )
+        })?;
+
+    // Get all keys under the namespace to find hosts
+    let range_end = get_etcd_range_end(&config.namespace);
+    let opts = GetOptions::new().with_range(range_end);
+    let response = client
+        .get(config.namespace.as_str(), Some(opts))
+        .await
+        .with_context(|| {
+            format!(
+                "failed to list hosts under {}. \
+                 The namespace may not exist yet, or you may not have read permissions. \
+                 This is normal if no publisher daemon has written data yet",
+                config.namespace
+            )
+        })?;
+
+    // Extract unique hostnames from keys
+    let mut hosts: Vec<String> = Vec::new();
+    for kv in response.kvs() {
+        let key = kv.key_str().unwrap_or("");
+        if let Some(relative_path) = key.strip_prefix(&config.namespace) {
+            let relative_path = relative_path.trim_start_matches('/');
+            let host = relative_path.split('/').next().map(String::from);
+            if let Some(host) = host {
+                if !hosts.contains(&host) {
+                    hosts.push(host);
+                }
+            }
+        }
+    }
+
+    let mut rows = Vec::with_capacity(hosts.len());
+    for host in hosts {
+        if exclude_host
+            .map(|matcher| matcher.matches(&host))
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let mut values = empty_state_values();
+        let host_prefix = join_etcd_path(&config.namespace, &host);
+
+        for (idx, state) in SYSTEM_STATE_DATA.iter().enumerate() {
+            let key = join_etcd_path(&host_prefix, state.key_name);
+            match client.get(key.as_str(), None).await {
+                Ok(response) => {
+                    if let Some(kv) = response.kvs().first() {
+                        if let Some(value) = parse_etcd_value(kv.value()) {
+                            values[idx] = Some(value);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("etcd key {} not found: {}", key, e);
+                    /* missing key is acceptable */
+                }
+            }
+        }
+
+        rows.push(HostState {
+            host,
+            values,
+            is_local: false,
+        });
+    }
+
+    rows.sort_by(|a, b| a.host.cmp(&b.host));
+    Ok(rows)
+}
+
+/// Computes the range end for an etcd prefix query.
+///
+/// This is used to get all keys with a given prefix.
+fn get_etcd_range_end(prefix: &str) -> Vec<u8> {
+    let mut end = prefix.as_bytes().to_vec();
+    for i in (0..end.len()).rev() {
+        if end[i] < 0xff {
+            end[i] += 1;
+            end.truncate(i + 1);
+            return end;
+        }
+    }
+    // If all bytes are 0xff, return an empty vec (means "all keys")
+    vec![]
+}
+
+/// Joins two etcd key path components, handling slashes correctly.
+///
+/// etcd keys are forward-slash separated strings (not platform-specific
+/// filesystem paths), so we need custom logic to handle edge cases like root paths
+/// and ensure no double slashes.
+pub fn join_etcd_path(prefix: &str, child: &str) -> String {
+    if prefix == "/" {
+        format!("/{}", child.trim_start_matches('/'))
+    } else {
+        format!(
+            "{}/{}",
+            prefix.trim_end_matches('/'),
+            child.trim_start_matches('/')
+        )
+    }
+}
+
+/// Parses build revision bytes from etcd value data.
+///
+/// Returns the full revision string (not truncated).
+/// Returns `None` if the data is not valid UTF-8, is empty, or contains only whitespace.
+fn parse_etcd_value(data: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(data).ok()?.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
 }
 
 /// Parses build revision bytes from ZooKeeper znode data.
@@ -281,12 +447,47 @@ pub fn load_cli_config() -> Result<Option<CliConfig>> {
         return Ok(Some(CliConfig {
             path,
             domain_suffix: None,
+            etcd: None,
             zookeeper: None,
         }));
     };
 
     let domain_suffix = ogygia_cfg.domain.and_then(|d| normalize_domain(&d));
 
+    // Parse etcd configuration (preferred)
+    let etcd = match ogygia_cfg.etcd {
+        Some(raw_etcd) => {
+            if raw_etcd.endpoints.is_empty() {
+                return Err(anyhow!(
+                    "etcd config {} does not define any endpoints. \
+                     Add endpoints in the format [\"http://host1:2379\", \"http://host2:2379\"]",
+                    path.display()
+                ));
+            }
+
+            // Validate endpoint format
+            for endpoint in &raw_etcd.endpoints {
+                if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
+                    return Err(anyhow!(
+                        "Invalid etcd endpoint '{}' in {}. \
+                         Endpoints must be in 'http://host:port' or 'https://host:port' format \
+                         (e.g., 'http://etcd1.example.com:2379')",
+                        endpoint,
+                        path.display()
+                    ));
+                }
+            }
+
+            Some(EtcdCliConfig {
+                endpoints: raw_etcd.endpoints,
+                namespace: normalize_namespace(&raw_etcd.namespace),
+                timeout: Duration::from_secs(raw_etcd.timeout_seconds.max(MIN_TIMEOUT_SECONDS)),
+            })
+        }
+        None => None,
+    };
+
+    // Parse ZooKeeper configuration
     let zookeeper = match ogygia_cfg.zookeeper {
         Some(raw_zk) => {
             if raw_zk.endpoints.is_empty() {
@@ -321,6 +522,7 @@ pub fn load_cli_config() -> Result<Option<CliConfig>> {
     Ok(Some(CliConfig {
         path,
         domain_suffix,
+        etcd,
         zookeeper,
     }))
 }
@@ -396,9 +598,26 @@ struct RawOgygiaConfig {
     /// Domain suffix to trim from hostnames for display (e.g., "example.com").
     #[serde(default)]
     domain: Option<String>,
+    /// etcd connection settings.
+    #[serde(default)]
+    etcd: Option<RawEtcdConfig>,
     /// ZooKeeper connection settings.
     #[serde(default)]
     zookeeper: Option<RawZookeeperConfig>,
+}
+
+/// Raw etcd configuration section from TOML.
+#[derive(Debug, Deserialize)]
+struct RawEtcdConfig {
+    /// List of etcd server endpoints (e.g., ["http://etcd1:2379", "http://etcd2:2379"]).
+    #[serde(default)]
+    endpoints: Vec<String>,
+    /// etcd namespace prefix where host data is stored.
+    #[serde(default = "default_etcd_namespace")]
+    namespace: String,
+    /// Connection timeout in seconds.
+    #[serde(default = "default_timeout_seconds")]
+    timeout_seconds: u64,
 }
 
 /// Raw ZooKeeper configuration section from TOML.
@@ -408,20 +627,25 @@ struct RawZookeeperConfig {
     #[serde(default)]
     endpoints: Vec<String>,
     /// ZooKeeper namespace path where host data is stored.
-    #[serde(default = "default_namespace")]
+    #[serde(default = "default_zookeeper_namespace")]
     namespace: String,
     /// Connection timeout in seconds.
     #[serde(default = "default_timeout_seconds")]
     timeout_seconds: u64,
 }
 
-/// Default ZooKeeper connection timeout in seconds.
+/// Default connection timeout in seconds.
 const fn default_timeout_seconds() -> u64 {
     10
 }
 
+/// Default etcd namespace for host data storage.
+fn default_etcd_namespace() -> String {
+    "/ogygia/nixos/versions".to_string()
+}
+
 /// Default ZooKeeper namespace for host data storage.
-fn default_namespace() -> String {
+fn default_zookeeper_namespace() -> String {
     "/nixos/versions".to_string()
 }
 

--- a/src/ogygia/src/status/tests.rs
+++ b/src/ogygia/src/status/tests.rs
@@ -6,6 +6,7 @@ use super::state::HostMatcher;
 use super::state::HostState;
 use super::state::STATE_COUNT;
 use super::state::empty_state_values;
+use super::state::join_etcd_path;
 use super::state::join_zk_path;
 use super::state::normalize_domain;
 use super::state::normalize_namespace;
@@ -95,6 +96,41 @@ fn test_join_zk_path_root_prefix() {
 #[test]
 fn test_join_zk_path_multi_level() {
     assert_eq!(join_zk_path("/a/b/c", "d/e"), "/a/b/c/d/e");
+}
+
+// ============================================================================
+// etcd path manipulation tests
+// ============================================================================
+
+#[test]
+fn test_join_etcd_path_normal() {
+    assert_eq!(join_etcd_path("/foo", "bar"), "/foo/bar");
+}
+
+#[test]
+fn test_join_etcd_path_with_trailing_slash() {
+    assert_eq!(join_etcd_path("/foo/", "bar"), "/foo/bar");
+}
+
+#[test]
+fn test_join_etcd_path_with_leading_slash() {
+    assert_eq!(join_etcd_path("/foo", "/bar"), "/foo/bar");
+}
+
+#[test]
+fn test_join_etcd_path_both_slashes() {
+    assert_eq!(join_etcd_path("/foo/", "/bar"), "/foo/bar");
+}
+
+#[test]
+fn test_join_etcd_path_root_prefix() {
+    assert_eq!(join_etcd_path("/", "bar"), "/bar");
+    assert_eq!(join_etcd_path("/", "/bar"), "/bar");
+}
+
+#[test]
+fn test_join_etcd_path_multi_level() {
+    assert_eq!(join_etcd_path("/a/b/c", "d/e"), "/a/b/c/d/e");
 }
 
 // ============================================================================


### PR DESCRIPTION
Added etcd as an alternative backend for the `ogygia status` command.
The etcd client uses the same key structure as ZooKeeper znodes
(/<namespace>/<host>/<state>) for compatibility.

Both ZooKeeper and etcd can be configured simultaneously. The NixOS
config-generator module creates a single config file with sections for
all enabled backends. The status command prefers etcd when both
backends are configured.

The etcd namespace default is /ogygia/nixos/versions while ZooKeeper
remains at /nixos/versions for backward compatibility.

The etcd and zookeeper modules are completely separate with no
cross-references. The shared config-generator module handles creating
the unified config.toml.

Test plan:
- CI (clippy, doc, formatting, audit, deny, nextest, cli-config checks)
- Added unit tests for etcd path manipulation (join_etcd_path)
- Updated NixOS module tests to cover etcd-only, zookeeper-only, and both