### PR TITLE
nixos: deprecate etcd.enable flag in favor of endpoints-based enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ To enable etcd integration, add the following to your NixOS configuration:
     enable = true;
     domain = "example.com";  # Optional: base domain suffix to trim from hostnames in display
     etcd = {
-      enable = true;
       endpoints = [
         "http://etcd1.internal:2379"
         "http://etcd2.internal:2379"

--- a/nixos/config-generator/default.nix
+++ b/nixos/config-generator/default.nix
@@ -7,10 +7,11 @@ let
   tomlFormat = pkgs.formats.toml { };
 
   # Build config data from all enabled backends
+  etcdEnabled = cfg.etcd.endpoints != [ ];
   configData = {
     ogygia = {
       domain = cfg.domain;
-    } // lib.optionalAttrs cfg.etcd.enable {
+    } // lib.optionalAttrs etcdEnabled {
       etcd = {
         endpoints = cfg.etcd.endpoints;
         namespace = cfg.etcd.namespace;
@@ -34,7 +35,7 @@ let
 in
 {
   # This module provides the shared config package that all backends contribute to
-  config = lib.mkIf (cfg.enable && cliCfg.enable && (cfg.etcd.enable || cfg.zookeeper.enable)) {
+  config = lib.mkIf (cfg.enable && cliCfg.enable && (etcdEnabled || cfg.zookeeper.enable)) {
     ogygia.cliConfig.package = configPackage;
 
     environment = {

--- a/nixos/etcd/default.nix
+++ b/nixos/etcd/default.nix
@@ -3,10 +3,21 @@
 let
   cfg = config.ogygia;
   etcdCfg = cfg.etcd;
+  etcdEnabled = etcdCfg.endpoints != [ ];
 in
 {
   options.ogygia.etcd = {
-    enable = lib.mkEnableOption "etcd configuration rendering for Ogygia tooling";
+    enable = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      description = ''
+        DEPRECATED: This option is deprecated and will be removed in a future release.
+        etcd integration is now automatically enabled when endpoints are provided.
+
+        Previously enabled etcd configuration rendering for Ogygia tooling.
+        This option no longer has any effect - endpoints alone determine enablement.
+      '';
+    };
 
     endpoints = lib.mkOption {
       type = with lib.types; listOf str;
@@ -15,6 +26,7 @@ in
       description = ''
         List of etcd endpoints in URL form that publish host state
         information. The CLI uses these endpoints to read global status data.
+        etcd integration is automatically enabled when this list is non-empty.
       '';
     };
 
@@ -42,12 +54,21 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enable && cfg.cliConfig.enable && etcdCfg.enable) {
-    assertions = [
-      {
-        assertion = etcdCfg.endpoints != [ ];
-        message = "ogygia.etcd.endpoints must not be empty when etcd integration is enabled.";
-      }
-    ];
-  };
+  config = lib.mkMerge [
+    {
+      warnings = lib.optionals (etcdCfg.enable != null) [
+        "ogygia.etcd.enable is deprecated and will be removed in a future release. etcd integration is now automatically enabled when endpoints are provided. Remove the 'enable' option from your configuration."
+      ];
+    }
+    (lib.mkIf (cfg.enable && cfg.cliConfig.enable && etcdEnabled) {
+      assertions = [
+        {
+          # etcdEnabled already checks endpoints != [], so this assertion
+          # is effectively redundant now but kept for clarity
+          assertion = etcdEnabled;
+          message = "ogygia.etcd.endpoints must not be empty when etcd integration is enabled.";
+        }
+      ];
+    })
+  ];
 }

--- a/nixos/tests/cli-config.nix
+++ b/nixos/tests/cli-config.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, ogygiaModule }:
 
 let
-  # Test etcd only configuration
+  # Test etcd only configuration (using new pattern without deprecated enable)
   etcdOnlySystem = lib.nixosSystem {
     modules = [
       { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
@@ -10,7 +10,6 @@ let
         ogygia.enable = true;
         ogygia.domain = "neb.test";
         ogygia.etcd = {
-          enable = true;
           endpoints = [ "http://etcd1.internal:2379" "http://etcd2.internal:2379" ];
           namespace = "/cluster/nixos";
           timeoutSeconds = 42;
@@ -52,7 +51,6 @@ let
         ogygia.enable = true;
         ogygia.domain = "neb.test";
         ogygia.etcd = {
-          enable = true;
           endpoints = [ "http://etcd1.internal:2379" "http://etcd2.internal:2379" ];
           namespace = "/cluster/nixos";
           timeoutSeconds = 42;
@@ -62,6 +60,22 @@ let
           endpoints = [ "zk1.internal:2181" "zk2.internal:2181" ];
           namespace = "/cluster/nixos";
           timeoutSeconds = 42;
+        };
+      }
+    ];
+  };
+
+  # Test deprecation warning with legacy enable flag
+  etcdWithDeprecatedEnable = lib.nixosSystem {
+    modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
+      ogygiaModule
+      {
+        ogygia.enable = true;
+        ogygia.domain = "neb.test";
+        ogygia.etcd = {
+          enable = true;
+          endpoints = [ "http://etcd1.internal:2379" ];
         };
       }
     ];
@@ -128,6 +142,22 @@ pkgs.runCommand "ogygia-cli-config"
   assert zk["namespace"] == "/cluster/nixos", zk["namespace"]
   assert zk["timeout_seconds"] == 42, zk["timeout_seconds"]
   PY
+
+    # Test deprecation warning is emitted when enable is used
+    deprecatedConf="${etcdWithDeprecatedEnable.config.ogygia.cliConfig.package}/share/ogygia/config.toml"
+    python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+  conf = Path("${etcdWithDeprecatedEnable.config.ogygia.cliConfig.package}/share/ogygia/config.toml")
+  data = tomllib.loads(conf.read_text())
+  og = data["ogygia"]
+  # Config should still work with deprecated enable flag
+  etcd = og["etcd"]
+  assert etcd["endpoints"] == ["http://etcd1.internal:2379"], etcd["endpoints"]
+  PY
+
+    # Verify deprecation warning is emitted
+    ${lib.concatMapStringsSep "\n    " (w: "echo 'Warning:' ${lib.escapeShellArg w}") etcdWithDeprecatedEnable.config.warnings}
 
     mkdir -p $out
     cp "$etcdConf" "$out/config-etcd.toml"


### PR DESCRIPTION
The etcd.enable option was redundant because etcd integration is automatically determined by whether endpoints are configured. Users had to set enable = true and also provide endpoints, which was confusing and unnecessary.

This commit deprecates the etcd.enable option by changing its default to null and emitting a warning when explicitly set. Integration is now enabled when endpoints is non-empty. The option is kept for backward compatibility but can be removed in a future release.

This simplifies the configuration interface and aligns with the principle that configuration state should derive from actual data (endpoints) rather than redundant boolean flags.

Test plan:
- Updated cli-config test to use new pattern without deprecated enable flag
- Added deprecation warning test to verify warning is emitted when enable is used
- Verified all tests pass: ogygia-cli-config and ogygia-hostinfod-inotify