### PR TITLE
ogygia: add hostinfod service for publishing version info to etcd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         arguments: .#ci
 
     - name: Build all outputs
-      run: nix-fast-build --no-nom --skip-cached --flake '.#ci'
+      run: nix-fast-build --no-nom --skip-cached --flake '.#ci' -j 2 --eval-workers 4
 
     - name: Flake check
       run: nix flake check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,8 +1014,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
 dependencies = [
  "bitflags 1.3.2",
+ "futures-core",
  "inotify-sys",
  "libc",
+ "tokio",
 ]
 
 [[package]]
@@ -1392,6 +1394,20 @@ dependencies = [
  "tracing-subscriber",
  "which",
  "zookeeper",
+]
+
+[[package]]
+name = "ogygia-hostinfod"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "etcd-client",
+ "hostname",
+ "inotify",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -102,10 +102,16 @@
             src = fileSetForCrate ./src/ogygia-irisd;
           });
 
+          ogygia-hostinfod = craneLib.buildPackage (individualCrateArgs // {
+            pname = "ogygia-hostinfod";
+            cargoExtraArgs = "-p ogygia-hostinfod";
+            src = fileSetForCrate ./src/ogygia-hostinfod;
+          });
+
         in
         {
           packages = {
-            inherit ogygia ogygia-irisd;
+            inherit ogygia ogygia-irisd ogygia-hostinfod;
             default = ogygia;
           };
 
@@ -127,7 +133,7 @@
           formatter = treefmtEval.config.build.wrapper;
 
           checks = {
-            inherit ogygia ogygia-irisd;
+            inherit ogygia ogygia-irisd ogygia-hostinfod;
 
             ogygia-clippy = craneLib.cargoClippy (commonArgs // {
               inherit cargoArtifacts;
@@ -175,11 +181,18 @@
               ogygiaModule = self.nixosModules.default;
               ogygia = self.packages.${system}.ogygia;
             };
+
+            ogygia-hostinfod-inotify = import ./nixos/tests/hostinfod-inotify.nix {
+              inherit pkgs system;
+              inherit (nixpkgs) lib;
+              ogygiaModule = self.nixosModules.default;
+            };
           };
         }) // {
       nixosModules.default = { pkgs, ... }: {
         imports = [ ./nixos ];
         _module.args.ogygia-irisd = self.packages.${pkgs.system}.ogygia-irisd;
+        _module.args.ogygia-hostinfod = self.packages.${pkgs.system}.ogygia-hostinfod;
       };
 
       ci = nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" ] (system:

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -27,10 +27,12 @@ in
     ./config-generator
     ./etcd
     ./irisd
+    ./hostinfod
   ];
 
   config = lib.mkIf cfg.enable {
     ogygia.versions.enable = lib.mkOverride 999 true;
     ogygia.cliConfig.enable = lib.mkOverride 999 true;
+    ogygia.hostinfod.enable = lib.mkOverride 999 (cfg.etcd.endpoints != [ ]);
   };
 }

--- a/nixos/etcd/default.nix
+++ b/nixos/etcd/default.nix
@@ -20,7 +20,7 @@ in
 
     namespace = lib.mkOption {
       type = lib.types.str;
-      default = "/ogygia/nixos/versions";
+      default = "/ogygia";
       description = "etcd key prefix that contains host state information.";
     };
 
@@ -28,6 +28,17 @@ in
       type = lib.types.int;
       default = 10;
       description = "Connection timeout used by the Ogygia CLI when contacting etcd.";
+    };
+
+    clientConnectionString = lib.mkOption {
+      type = lib.types.str;
+      readOnly = true;
+      default = lib.concatStringsSep "," etcdCfg.endpoints;
+      description = ''
+        Read-only option that generates a comma-separated connection string
+        from the configured endpoints. This is used by services like
+        ogygia-hostinfod to connect to etcd.
+      '';
     };
   };
 

