### PR TITLE
ci: implement R2-backed nix-fast-build CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   nix:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-24.04
@@ -22,34 +23,39 @@ jobs:
 
     - name: Install Nix
       uses: cachix/install-nix-action@fd24c48048070c1be9acd18c9d369a83f0fe94d7 # v31
-
-    - name: Setup Cachix
-      uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
       with:
-        name: ogygia
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        extra_nix_config: |
+          accept-flake-config = true
+
+    - name: Enter CI devShell
+      uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1
+      with:
+        arguments: .#ci
 
     - name: Build all outputs
-      run: |
-        # Get current system using Nix
-        SYSTEM=$(nix-instantiate --eval -E builtins.currentSystem | tr -d '"')
-        
-        echo "Building for system: $SYSTEM"
-        
-        echo "Discovering all buildable outputs..."
-        buildable_outputs=$(nix flake show --json | jq -r --arg system "$SYSTEM" '
-          [
-            (.packages[$system] // {} | to_entries[] | ".#packages." + $system + "." + .key),
-            (.checks[$system] // {} | to_entries[] | ".#checks." + $system + "." + .key),
-            (.devShells[$system] // {} | to_entries[] | ".#devShells." + $system + "." + .key)
-          ] | .[]
-        ')
-        
-        echo "Found buildable outputs:"
-        echo "$buildable_outputs"
-        
-        echo "Building all outputs..."
-        echo "$buildable_outputs" | xargs nix build
+      run: nix-fast-build --no-nom --skip-cached --flake '.#ci'
 
     - name: Flake check
       run: nix flake check
+
+    - name: Sign and push to R2
+      if: always()
+      run: |
+        if [ -z "$SIGNING_KEY" ]; then
+          echo "No signing key available; skipping sign+push."
+          exit 0
+        fi
+        echo "$SIGNING_KEY" > /tmp/nix-signing-key
+        trap 'rm -f /tmp/nix-signing-key' EXIT
+        paths=$(nix path-info --all --json \
+          | jq -r 'to_entries[] | select(.value.ultimate == true) | .key')
+        if [ -z "$paths" ]; then
+          echo "No ultimate paths to sign; skipping."
+          exit 0
+        fi
+        echo "$paths" | xargs nix store sign --key-file /tmp/nix-signing-key
+        echo "$paths" | xargs nix copy --to 's3://jakehillion-nix?endpoint=https://28e45df51086264c6d9cf2b5e6ecc190.r2.cloudflarestorage.com&region=auto'
+      env:
+        SIGNING_KEY: ${{ secrets.NIX_SIGNING_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/flake.lock
+++ b/flake.lock
@@ -52,6 +52,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-fast-build",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -67,6 +88,28 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-fast-build": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1775727451,
+        "narHash": "sha256-IJSKVJ0+MXMMLiViVlfEDpfA339fNHYdMoLa69HhlXg=",
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "rev": "1030b0cfaca52f95769d0998ea366946144cd47c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
         "type": "github"
       }
     },
@@ -92,8 +135,9 @@
         "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
+        "nix-fast-build": "nix-fast-build",
         "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "rust-analyzer-src": {
@@ -129,6 +173,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-fast-build",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://ogygia.cachix.org"
+      "https://nixcache.jakehillion.me"
     ];
     extra-trusted-public-keys = [
-      "ogygia.cachix.org-1:xb4bnMPeWgSP81Xs0Vl7ZU4Ez7Ul65qp/EoZ40pDaWo="
+      "nixcache.jakehillion.me-1:HQsjYdrcs3ilS/ngtlbTQXU4Xfsm+va5NN7yoK0wKMg="
     ];
   };
 
@@ -24,9 +24,12 @@
 
     advisory-db.url = "github:rustsec/advisory-db";
     advisory-db.flake = false;
+
+    nix-fast-build.url = "github:Mic92/nix-fast-build";
+    nix-fast-build.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, treefmt-nix, fenix, crane, advisory-db }:
+  outputs = { self, nixpkgs, flake-utils, treefmt-nix, fenix, crane, advisory-db, nix-fast-build }:
     flake-utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ]
       (system:
         let
@@ -114,6 +117,13 @@
             ];
           };
 
+          devShells.ci = pkgs.mkShell {
+            packages = [
+              pkgs.jq
+              nix-fast-build.packages.${system}.nix-fast-build
+            ];
+          };
+
           formatter = treefmtEval.config.build.wrapper;
 
           checks = {
@@ -171,5 +181,11 @@
         imports = [ ./nixos ];
         _module.args.ogygia-irisd = self.packages.${pkgs.system}.ogygia-irisd;
       };
+
+      ci = nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" ] (system:
+        (self.packages.${system} or { })
+        // (self.checks.${system} or { })
+        // (self.devShells.${system} or { })
+      );
     };
 }


### PR DESCRIPTION
The project was using Cachix for CI caching with a manual discovery and build process. This approach doesn't provide the same efficiency and flexibility as using nix-fast-build with R2 storage.

Integrated nix-fast-build into the flake as a new input, added a ci devShell containing nix-fast-build and jq, created a ci attrset combining all buildable outputs (packages, checks, devShells), updated the CI workflow to use nix-fast-build with the .#ci attrset, configured R2 cache endpoint with the correct public key, and added post-build signing and push to R2.

This approach provides faster builds through parallel execution, better caching with R2, and consistent artifact signing. The ci attrset allows nix-fast-build to discover and build all outputs efficiently.

Test plan:
- Ran nix flake check to verify flake evaluates correctly and all outputs are properly defined