### PR TITLE
config: add deprecation warnings for ZooKeeper settings

### DIFF
--- a/nixos/config/default.nix
+++ b/nixos/config/default.nix
@@ -26,28 +26,50 @@ in
       description = ''
         List of ZooKeeper endpoints in <host>:<port> form that publish host state
         information. The CLI uses these endpoints to read global status data.
+
+        :::{.warning}
+        ZooKeeper support is deprecated and will be removed in a future version.
+        Please migrate to etcd, which is more actively supported and will receive all future features.
+        :::
       '';
     };
 
     namespace = lib.mkOption {
       type = lib.types.str;
       default = "/nixos/versions";
-      description = "ZooKeeper znode prefix that contains host state information.";
+      description = ''
+        ZooKeeper znode prefix that contains host state information.
+
+        :::{.warning}
+        ZooKeeper support is deprecated and will be removed in a future version.
+        Please migrate to etcd, which is more actively supported and will receive all future features.
+        :::
+      '';
     };
 
     timeoutSeconds = lib.mkOption {
       type = lib.types.int;
       default = 10;
-      description = "Connection timeout used by the Ogygia CLI when contacting ZooKeeper.";
+      description = ''
+        Connection timeout used by the Ogygia CLI when contacting ZooKeeper.
+
+        :::{.warning}
+        ZooKeeper support is deprecated and will be removed in a future version.
+        Please migrate to etcd, which is more actively supported and will receive all future features.
+        :::
+      '';
     };
   };
 
-  config = lib.mkIf (cfg.enable && cfg.cliConfig.enable && zkCfg.enable) {
-    assertions = lib.optionals zkCfg.enable [
+  config = lib.mkIf (cfg.enable && cfg.cliConfig.enable && zkCfg.enable)
+    (lib.warn
+      "ogygia: ZooKeeper support is deprecated and will be removed in a future version. Please migrate to etcd, which is more actively supported and will receive all future features."
       {
-        assertion = zkCfg.endpoints != [ ];
-        message = "ogygia.zookeeper.endpoints must not be empty when ZooKeeper integration is enabled.";
-      }
-    ];
-  };
+        assertions = lib.optionals zkCfg.enable [
+          {
+            assertion = zkCfg.endpoints != [ ];
+            message = "ogygia.zookeeper.endpoints must not be empty when ZooKeeper integration is enabled.";
+          }
+        ];
+      });
 }

--- a/src/ogygia/src/status/mod.rs
+++ b/src/ogygia/src/status/mod.rs
@@ -108,6 +108,10 @@ pub fn show_status() -> Result<()> {
                     }
                 }
             } else if let Some(zookeeper) = cli_config.zookeeper.as_ref() {
+                warn!(
+                    "ZooKeeper support is deprecated and will be removed in a future version. \
+                     Please migrate to etcd, which is more actively supported and will receive all future features."
+                );
                 info!(
                     namespace = %zookeeper.namespace,
                     config = %cli_config.path.display(),


### PR DESCRIPTION
ZooKeeper support is being phased out in favor of etcd, which is more actively maintained and will receive all future features. Users currently using ZooKeeper need clear warnings to migrate their configurations.

This change adds deprecation warnings in two places:
1. A runtime warning in the Rust CLI when ZooKeeper is used as a fallback (i.e., when etcd is not configured)
2. A build-time warning in the NixOS module when zookeeper.enable is set, plus deprecation notices in all option descriptions

These warnings inform users that ZooKeeper will be removed in a future version and direct them to migrate to etcd for continued support.

Test plan:
- nix flake check passes (CI)
- Build-time warnings appear when ZooKeeper is enabled in test configurations
- Runtime warning will trigger when ZooKeeper is used without etcd config