--- a/nixos/hostinfod/default.nix
+++ b/nixos/hostinfod/default.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ogygia-hostinfod, ... }:
+
+let
+  cfg = config.ogygia.hostinfod;
+  etcdCfg = config.ogygia.etcd;
+in
+{
+  options.ogygia.hostinfod = {
+    enable = lib.mkEnableOption "ogygia-hostinfod etcd publisher for host version tracking";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = ogygia-hostinfod;
+      description = "The ogygia-hostinfod package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.ogygia-hostinfod = {
+      description = "Ogygia Host Info etcd Publisher";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/ogygia-hostinfod --endpoints ${lib.escapeShellArg etcdCfg.clientConnectionString} --prefix ${lib.escapeShellArg (etcdCfg.namespace + "/nixos/versions")}";
+        Restart = "always";
+        RestartSec = "10s";
+        DynamicUser = true;
+        RuntimeDirectory = "ogygia-hostinfod";
+
+        # Security hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        # Read access to system directories for version tracking
+        # Note: We need access to parent directories because inotify watches
+        # the directory containing the symlink, not the symlink itself
+        ReadOnlyPaths = [
+          "/run"
+          "/nix/var/nix/profiles"
+        ];
+      };
+
+      environment = {
+        RUST_LOG = lib.mkDefault "info";
+      };
+    };
+  };
+}

--- a/nixos/tests/hostinfod-inotify.nix
+++ b/nixos/tests/hostinfod-inotify.nix
@@ -1,0 +1,85 @@
+{ pkgs, lib, system, ogygiaModule }:
+
+# This test verifies that ogygia-hostinfod correctly detects filesystem changes
+# and updates etcd. We test this by:
+# 1. Starting the service and verifying initial etcd values
+# 2. The daemon watches system paths for changes
+# 3. We verify the service is running and functioning
+#
+# Note: We don't test symlink changes to /run/current-system in the VM test
+# because that would break the running system. The inotify functionality is
+# tested separately with unit tests or manual testing.
+
+pkgs.testers.nixosTest {
+  name = "ogygia-hostinfod";
+
+  nodes.machine = { config, pkgs, ... }: {
+    imports = [ ogygiaModule ];
+
+    # Set up etcd
+    services.etcd = {
+      enable = true;
+      listenClientUrls = [ "http://localhost:2379" ];
+      advertiseClientUrls = [ "http://localhost:2379" ];
+    };
+
+    # Configure ogygia with etcd - hostinfod should auto-enable
+    ogygia = {
+      enable = true;
+      domain = "test.local";
+      etcd.endpoints = [ "http://localhost:2379" ];
+    };
+
+    # Set a custom hostname for predictable testing
+    networking.hostName = "test-host";
+  };
+
+  testScript = ''
+    import time
+
+    machine.start()
+    
+    # Wait for etcd to be ready
+    machine.wait_for_unit("etcd.service")
+    machine.wait_for_open_port(2379)
+    
+    # Wait for hostinfod to start
+    machine.wait_for_unit("ogygia-hostinfod.service")
+    
+    # Wait a moment for initial etcd write
+    time.sleep(3)
+    
+    # Check that initial values are in etcd
+    hostname = "test-host"
+    
+    # Test current system - should have a value (even if "unknown")
+    result = machine.succeed("etcdctl get /ogygia/nixos/versions/{}/current --print-value-only".format(hostname))
+    current_revision = result.strip()
+    print(f"Current revision in etcd: {current_revision}")
+    assert len(current_revision) > 0, "No current revision found in etcd"
+    
+    # Test booted system
+    result = machine.succeed("etcdctl get /ogygia/nixos/versions/{}/booted --print-value-only".format(hostname))
+    booted_revision = result.strip()
+    print(f"Booted revision in etcd: {booted_revision}")
+    assert len(booted_revision) > 0, "No booted revision found in etcd"
+    
+    # Verify the service is still running after initial setup
+    machine.succeed("systemctl is-active ogygia-hostinfod.service")
+    print("Service is still running")
+    
+    # Check that the service is watching for changes
+    # We can verify this by checking the logs
+    logs = machine.succeed("journalctl -u ogygia-hostinfod.service --no-pager -n 10")
+    print(f"Service logs: {logs}")
+    
+    # Verify that the watching is set up correctly
+    assert "Watching /run for current" in logs, "Service not watching /run for current"
+    assert "Watching /run for booted" in logs, "Service not watching /run for booted"
+    assert "Watching /nix/var/nix/profiles for nextboot" in logs, "Service not watching profiles"
+    
+    print("SUCCESS: ogygia-hostinfod is running and properly configured!")
+    print("Note: Full inotify testing with system changes should be done manually")
+    print("      or in a separate integration test environment.")
+  '';
+}

--- a/src/ogygia-hostinfod/Cargo.toml
+++ b/src/ogygia-hostinfod/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ogygia-hostinfod"
+version.workspace = true
+edition = "2021"
+license.workspace = true
+
+[dependencies]
+# CLI
+clap = { workspace = true }
+anyhow = { workspace = true }
+hostname = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# etcd client
+etcd-client = { workspace = true }
+
+# Filesystem watching - using raw inotify for proper symlink change detection
+inotify = "0.10"
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/src/ogygia-hostinfod/src/main.rs
+++ b/src/ogygia-hostinfod/src/main.rs
@@ -1,0 +1,377 @@
+use std::collections::HashMap;
+use std::env;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::process::Command as ProcessCommand;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use clap::Parser;
+use etcd_client::Client;
+use etcd_client::PutOptions;
+use hostname::get as get_hostname;
+use inotify::EventMask;
+use inotify::Inotify;
+use inotify::WatchMask;
+use tokio::sync::mpsc;
+use tracing::debug;
+use tracing::info;
+use tracing::warn;
+
+const HOSTNAME_OVERRIDE_ENV: &str = "OGYGIA_HOSTNAME";
+const REVISION_RELATIVE_PATH: &str = "sw/share/ogygia/build-revision";
+
+/// System states to track and their corresponding etcd key suffixes.
+const SYSTEM_STATES: [(&str, &str); 3] = [
+    ("/run/current-system", "current"),
+    ("/run/booted-system", "booted"),
+    ("/nix/var/nix/profiles/system", "nextboot"),
+];
+
+/// inotify watch flags matching the reference Python implementation:
+/// CREATE | DELETE | MOVED_TO | MOVED_FROM | ATTRIB | DONT_FOLLOW
+const WATCH_MASK: WatchMask = WatchMask::CREATE
+    .union(WatchMask::DELETE)
+    .union(WatchMask::MOVED_TO)
+    .union(WatchMask::MOVED_FROM)
+    .union(WatchMask::ATTRIB)
+    .union(WatchMask::DONT_FOLLOW);
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "ogygia-hostinfod",
+    version,
+    about = "Ogygia host info etcd publisher"
+)]
+struct Cli {
+    /// etcd endpoints (comma-separated or multiple args)
+    #[arg(
+        long,
+        env = "OGYGIA_ETCD_ENDPOINTS",
+        value_delimiter = ',',
+        required = true
+    )]
+    endpoints: Vec<String>,
+
+    /// etcd key prefix
+    #[arg(
+        long,
+        env = "OGYGIA_ETCD_PREFIX",
+        default_value = "/ogygia/nixos/versions"
+    )]
+    prefix: String,
+}
+
+fn detect_hostname() -> String {
+    hostname_from_env(HOSTNAME_OVERRIDE_ENV)
+        .or_else(|| hostname_from_command("hostname", &["-f"]))
+        .or_else(|| hostname_from_env("HOSTNAME"))
+        .or_else(|| hostname_from_command("hostname", &[]))
+        .or_else(hostname_from_syscall)
+        .unwrap_or_else(|| "unknown-host".to_string())
+}
+
+fn hostname_from_env(var: &str) -> Option<String> {
+    env::var(var)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string())
+}
+
+fn hostname_from_command(program: &str, args: &[&str]) -> Option<String> {
+    let output = ProcessCommand::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string())
+}
+
+fn hostname_from_syscall() -> Option<String> {
+    get_hostname()
+        .ok()
+        .and_then(|s| s.into_string().ok())
+        .filter(|s| !s.trim().is_empty())
+}
+
+fn read_revision(base_path: &str) -> Option<String> {
+    let revision_path = Path::new(base_path).join(REVISION_RELATIVE_PATH);
+
+    match std::fs::read_to_string(&revision_path) {
+        Ok(contents) => {
+            let trimmed = contents.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            warn!("Failed to read {}: {}", revision_path.display(), e);
+            None
+        }
+    }
+}
+
+async fn update_etcd_key(
+    client: &mut Client,
+    key: &str,
+    revision: &str,
+    cached: &mut HashMap<String, String>,
+) -> Result<bool> {
+    if cached.get(key) == Some(&revision.to_string()) {
+        return Ok(false);
+    }
+
+    info!("Updating etcd key {} = {}", key, revision);
+    client
+        .put(key, revision, Some(PutOptions::default()))
+        .await?;
+    cached.insert(key.to_string(), revision.to_string());
+    Ok(true)
+}
+
+async fn update_all_states(
+    client: &mut Client,
+    prefix: &str,
+    hostname: &str,
+    cached: &mut HashMap<String, String>,
+) -> Result<u32> {
+    info!("Starting update_all_states...");
+    let mut updates = 0;
+
+    for (base_path, state_name) in SYSTEM_STATES.iter() {
+        info!("Processing state: {} at path: {}", state_name, base_path);
+        match read_revision(base_path) {
+            Some(revision) => {
+                info!("Read revision for {}: {}", state_name, revision);
+                let key = format!("{}/{}/{}", prefix, hostname, state_name);
+                if update_etcd_key(client, &key, &revision, cached).await? {
+                    updates += 1;
+                }
+            }
+            None => {
+                info!("No revision found for {} at {}", state_name, base_path);
+            }
+        }
+    }
+
+    if updates > 0 {
+        info!("Made {} etcd updates", updates);
+    } else {
+        info!("No etcd updates needed");
+    }
+
+    info!("Finished update_all_states");
+
+    Ok(updates)
+}
+
+/// Check if an inotify event indicates a relevant change to one of our watched paths
+fn is_relevant_event(event: &inotify::Event<&std::ffi::OsStr>) -> bool {
+    let mask = event.mask;
+
+    // Check if any of the relevant flags are set
+    let is_relevant = mask.intersects(
+        EventMask::CREATE
+            .union(EventMask::DELETE)
+            .union(EventMask::MOVED_TO)
+            .union(EventMask::MOVED_FROM)
+            .union(EventMask::ATTRIB),
+    );
+
+    if !is_relevant {
+        return false;
+    }
+
+    // Check if the event is on a file we care about
+    if let Some(name) = event.name {
+        let name_bytes = name.as_bytes();
+        // Check if it's the "system" link in /nix/var/nix/profiles/
+        // or related to current-system/booted-system
+        if name_bytes == b"system"
+            || name_bytes == b"current-system"
+            || name_bytes == b"booted-system"
+        {
+            return true;
+        }
+    }
+
+    // Events without a name are on the watched directory itself (e.g., ATTRIB on the symlink)
+    if event.name.is_none() {
+        // Check if the event mask includes ISDIR or is ATTRIB (symlink change)
+        return mask.contains(EventMask::ATTRIB)
+            || mask.contains(EventMask::CREATE)
+            || mask.contains(EventMask::DELETE);
+    }
+
+    false
+}
+
+/// Spawn a blocking thread that sets up inotify and watches for changes
+fn spawn_inotify_thread(tx: mpsc::Sender<()>) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        // Initialize inotify
+        let mut inotify = match Inotify::init() {
+            Ok(i) => i,
+            Err(e) => {
+                warn!("Failed to initialize inotify: {}", e);
+                return;
+            }
+        };
+
+        // Add watches for each system state
+        let mut watch_count = 0;
+        for (base_path, state_name) in SYSTEM_STATES.iter() {
+            let path = Path::new(base_path);
+            let parent = if path.file_name().is_some() {
+                path.parent().unwrap_or(Path::new("/"))
+            } else {
+                path
+            };
+
+            if parent.exists() {
+                match inotify.watches().add(parent, WATCH_MASK) {
+                    Ok(wd) => {
+                        info!(
+                            "Watching {} for {} (watch descriptor: {:?})",
+                            parent.display(),
+                            state_name,
+                            wd
+                        );
+                        watch_count += 1;
+                    }
+                    Err(e) => {
+                        warn!("Failed to watch {}: {}", parent.display(), e);
+                    }
+                }
+            } else {
+                warn!("Parent path does not exist: {}", parent.display());
+            }
+        }
+
+        if watch_count == 0 {
+            warn!("No directories could be watched, exiting watcher thread");
+            return;
+        }
+
+        info!("Starting inotify watch loop in blocking thread");
+
+        // Buffer for reading events (must be large enough for multiple events)
+        let mut buffer = [0u8; 4096];
+
+        loop {
+            match inotify.read_events_blocking(&mut buffer) {
+                Ok(events) => {
+                    let mut relevant_change = false;
+                    for event in events {
+                        debug!(
+                            "inotify event: {:?}, mask: {:?}, name: {:?}",
+                            event.wd, event.mask, event.name
+                        );
+
+                        if is_relevant_event(&event) {
+                            relevant_change = true;
+                            if let Some(name) = event.name {
+                                info!("Detected change in: {:?}", name);
+                            } else {
+                                info!(
+                                    "Detected change in watched directory (mask: {:?})",
+                                    event.mask
+                                );
+                            }
+                        }
+                    }
+
+                    if relevant_change {
+                        // Use blocking_send since we're in a sync thread
+                        if tx.blocking_send(()).is_err() {
+                            // Channel closed, exit the thread
+                            info!("Channel closed, exiting inotify watcher thread");
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Error reading inotify events: {}", e);
+                    // Small delay before retrying to avoid busy-looping on persistent errors
+                    thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    })
+}
+
+async fn run(prefix: String, mut client: Client) -> Result<()> {
+    let hostname = detect_hostname();
+    info!("Hostname: {}", hostname);
+    info!("etcd prefix: {}", prefix);
+
+    let mut cached: HashMap<String, String> = HashMap::new();
+
+    // Initial update
+    update_all_states(&mut client, &prefix, &hostname, &mut cached).await?;
+
+    // Create async channel for inotify thread communication
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    // Spawn blocking thread for inotify
+    let inotify_thread = spawn_inotify_thread(tx);
+
+    // Watch for changes and update etcd
+    loop {
+        tokio::select! {
+            // Wait for inotify signals
+            maybe_signal = rx.recv() => {
+                if maybe_signal.is_none() {
+                    info!("Channel closed, exiting...");
+                    break;
+                }
+                info!("Received inotify signal, updating etcd...");
+
+                match update_all_states(&mut client, &prefix, &hostname, &mut cached).await {
+                    Ok(updates) => {
+                        info!("Finished updating etcd after inotify signal, {} updates made", updates);
+                    }
+                    Err(e) => {
+                        warn!("Failed to update etcd: {}", e);
+                    }
+                }
+            }
+
+            // Handle shutdown signal
+            _ = tokio::signal::ctrl_c() => {
+                info!("Received shutdown signal, exiting...");
+                break;
+            }
+        }
+    }
+
+    // Clean up
+    drop(rx);
+    let _ = inotify_thread.join();
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+
+    info!("Connecting to etcd at {:?}", cli.endpoints);
+
+    let client = Client::connect(&cli.endpoints, None)
+        .await
+        .with_context(|| format!("Failed to connect to etcd at {:?}", cli.endpoints))?;
+
+    info!("Connected to etcd");
+
+    run(cli.prefix, client).await
+}

--- a/src/ogygia/src/status/state.rs
+++ b/src/ogygia/src/status/state.rs
@@ -478,9 +478,17 @@ pub fn load_cli_config() -> Result<Option<CliConfig>> {
                 }
             }
 
+            let base_namespace = normalize_namespace(&raw_etcd.namespace);
+            // Append /nixos/versions to the base namespace (e.g., /ogygia -> /ogygia/nixos/versions)
+            let namespace = if base_namespace == "/" {
+                "/nixos/versions".to_string()
+            } else {
+                format!("{}/nixos/versions", base_namespace)
+            };
+
             Some(EtcdCliConfig {
                 endpoints: raw_etcd.endpoints,
-                namespace: normalize_namespace(&raw_etcd.namespace),
+                namespace,
                 timeout: Duration::from_secs(raw_etcd.timeout_seconds.max(MIN_TIMEOUT_SECONDS)),
             })
         }
@@ -641,7 +649,7 @@ const fn default_timeout_seconds() -> u64 {
 
 /// Default etcd namespace for host data storage.
 fn default_etcd_namespace() -> String {
-    "/ogygia/nixos/versions".to_string()
+    "/ogygia".to_string()
 }
 
 /// Default ZooKeeper namespace for host data storage.


### PR DESCRIPTION
Ogygia has always embedded Git revision hashes into NixOS system closures and provided visibility into these hashes across the fleet via ZooKeeper. However, until now there was no upstream mechanism to actually publish host version data to the coordination backend.

This commit introduces ogygia-hostinfod, an async daemon that publishes host version information (current, booted, and nextboot revisions) to etcd. The service watches standard NixOS system paths for changes and updates etcd only when values differ from cached state. Unlike the existing ZooKeeper read-only support, this is a write path that populates the coordination store.

We are choosing etcd over ZooKeeper for the write path implementation. The etcd implementation uses /ogygia/nixos/versions as its key namespace, while ZooKeeper remains at its legacy /nixos/versions location.

The ogygia.etcd module provides a read-only clientConnectionString option that generates a comma-separated list of endpoints from the configured endpoints list. The hostinfod service automatically uses this connection string when the etcd module is enabled, avoiding configuration duplication between the read and write paths.

Test plan:
- Added etcd-client to workspace dependencies
- Created ogygia-hostinfod crate with tokio async runtime and notify watcher
- Implemented NixOS module with systemd service and security hardening
- Added ogygia.etcd.clientConnectionString read-only option
- hostinfod now automatically inherits etcd endpoints and namespace when available
- Verified crate structure matches ogygia-irisd patterns
- ZooKeeper legacy support remains unchanged at /nixos/versions