### PR TITLE
ogygia-dashboard: add NixOS host status visualization web service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +338,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +477,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "env_home"
@@ -730,6 +779,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +973,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1196,6 +1284,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "liblzma"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1333,32 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1419,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "ogygia"
 version = "0.1.0"
 dependencies = [
@@ -1435,6 +1572,32 @@ dependencies = [
  "tracing-subscriber",
  "which",
  "zookeeper",
+]
+
+[[package]]
+name = "ogygia-dashboard"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.8",
+ "chrono",
+ "clap",
+ "enum-map",
+ "etcd-client",
+ "git2",
+ "hyper",
+ "hyper-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "strum",
+ "tempfile",
+ "tokio",
+ "toml",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1498,6 +1661,24 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2646,6 +2827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,10 +3068,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,16 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Date/time
+chrono = { version = "0.4", features = ["serde"] }
+
+# Git
+git2 = "0.20"
+tempfile = "3.0"
+
+# Enums
+enum-map = "2.7"
+
 # Utilities
 bytes = "1"
 futures = "0.3"

--- a/flake.nix
+++ b/flake.nix
@@ -75,8 +75,8 @@
           commonArgs = {
             inherit src;
             strictDeps = true;
-            buildInputs = [ ];
-            nativeBuildInputs = [ pkgs.protobuf ];
+            buildInputs = [ pkgs.openssl ];
+            nativeBuildInputs = [ pkgs.protobuf pkgs.pkg-config ];
           };
 
           individualCrateArgs = commonArgs // {
@@ -108,10 +108,19 @@
             src = fileSetForCrate ./src/ogygia-hostinfod;
           });
 
+          ogygia-dashboard = craneLib.buildPackage (individualCrateArgs // {
+            pname = "ogygia-dashboard";
+            cargoExtraArgs = "-p ogygia-dashboard";
+            src = fileSetForCrate ./src/ogygia-dashboard;
+            postInstall = ''
+              ${pkgs.patchelf}/bin/patchelf --set-rpath "${lib.makeLibraryPath [ pkgs.openssl ]}" $out/bin/ogygia-dashboard
+            '';
+          });
+
         in
         {
           packages = {
-            inherit ogygia ogygia-irisd ogygia-hostinfod;
+            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard;
             default = ogygia;
           };
 
@@ -133,7 +142,7 @@
           formatter = treefmtEval.config.build.wrapper;
 
           checks = {
-            inherit ogygia ogygia-irisd ogygia-hostinfod;
+            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard;
 
             ogygia-clippy = craneLib.cargoClippy (commonArgs // {
               inherit cargoArtifacts;
@@ -193,6 +202,7 @@
         imports = [ ./nixos ];
         _module.args.ogygia-irisd = self.packages.${pkgs.system}.ogygia-irisd;
         _module.args.ogygia-hostinfod = self.packages.${pkgs.system}.ogygia-hostinfod;
+        _module.args.ogygia-dashboard = self.packages.${pkgs.system}.ogygia-dashboard;
       };
 
       ci = nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" ] (system:

--- a/nixos/dashboard/default.nix
+++ b/nixos/dashboard/default.nix
@@ -1,0 +1,98 @@
+{ config, lib, pkgs, ogygia-dashboard, ... }:
+
+let
+  cfg = config.ogygia.dashboard;
+  etcdCfg = config.ogygia.etcd;
+
+  ogygiaConfig = config.ogygia;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  configFile = tomlFormat.generate "ogygia-dashboard.toml" ({
+    server = cfg.serverConfig;
+    git = {
+      remote_url = ogygiaConfig.gitRemoteUrl;
+    };
+    etcd = {
+      endpoints = etcdCfg.endpoints;
+      prefix = etcdCfg.namespace + "/nixos/versions";
+    };
+    title = cfg.title;
+  } // lib.optionalAttrs (cfg.hostnameStripSuffix != null) {
+    hostname_strip_suffix = cfg.hostnameStripSuffix;
+  });
+in
+{
+  options.ogygia.dashboard = {
+    enable = lib.mkEnableOption "ogygia-dashboard NixOS host status visualization webserver";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = ogygia-dashboard;
+      description = "The ogygia-dashboard package to use.";
+    };
+
+    title = lib.mkOption {
+      type = lib.types.str;
+      default = config.ogygia.domain;
+      description = "Title displayed on the dashboard page. Defaults to the island domain.";
+    };
+
+    hostnameStripSuffix = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = ".${config.ogygia.domain}";
+      description = "Suffix to strip from hostnames when displaying them on the dashboard. Defaults to the island domain.";
+      example = ".example.com";
+    };
+
+    serverConfig = lib.mkOption {
+      type = lib.types.attrs;
+      default = { port = 8080; };
+      description = "Server bind configuration passed to the dashboard TOML config.";
+      example = { port = 8080; };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = etcdCfg.endpoints != [ ];
+        message = "ogygia.etcd.endpoints must not be empty when ogygia.dashboard is enabled.";
+      }
+    ];
+
+    systemd.services.ogygia-dashboard = {
+      description = "Ogygia Dashboard - NixOS Host Status Visualization";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/ogygia-dashboard --config ${configFile}";
+        Restart = "always";
+        RestartSec = "10s";
+        DynamicUser = true;
+        RuntimeDirectory = "ogygia-dashboard";
+
+        # Security hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+
+      environment = {
+        RUST_LOG = lib.mkDefault "info";
+      };
+    };
+  };
+}

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -13,6 +13,12 @@ in
       example = "island.example.com";
     };
 
+    gitRemoteUrl = lib.mkOption {
+      type = lib.types.str;
+      description = "Git remote URL for the NixOS configuration repository.";
+      example = "https://git.example.com/user/nixos.git";
+    };
+
     nebula.ipv4 = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
@@ -28,6 +34,7 @@ in
     ./etcd
     ./irisd
     ./hostinfod
+    ./dashboard
   ];
 
   config = lib.mkIf cfg.enable {

--- a/src/ogygia-dashboard/Cargo.toml
+++ b/src/ogygia-dashboard/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "ogygia-dashboard"
+version.workspace = true
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+# CLI
+clap = { workspace = true }
+anyhow = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# HTTP server
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
+
+# HTTP client
+reqwest = { workspace = true }
+
+# etcd client
+etcd-client = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+
+# Git
+git2 = { workspace = true }
+tempfile = { workspace = true }
+chrono = { workspace = true }
+
+# Enums
+strum = { workspace = true }
+enum-map = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/src/ogygia-dashboard/src/config.rs
+++ b/src/ogygia-dashboard/src/config.rs
@@ -1,0 +1,302 @@
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    pub server: ServerConfig,
+    pub git: GitConfig,
+    pub etcd: EtcdConfig,
+    #[serde(default = "default_title")]
+    pub title: String,
+    #[serde(default)]
+    pub hostname_strip_suffix: Option<String>,
+}
+
+fn default_title() -> String {
+    "Status Page".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    #[serde(flatten)]
+    pub bind: Bind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Bind {
+    Tcp { port: u16 },
+    Unix { socket: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitConfig {
+    pub remote_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EtcdConfig {
+    pub endpoints: Vec<String>,
+    #[serde(default = "default_etcd_prefix")]
+    pub prefix: String,
+}
+
+fn default_etcd_prefix() -> String {
+    "/ogygia/nixos/versions".to_string()
+}
+
+impl Config {
+    pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())
+            .with_context(|| format!("Failed to read config file: {}", path.as_ref().display()))?;
+
+        let config: Config = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse config file: {}", path.as_ref().display()))?;
+
+        config.validate()?;
+
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.git.remote_url.is_empty() {
+            return Err(anyhow::anyhow!("git.remote_url cannot be empty"));
+        }
+
+        if self.etcd.endpoints.is_empty() {
+            return Err(anyhow::anyhow!("etcd.endpoints cannot be empty"));
+        }
+
+        for endpoint in &self.etcd.endpoints {
+            if endpoint.is_empty() {
+                return Err(anyhow::anyhow!("etcd endpoint cannot be empty"));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Override server config with CLI values if provided
+    /// CLI args take precedence: socket > port > config file
+    pub fn override_server_config(&mut self, port: Option<u16>, socket: Option<String>) {
+        match (socket, port) {
+            (Some(socket), _) => {
+                // Socket takes precedence over port
+                self.server.bind = Bind::Unix { socket };
+            }
+            (None, Some(port)) => {
+                // Port specified, override existing config
+                self.server.bind = Bind::Tcp { port };
+            }
+            (None, None) => {
+                // No CLI overrides, keep existing config
+            }
+        }
+    }
+
+    /// Get the full git repository URL
+    pub fn git_repo_url(&self) -> &str {
+        &self.git.remote_url
+    }
+
+    /// Get the repository web URL (removes .git suffix if present)
+    pub fn repo_web_url(&self) -> String {
+        if self.git.remote_url.ends_with(".git") {
+            self.git.remote_url[..self.git.remote_url.len() - 4].to_string()
+        } else {
+            self.git.remote_url.to_string()
+        }
+    }
+
+    /// Get the pull requests web URL
+    pub fn pulls_web_url(&self) -> String {
+        format!("{}/pulls", self.repo_web_url())
+    }
+
+    /// Get the API URL for pull requests (assumes Gitea/Forgejo API structure)
+    pub fn pulls_api_url(&self) -> String {
+        let web_url = self.repo_web_url();
+        // Extract server, username, and repo from the URL
+        if let Some(parts) = self.parse_repo_url(&web_url) {
+            format!(
+                "https://{}/api/v1/repos/{}/{}/pulls?state=open&limit=1",
+                parts.0, parts.1, parts.2
+            )
+        } else {
+            // Fallback if parsing fails
+            format!("{web_url}/api/v1/pulls?state=open&limit=1")
+        }
+    }
+
+    /// Get commit web URL
+    pub fn commit_web_url(&self, commit_hash: &str) -> String {
+        format!("{}/commit/{}", self.repo_web_url(), commit_hash)
+    }
+
+    /// Parse repository URL to extract server, username, and repository name
+    /// Returns (server, username, repository) or None if parsing fails
+    fn parse_repo_url(&self, url: &str) -> Option<(String, String, String)> {
+        let url = url
+            .strip_prefix("https://")
+            .or_else(|| url.strip_prefix("http://"))?;
+        let parts: Vec<&str> = url.split('/').collect();
+        if parts.len() >= 3 {
+            Some((
+                parts[0].to_string(),
+                parts[1].to_string(),
+                parts[2].to_string(),
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    fn test_config() -> Config {
+        Config {
+            server: ServerConfig {
+                bind: Bind::Tcp { port: 8080 },
+            },
+            git: GitConfig {
+                remote_url: "https://git.example.com/user/repo.git".to_string(),
+            },
+            etcd: EtcdConfig {
+                endpoints: vec!["http://etcd1:2379".to_string()],
+                prefix: default_etcd_prefix(),
+            },
+            title: default_title(),
+            hostname_strip_suffix: None,
+        }
+    }
+
+    #[test]
+    fn test_load_from_toml_tcp() {
+        let toml_content = r#"
+[server]
+port = 9090
+
+[git]
+remote_url = "https://git.example.com/testuser/testrepo.git"
+
+[etcd]
+endpoints = ["http://etcd1:2379", "http://etcd2:2379"]
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+
+        let config = Config::load_from_file(temp_file.path()).unwrap();
+
+        assert!(matches!(config.server.bind, Bind::Tcp { port: 9090 }));
+        assert_eq!(
+            config.git.remote_url,
+            "https://git.example.com/testuser/testrepo.git"
+        );
+        assert_eq!(
+            config.etcd.endpoints,
+            vec!["http://etcd1:2379", "http://etcd2:2379"]
+        );
+        assert_eq!(config.etcd.prefix, "/ogygia/nixos/versions");
+        assert_eq!(config.title, "Status Page");
+        assert!(config.hostname_strip_suffix.is_none());
+    }
+
+    #[test]
+    fn test_load_from_toml_unix() {
+        let toml_content = r#"
+title = "My Dashboard"
+hostname_strip_suffix = ".example.com"
+
+[server]
+socket = "/tmp/test.sock"
+
+[git]
+remote_url = "https://git.example.com/testuser/testrepo.git"
+
+[etcd]
+endpoints = ["http://etcd1:2379", "http://etcd2:2379"]
+prefix = "/custom/prefix"
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+
+        let config = Config::load_from_file(temp_file.path()).unwrap();
+
+        assert!(matches!(config.server.bind, Bind::Unix { socket } if socket == "/tmp/test.sock"));
+        assert_eq!(config.title, "My Dashboard");
+        assert_eq!(
+            config.hostname_strip_suffix,
+            Some(".example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_override_server_config() {
+        // Test socket override (takes precedence)
+        let mut config = test_config();
+        config.override_server_config(Some(3000), Some("/tmp/override.sock".to_string()));
+        assert!(
+            matches!(config.server.bind, Bind::Unix { socket } if socket == "/tmp/override.sock")
+        );
+
+        // Test port override only
+        let mut config = test_config();
+        config.override_server_config(Some(3000), None);
+        assert!(matches!(config.server.bind, Bind::Tcp { port: 3000 }));
+
+        // Test no override
+        let mut config = test_config();
+        config.override_server_config(None, None);
+        assert!(matches!(config.server.bind, Bind::Tcp { port: 8080 }));
+    }
+
+    #[test]
+    fn test_url_generation() {
+        let config = test_config();
+
+        assert_eq!(
+            config.git_repo_url(),
+            "https://git.example.com/user/repo.git"
+        );
+        assert_eq!(config.repo_web_url(), "https://git.example.com/user/repo");
+        assert_eq!(
+            config.pulls_web_url(),
+            "https://git.example.com/user/repo/pulls"
+        );
+        assert_eq!(
+            config.commit_web_url("abc123"),
+            "https://git.example.com/user/repo/commit/abc123"
+        );
+        assert_eq!(
+            config.pulls_api_url(),
+            "https://git.example.com/api/v1/repos/user/repo/pulls?state=open&limit=1"
+        );
+    }
+
+    #[test]
+    fn test_validation_empty_remote_url() {
+        let mut config = test_config();
+        config.git.remote_url = "".to_string();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_empty_etcd_endpoints() {
+        let mut config = test_config();
+        config.etcd.endpoints = vec![];
+        assert!(config.validate().is_err());
+    }
+}

--- a/src/ogygia-dashboard/src/etcd.rs
+++ b/src/ogygia-dashboard/src/etcd.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use enum_map::EnumMap;
+use etcd_client::Client;
+use etcd_client::EventType;
+use etcd_client::GetOptions;
+use etcd_client::WatchOptions;
+use git2::Oid;
+use tokio::sync::Mutex;
+
+use crate::config::Config;
+use crate::nixos::CommitState;
+
+#[derive(Default, Debug, Clone)]
+pub struct HostStates {
+    pub version: usize,
+    pub host_states: HashMap<String, EnumMap<CommitState, Option<Oid>>>,
+}
+
+pub struct Etcd {
+    states: Mutex<Arc<HostStates>>,
+}
+
+impl Etcd {
+    pub async fn new(config: &Config) -> Result<Arc<Self>> {
+        let mut client = Client::connect(&config.etcd.endpoints, None).await?;
+        let prefix = config.etcd.prefix.clone();
+
+        let me = Arc::new(Self {
+            states: Default::default(),
+        });
+
+        // Load initial state
+        me.load_all(&mut client, &prefix).await?;
+
+        // Spawn background watcher
+        tokio::spawn({
+            let weak = Arc::downgrade(&me);
+            let endpoints = config.etcd.endpoints.clone();
+            let prefix = prefix.clone();
+            async move {
+                loop {
+                    let Some(me) = weak.upgrade() else {
+                        break;
+                    };
+
+                    if let Err(e) = me.watch_loop(&endpoints, &prefix).await {
+                        tracing::error!("etcd watch error: {e}, reconnecting...");
+                    }
+
+                    // Brief pause before reconnecting
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+                    let Some(me) = weak.upgrade() else {
+                        break;
+                    };
+
+                    let mut client = match Client::connect(&endpoints, None).await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::error!("Failed to reconnect to etcd: {e}");
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                            continue;
+                        }
+                    };
+
+                    // Reload all state after reconnection
+                    if let Err(e) = me.load_all(&mut client, &prefix).await {
+                        tracing::error!("Failed to reload state after reconnection: {e}");
+                    }
+                }
+            }
+        });
+
+        Ok(me)
+    }
+
+    pub async fn state(&self) -> Arc<HostStates> {
+        self.states.lock().await.clone()
+    }
+
+    async fn load_all(&self, client: &mut Client, prefix: &str) -> Result<()> {
+        let resp = client
+            .get(prefix, Some(GetOptions::new().with_prefix()))
+            .await?;
+
+        let mut guard = self.states.lock().await;
+        let states = Arc::make_mut(&mut *guard);
+        states.host_states.clear();
+
+        for kv in resp.kvs() {
+            let key = kv.key_str()?;
+            let value = kv.value_str()?;
+
+            if let Some((host, commit_state)) = parse_key(key, prefix) {
+                let commit = Oid::from_str(value)?;
+                states.host_states.entry(host.to_string()).or_default()[commit_state] =
+                    Some(commit);
+            }
+        }
+
+        states.version += 1;
+        tracing::info!(
+            "Loaded {} hosts from etcd, version: {}",
+            states.host_states.len(),
+            states.version
+        );
+
+        Ok(())
+    }
+
+    async fn watch_loop(&self, endpoints: &[String], prefix: &str) -> Result<()> {
+        let mut client = Client::connect(endpoints, None).await?;
+        let (_watcher, mut stream) = client
+            .watch(prefix, Some(WatchOptions::new().with_prefix()))
+            .await?;
+
+        tracing::info!("etcd watch established on prefix: {prefix}");
+
+        while let Some(resp) = stream.message().await? {
+            for event in resp.events() {
+                let Some(kv) = event.kv() else {
+                    continue;
+                };
+
+                let key = kv.key_str()?;
+                let Some((host, commit_state)) = parse_key(key, prefix) else {
+                    continue;
+                };
+
+                match event.event_type() {
+                    EventType::Put => {
+                        let value = kv.value_str()?;
+                        let commit = Oid::from_str(value)?;
+
+                        let mut guard = self.states.lock().await;
+                        let states = Arc::make_mut(&mut *guard);
+                        let old = states.host_states.entry(host.to_string()).or_default()
+                            [commit_state]
+                            .replace(commit);
+
+                        states.version += 1;
+
+                        let old_str = old.map(|c| c.to_string()[..12].to_string());
+                        tracing::info!(
+                            "Host '{}' state '{}' changed from {} to {}",
+                            host,
+                            commit_state.as_ref(),
+                            old_str.as_deref().unwrap_or("None"),
+                            &commit.to_string()[..12]
+                        );
+                    }
+                    EventType::Delete => {
+                        let mut guard = self.states.lock().await;
+                        let states = Arc::make_mut(&mut *guard);
+                        if let Some(host_map) = states.host_states.get_mut(host) {
+                            host_map[commit_state] = None;
+                        }
+                        states.version += 1;
+                        tracing::info!("Host '{}' state '{}' deleted", host, commit_state.as_ref());
+                    }
+                }
+            }
+        }
+
+        tracing::warn!("etcd watch stream ended");
+        Ok(())
+    }
+}
+
+/// Parse an etcd key like "/ogygia/nixos/versions/hostname/state" into (hostname, CommitState)
+fn parse_key<'a>(key: &'a str, prefix: &str) -> Option<(&'a str, CommitState)> {
+    let rest = key.strip_prefix(prefix)?.strip_prefix('/')?;
+    let (host, state_str) = rest.split_once('/')?;
+    let state = state_str.parse::<CommitState>().ok()?;
+    Some((host, state))
+}

--- a/src/ogygia-dashboard/src/git.rs
+++ b/src/ogygia-dashboard/src/git.rs
@@ -1,0 +1,217 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use chrono::TimeZone;
+use chrono::Utc;
+use git2::Oid;
+use git2::Repository;
+use tempfile::TempDir;
+
+use crate::config::Config;
+use crate::nixos::CommitInfo;
+
+pub struct GitManager {
+    temp_dir: Option<TempDir>,
+    repo_path: Option<PathBuf>, // For test cases only
+}
+
+// Implement Send + Sync for GitManager since we manage our own repo access
+unsafe impl Send for GitManager {}
+unsafe impl Sync for GitManager {}
+
+impl GitManager {
+    pub async fn new(config: &Config) -> Result<Self> {
+        let temp_dir = TempDir::new().context("Failed to create temp directory")?;
+        let repo_path = temp_dir.path();
+
+        Repository::clone(config.git_repo_url(), repo_path)
+            .context("Failed to clone nixos repository")?;
+
+        Ok(Self {
+            temp_dir: Some(temp_dir),
+            repo_path: None,
+        })
+    }
+
+    fn open_repo(&self) -> Result<Repository> {
+        let repo_path = if let Some(ref temp_dir) = self.temp_dir {
+            temp_dir.path()
+        } else if let Some(ref path) = self.repo_path {
+            path
+        } else {
+            return Err(anyhow::anyhow!("No repository path available"));
+        };
+        Repository::open(repo_path).context("Failed to open repository")
+    }
+
+    pub async fn fetch_updates(&self) -> Result<()> {
+        let repo = self.open_repo()?;
+        let mut remote = repo
+            .find_remote("origin")
+            .context("Failed to find origin remote")?;
+
+        // Configure fetch options for comprehensive updates
+        let mut fo = git2::FetchOptions::new();
+        fo.download_tags(git2::AutotagOption::All);
+        fo.prune(git2::FetchPrune::On);
+
+        remote
+            .fetch(
+                &[
+                    "+refs/heads/*:refs/remotes/origin/*",
+                    "+refs/tags/*:refs/tags/*",
+                ],
+                Some(&mut fo),
+                None,
+            )
+            .context("Failed to fetch with full options")?;
+
+        Ok(())
+    }
+
+    /// Get commit metadata for the specified commit hashes.
+    /// Also includes main branch tip and initial commit for context.
+    pub fn get_commits_info(&self, commit_hashes: &HashSet<Oid>) -> Result<Vec<CommitInfo>> {
+        let repo = self.open_repo()?;
+        let mut commits = Vec::new();
+
+        for &commit_oid in commit_hashes {
+            match self.get_commit_info_from_oid(&repo, commit_oid, "") {
+                Ok(commit_info) => commits.push(commit_info),
+                Err(e) => {
+                    tracing::warn!("Failed to get commit info for {commit_oid}: {e}");
+                    commits.push(CommitInfo::Missing(commit_oid.to_string()));
+                }
+            }
+        }
+
+        // Include main tip and initial commit for context
+        if let Ok(main_tip_oid) = self.get_main_tip() {
+            if !commit_hashes.contains(&main_tip_oid) {
+                match self.get_commit_info_from_oid(&repo, main_tip_oid, "") {
+                    Ok(commit_info) => commits.push(commit_info),
+                    Err(e) => {
+                        tracing::warn!("Failed to get main tip commit info for {main_tip_oid}: {e}")
+                    }
+                }
+            }
+
+            // Add initial commit
+            if let Ok(initial_oid) = self.get_initial_commit(&repo, main_tip_oid)
+                && !commit_hashes.contains(&initial_oid)
+            {
+                match self.get_commit_info_from_oid(&repo, initial_oid, "") {
+                    Ok(commit_info) => commits.push(commit_info),
+                    Err(e) => {
+                        tracing::warn!("Failed to get initial commit info for {initial_oid}: {e}")
+                    }
+                }
+            }
+
+            // Include merge-base for each commit with main branch
+            let mut seen_commits = HashSet::new();
+            for &commit_oid in commit_hashes {
+                seen_commits.insert(commit_oid);
+            }
+            seen_commits.insert(main_tip_oid);
+            if let Ok(initial_oid) = self.get_initial_commit(&repo, main_tip_oid) {
+                seen_commits.insert(initial_oid);
+            }
+
+            for &commit_oid in &seen_commits.clone() {
+                if let Ok(merge_base_oid) = repo.merge_base(commit_oid, main_tip_oid)
+                    && !seen_commits.contains(&merge_base_oid)
+                {
+                    match self.get_commit_info_from_oid(&repo, merge_base_oid, "") {
+                        Ok(commit_info) => {
+                            commits.push(commit_info);
+                            seen_commits.insert(merge_base_oid);
+                        }
+                        Err(e) => tracing::warn!(
+                            "Failed to get merge-base commit info for {merge_base_oid}: {e}"
+                        ),
+                    }
+                }
+            }
+        }
+
+        // Sort by missing status first (missing commits at top), then by timestamp (newest first)
+        commits.sort_by(|a, b| {
+            match (a, b) {
+                (CommitInfo::Missing(_), CommitInfo::Complete { .. }) => std::cmp::Ordering::Less,
+                (CommitInfo::Complete { .. }, CommitInfo::Missing(_)) => {
+                    std::cmp::Ordering::Greater
+                }
+                (CommitInfo::Missing(hash_a), CommitInfo::Missing(hash_b)) => hash_a.cmp(hash_b),
+                (
+                    CommitInfo::Complete {
+                        timestamp: ts_a, ..
+                    },
+                    CommitInfo::Complete {
+                        timestamp: ts_b, ..
+                    },
+                ) => {
+                    ts_b.cmp(ts_a) // Newest first
+                }
+            }
+        });
+
+        Ok(commits)
+    }
+
+    pub fn get_main_tip(&self) -> Result<Oid> {
+        let repo = self.open_repo()?;
+        if let Ok(main_ref) = repo.find_reference("refs/remotes/origin/main") {
+            main_ref
+                .target()
+                .ok_or_else(|| anyhow::anyhow!("No target for main ref"))
+        } else if let Ok(main_ref) = repo.find_reference("refs/heads/main") {
+            main_ref
+                .target()
+                .ok_or_else(|| anyhow::anyhow!("No target for main ref"))
+        } else {
+            Err(anyhow::anyhow!("No main branch found"))
+        }
+    }
+
+    fn get_initial_commit(&self, repo: &Repository, main_oid: Oid) -> Result<Oid> {
+        let mut walker = repo.revwalk()?;
+        walker.push(main_oid)?;
+        walker.set_sorting(git2::Sort::TIME | git2::Sort::REVERSE)?;
+
+        walker
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No commits found"))?
+            .map_err(|e| anyhow::anyhow!("Error walking commits: {}", e))
+    }
+
+    fn get_commit_info_from_oid(
+        &self,
+        repo: &Repository,
+        commit_oid: Oid,
+        hostname: &str,
+    ) -> Result<CommitInfo> {
+        let commit = repo
+            .find_commit(commit_oid)
+            .with_context(|| format!("object not found - no match for id ({commit_oid})"))?;
+
+        let timestamp = Utc
+            .timestamp_opt(commit.time().seconds(), 0)
+            .single()
+            .context("Invalid commit timestamp")?;
+
+        // Determine branch - for now, assume main if not specified
+        let branch = "main".to_string();
+
+        Ok(CommitInfo::Complete {
+            hash: commit_oid.to_string(),
+            message: commit.message().unwrap_or("").to_string(),
+            author: commit.author().name().unwrap_or("").to_string(),
+            timestamp,
+            branch,
+            hosts_using: vec![hostname.to_string()],
+        })
+    }
+}

--- a/src/ogygia-dashboard/src/main.rs
+++ b/src/ogygia-dashboard/src/main.rs
@@ -1,0 +1,100 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::Router;
+use axum::routing::get;
+use clap::Parser;
+use tokio::net::TcpListener;
+use tokio::net::UnixListener;
+use tower::ServiceExt;
+
+mod config;
+mod etcd;
+mod git;
+mod nixos;
+mod web;
+
+use crate::config::Config;
+use crate::web::AppState;
+
+#[derive(Parser)]
+#[command(name = "ogygia-dashboard")]
+#[command(about = "NixOS host status visualization webserver")]
+struct Cli {
+    /// Configuration file path (required)
+    #[arg(short, long)]
+    config: PathBuf,
+
+    /// Port to bind the server to (TCP) - overrides config file
+    #[arg(short, long)]
+    port: Option<u16>,
+
+    /// Unix socket path to bind to (alternative to TCP) - overrides config file
+    #[arg(short, long)]
+    socket: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+
+    // Load configuration
+    let mut config = Config::load_from_file(&cli.config)?;
+
+    // Override config with CLI arguments
+    config.override_server_config(
+        cli.port,
+        cli.socket.map(|p| p.to_string_lossy().to_string()),
+    );
+
+    let app_state = Arc::new(AppState::new(config.clone()).await?);
+
+    let app = Router::new()
+        .route("/", get(web::index))
+        .route("/nixos/commits", get(web::nixos_commits_html))
+        .with_state(app_state);
+
+    match &config.server.bind {
+        crate::config::Bind::Unix { socket } => {
+            let socket_path = PathBuf::from(socket);
+            // Remove existing socket file if it exists
+            if socket_path.exists() {
+                std::fs::remove_file(&socket_path)?;
+            }
+
+            tracing::info!("Server starting on Unix socket: {}", socket_path.display());
+            let listener = UnixListener::bind(&socket_path)?;
+
+            loop {
+                let (stream, _) = listener.accept().await?;
+                let tower_service = app.clone();
+
+                tokio::spawn(async move {
+                    let socket = hyper_util::rt::TokioIo::new(stream);
+                    let hyper_service = hyper::service::service_fn(move |request| {
+                        tower_service.clone().oneshot(request)
+                    });
+
+                    if let Err(err) = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(socket, hyper_service)
+                        .await
+                    {
+                        eprintln!("Failed to serve connection: {err}");
+                    }
+                });
+            }
+        }
+        crate::config::Bind::Tcp { port } => {
+            let addr: SocketAddr = format!("0.0.0.0:{port}").parse()?;
+            tracing::info!("Server starting on TCP: {addr}");
+            let listener = TcpListener::bind(addr).await?;
+            axum::serve(listener, app).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/ogygia-dashboard/src/nixos.rs
+++ b/src/ogygia-dashboard/src/nixos.rs
@@ -1,0 +1,78 @@
+use chrono::DateTime;
+use chrono::Utc;
+use enum_map::Enum;
+use serde::Deserialize;
+use serde::Serialize;
+use strum::AsRefStr;
+use strum::EnumIter;
+use strum::EnumString;
+
+#[derive(EnumIter, AsRefStr, Enum, EnumString, Debug, Copy, Clone)]
+#[strum(serialize_all = "lowercase")]
+pub enum CommitState {
+    Booted,
+    Current,
+    NextBoot,
+}
+
+/// Information about a commit relevant to host states
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CommitInfo {
+    Missing(String), // Just the hash
+    Complete {
+        hash: String,
+        message: String,
+        author: String,
+        timestamp: DateTime<Utc>,
+        branch: String,
+        hosts_using: Vec<String>, // Which hosts are using this commit
+    },
+}
+
+impl CommitInfo {
+    /// Get the short version of the commit hash (first 7 characters)
+    pub fn short_hash(&self) -> &str {
+        let hash = match self {
+            CommitInfo::Missing(hash) => hash,
+            CommitInfo::Complete { hash, .. } => hash,
+        };
+        &hash[..7.min(hash.len())]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_commit_info_creation() {
+        let commit_info = CommitInfo::Complete {
+            hash: "abcdef123456".to_string(),
+            message: "Test commit".to_string(),
+            author: "Test Author".to_string(),
+            timestamp: Utc::now(),
+            branch: "main".to_string(),
+            hosts_using: vec!["host1".to_string(), "host2".to_string()],
+        };
+
+        assert_eq!(commit_info.short_hash(), "abcdef1");
+
+        if let CommitInfo::Complete {
+            hash,
+            message,
+            author,
+            branch,
+            hosts_using,
+            ..
+        } = &commit_info
+        {
+            assert_eq!(hash, "abcdef123456");
+            assert_eq!(message, "Test commit");
+            assert_eq!(author, "Test Author");
+            assert_eq!(branch, "main");
+            assert_eq!(hosts_using.len(), 2);
+        } else {
+            panic!("Expected Complete variant");
+        }
+    }
+}

--- a/src/ogygia-dashboard/src/web.rs
+++ b/src/ogygia-dashboard/src/web.rs
@@ -1,0 +1,1024 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Html;
+use axum::response::IntoResponse;
+use chrono::DateTime;
+use chrono::Utc;
+use tokio::sync::Mutex;
+
+use crate::config::Config;
+use crate::etcd::Etcd;
+use crate::etcd::HostStates;
+use crate::git::GitManager;
+use crate::nixos::CommitInfo;
+
+#[derive(Clone)]
+struct CachedCommits {
+    version: usize,
+    commits: Vec<CommitInfo>,
+    expiry_time: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+struct CachedHtml {
+    version: usize,
+    pr_count: Option<u32>,
+    html: String,
+}
+
+#[derive(Clone)]
+struct CachedPrCount {
+    count: Option<u32>,
+    cached_at: DateTime<Utc>,
+}
+
+pub struct AppState {
+    config: Config,
+    git_manager: GitManager,
+    etcd: Arc<Etcd>,
+    commits_cache: Mutex<Arc<CachedCommits>>,
+    html_cache: Mutex<Arc<CachedHtml>>,
+    pr_count_cache: Mutex<Arc<CachedPrCount>>,
+}
+
+impl AppState {
+    pub async fn new(config: Config) -> Result<Self> {
+        let git_manager = GitManager::new(&config).await?;
+        git_manager.fetch_updates().await?;
+        let etcd = Etcd::new(&config).await?;
+
+        Ok(Self {
+            config,
+            git_manager,
+            etcd,
+            commits_cache: Mutex::new(Arc::new(CachedCommits {
+                version: 0,
+                commits: Vec::new(),
+                expiry_time: DateTime::<Utc>::MAX_UTC,
+            })),
+            html_cache: Mutex::new(Arc::new(CachedHtml {
+                version: 0,
+                pr_count: None,
+                html: String::new(),
+            })),
+            pr_count_cache: Mutex::new(Arc::new(CachedPrCount {
+                count: None,
+                cached_at: DateTime::from_timestamp(0, 0).unwrap(), // Unix epoch
+            })),
+        })
+    }
+
+    /// Get commit metadata for all commits referenced by etcd host states.
+    /// Uses version-based caching to avoid redundant git operations.
+    /// Also includes time-based expiry when commits have missing metadata.
+    async fn get_commits(&self) -> Result<Arc<CachedCommits>> {
+        let host_states = self.etcd.state().await;
+        let now = Utc::now();
+
+        let mut cache = self.commits_cache.lock().await;
+
+        // Check if commits cache is up to date while holding the lock
+        // Use >= in case cache was updated by another thread while we waited for the lock
+        if cache.version >= host_states.version && now < cache.expiry_time {
+            return Ok(cache.clone());
+        }
+
+        // Cache is stale or expired, we need to update it
+        // If cache expired due to missing commits, run git fetch first
+        if now >= cache.expiry_time && cache.version > 0 {
+            self.git_manager.fetch_updates().await?;
+        }
+
+        // Collect all unique commit hashes from etcd state
+        let mut commit_hashes = HashSet::new();
+        for host_states in host_states.host_states.values() {
+            for &oid in host_states.values().flatten() {
+                commit_hashes.insert(oid);
+            }
+        }
+
+        // Fetch commit info from git (this is the expensive operation)
+        let commits = self.git_manager.get_commits_info(&commit_hashes)?;
+
+        // Check if any commits are missing
+        let has_missing_commits = commits.iter().any(|c| matches!(c, CommitInfo::Missing(_)));
+
+        // Set expiry time: 1 minute from now if missing commits, 15 minutes otherwise to update the status of tracked branches
+        let expiry_time = if has_missing_commits {
+            now + chrono::Duration::minutes(1)
+        } else {
+            now + chrono::Duration::minutes(15)
+        };
+
+        // Update cache while still holding the lock
+        let new_cache = Arc::new(CachedCommits {
+            version: host_states.version,
+            commits,
+            expiry_time,
+        });
+
+        *cache = new_cache.clone();
+        Ok(new_cache)
+    }
+
+    /// Get PR count with time-based caching (5 minute TTL).
+    /// Independent of etcd version changes.
+    async fn get_pr_count(&self) -> Option<u32> {
+        const PR_COUNT_TTL_MINUTES: i64 = 5;
+
+        let mut cache = self.pr_count_cache.lock().await;
+        let now = Utc::now();
+
+        // Check if cache is fresh (within TTL)
+        if (now - cache.cached_at).num_minutes() < PR_COUNT_TTL_MINUTES {
+            return cache.count;
+        }
+
+        // Cache is stale, fetch fresh PR count
+        let pr_count = self.fetch_pr_count().await;
+
+        *cache = Arc::new(CachedPrCount {
+            count: pr_count,
+            cached_at: now,
+        });
+
+        pr_count
+    }
+
+    /// Generate and cache HTML git graph visualization.
+    /// Combines etcd host states with git commit metadata.
+    async fn get_cached_html(&self) -> Result<String> {
+        let host_states = self.etcd.state().await;
+        let commits = self.get_commits().await?;
+        let current_pr_count = self.get_pr_count().await;
+
+        let mut cache = self.html_cache.lock().await;
+
+        // Check if HTML cache is up to date while holding the lock
+        // Cache is valid only if BOTH etcd version and PR count haven't changed
+        let cache_valid =
+            cache.version >= host_states.version && cache.pr_count == current_pr_count;
+
+        if cache_valid {
+            return Ok(cache.html.clone());
+        }
+
+        // Get the actual main tip OID from git
+        let main_tip_oid = self.git_manager.get_main_tip().ok();
+
+        // Cache is stale (either etcd state or PR count changed), regenerate HTML
+        let html = generate_git_graph_html(
+            &self.config,
+            &host_states,
+            &commits.commits,
+            current_pr_count,
+            main_tip_oid,
+        );
+
+        // Update cache while still holding the lock
+        *cache = Arc::new(CachedHtml {
+            version: host_states.version,
+            pr_count: current_pr_count,
+            html: html.clone(),
+        });
+
+        Ok(html)
+    }
+
+    async fn fetch_pr_count(&self) -> Option<u32> {
+        let client = reqwest::Client::new();
+        match client.get(self.config.pulls_api_url()).send().await {
+            Ok(response) => {
+                if let Some(total_count) = response.headers().get("x-total-count")
+                    && let Ok(count_str) = total_count.to_str()
+                    && let Ok(count) = count_str.parse::<u32>()
+                    && count > 0
+                {
+                    return Some(count);
+                }
+                None
+            }
+            Err(_) => None,
+        }
+    }
+}
+
+pub async fn index(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    // Generate the HTML git graph content
+    let git_graph_content = match state.get_cached_html().await {
+        Ok(html) => html,
+        Err(_) => "<p>Error generating git graph</p>".to_string(),
+    };
+
+    let title = &state.config.title;
+
+    let html = format!(
+        r#"
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{title}</title>
+    <style>
+        body {{
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            background-color: #f5f5f5;
+        }}
+        .container {{
+            max-width: 1200px;
+            margin: 0 auto;
+            background-color: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        h1 {{
+            color: #333;
+            text-align: center;
+        }}
+        .status-section {{
+            margin: 20px 0;
+            text-align: center;
+        }}
+        .svg-container {{
+            margin: 20px 0;
+            text-align: center;
+        }}
+        .section-header {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+            border-bottom: 1px solid #e1e4e8;
+            padding-bottom: 12px;
+        }}
+        .section-title {{
+            margin: 0;
+            color: #24292f;
+            font-size: 20px;
+        }}
+        .section-links {{
+            display: flex;
+            gap: 10px;
+        }}
+        .section-links a {{
+            color: #0969da;
+            text-decoration: none;
+            padding: 6px 12px;
+            border: 1px solid #d1d5da;
+            border-radius: 6px;
+            font-size: 14px;
+            background-color: #f6f8fa;
+        }}
+        .section-links a:hover {{
+            background-color: #e1e4e8;
+            border-color: #0969da;
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>{title}</h1>
+
+        <div class="status-section">
+            <div class="git-graph-container">
+                {git_graph_content}
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+    "#
+    );
+
+    Html(html)
+}
+
+async fn generate_html_git_graph(state: Arc<AppState>) -> Result<String, String> {
+    // Generate cached HTML git graph (with PR count cached)
+    state
+        .get_cached_html()
+        .await
+        .map_err(|e| format!("Failed to generate HTML: {e}"))
+}
+
+pub async fn nixos_commits_html(
+    State(state): State<Arc<AppState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // Generate HTML git graph
+    match generate_html_git_graph(state).await {
+        Ok(html_content) => Ok((
+            StatusCode::OK,
+            [("content-type", "text/html; charset=utf-8")],
+            html_content,
+        )),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to generate HTML: {e}"),
+        )),
+    }
+}
+
+fn generate_git_graph_html(
+    config: &Config,
+    host_states: &HostStates,
+    commits: &[CommitInfo],
+    pr_count: Option<u32>,
+    main_tip_oid: Option<git2::Oid>,
+) -> String {
+    let mut html = String::new();
+
+    // Analyze commit structure - all commits treated as main branch (linear timeline)
+    let commit_graph = analyze_commit_structure(commits);
+
+    // Add CSS styles
+    html.push_str(
+        r#"
+<style>
+.git-graph {
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-size: 14px;
+    line-height: 1.5;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #e1e4e8;
+}
+
+.commit-row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+    position: relative;
+}
+
+.commit-line {
+    width: 24px;
+    height: 24px;
+    position: relative;
+    margin-right: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Gitea-style grid system */
+.git-graph-line {
+    position: absolute;
+    width: 2px;
+    height: 100%;
+    top: 0;
+    background: var(--line-color, #d1d5da);
+}
+
+.git-graph-line.main {
+    --line-color: #22c55e;
+    left: 11px;
+}
+
+.git-graph-line.branch {
+    --line-color: #f97316;
+    left: 19px;
+}
+
+.git-graph-line.dashed {
+    background: repeating-linear-gradient(
+        to bottom,
+        var(--line-color) 0,
+        var(--line-color) 3px,
+        transparent 3px,
+        transparent 6px
+    );
+}
+
+/* Gitea-style connections */
+.git-graph-connection {
+    position: absolute;
+    width: 10px;
+    height: 2px;
+    top: 11px;
+    left: 11px;
+    background: var(--line-color, #f97316);
+}
+
+.git-graph-connection.branch-out {
+    --line-color: #f97316;
+}
+
+/* Angled connections like Gitea */
+.git-graph-connection.angled::after {
+    content: '';
+    position: absolute;
+    right: -2px;
+    top: 0;
+    width: 2px;
+    height: 12px;
+    background: var(--line-color, #f97316);
+}
+
+.git-graph-connection.angled-in::before {
+    content: '';
+    position: absolute;
+    right: -2px;
+    top: -10px;
+    width: 2px;
+    height: 12px;
+    background: var(--line-color, #f97316);
+}
+
+.commit-bubble {
+    width: 12px;
+    height: 12px;
+    background: #f6f8fa;
+    border: 2px solid #d1d5da;
+    border-radius: 50%;
+    position: relative;
+    z-index: 2;
+    cursor: help;
+}
+
+.commit-bubble.main-branch {
+    margin-right: 8px; /* Position on main line */
+}
+
+.commit-bubble.branch {
+    margin-left: 8px; /* Position on branch line */
+}
+
+
+.commit-hash.missing {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+}
+
+.commit-info {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    justify-content: space-between;
+}
+
+.commit-left {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+}
+
+.commit-right {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.commit-hash {
+    background: #f6f8fa;
+    border: 1px solid #d1d5da;
+    border-radius: 16px;
+    padding: 4px 12px;
+    margin-right: 12px;
+    text-decoration: none;
+    color: #0969da;
+    font-weight: 500;
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.commit-hash:hover {
+    background: #f3f4f6;
+    border-color: #0969da;
+}
+
+.commit-author {
+    color: #656d76;
+    margin-right: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120px;
+}
+
+.commit-date {
+    color: #656d76;
+    margin-right: 12px;
+    font-size: 12px;
+    white-space: nowrap;
+    cursor: help;
+}
+
+.host-badges {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.host-badge {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.host-badge.current-booted {
+    background: #fed7aa;
+    color: #ea580c;
+    border: 1px solid #fdba74;
+}
+
+.host-badge.current-only {
+    background: #fef3c7;
+    color: #d97706;
+    border: 1px solid #fcd34d;
+}
+
+.host-badge.booted-only {
+    background: #e0f2fe;
+    color: #0284c7;
+    border: 1px solid #7dd3fc;
+}
+
+.host-badge.current-booted-nextboot {
+    background: #f3e8ff;
+    color: #7c3aed;
+    border: 1px solid #c4b5fd;
+}
+
+.host-badge.current-nextboot {
+    background: #dcfce7;
+    color: #16a34a;
+    border: 1px solid #86efac;
+}
+
+.host-badge.booted-nextboot {
+    background: #cffafe;
+    color: #0891b2;
+    border: 1px solid #67e8f9;
+}
+
+.host-badge.nextboot-only {
+    background: #fef2f2;
+    color: #dc2626;
+    border: 1px solid #fecaca;
+}
+
+.host-badge.main-tip {
+    background: transparent;
+    color: #656d76;
+    border: 1px solid #d1d5da;
+    font-weight: 500;
+}
+
+.legend {
+    margin-top: 20px;
+    padding: 12px;
+    background: #f6f8fa;
+    border-radius: 6px;
+    border: 1px solid #d1d5da;
+}
+
+.legend-title {
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: #24292f;
+}
+
+.legend-items {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.legend-badge {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+}
+
+.legend-badge.current-booted {
+    background: #fed7aa;
+    color: #ea580c;
+    border: 1px solid #fdba74;
+}
+
+.legend-badge.current-only {
+    background: #fef3c7;
+    color: #d97706;
+    border: 1px solid #fcd34d;
+}
+
+.legend-badge.booted-only {
+    background: #e0f2fe;
+    color: #0284c7;
+    border: 1px solid #7dd3fc;
+}
+
+.legend-badge.current-booted-nextboot {
+    background: #f3e8ff;
+    color: #7c3aed;
+    border: 1px solid #c4b5fd;
+}
+
+.legend-badge.current-nextboot {
+    background: #dcfce7;
+    color: #16a34a;
+    border: 1px solid #86efac;
+}
+
+.legend-badge.booted-nextboot {
+    background: #cffafe;
+    color: #0891b2;
+    border: 1px solid #67e8f9;
+}
+
+.legend-badge.nextboot-only {
+    background: #fef2f2;
+    color: #dc2626;
+    border: 1px solid #fecaca;
+}
+</style>
+"#,
+    );
+
+    // Start git graph container
+    html.push_str(r#"<div class="git-graph">"#);
+
+    // Add section header inside the git graph
+    let pr_count_text = match pr_count {
+        Some(count) => format!(" ({count})"),
+        None => String::new(),
+    };
+
+    html.push_str(&format!(
+        r#"
+        <div class="section-header">
+            <h2 class="section-title">NixOS Host Status</h2>
+            <div class="section-links">
+                <a href="{}" target="_blank">Repository</a>
+                <a href="{}" target="_blank">Pull Requests{pr_count_text}</a>
+            </div>
+        </div>
+    "#,
+        config.repo_web_url(),
+        config.pulls_web_url()
+    ));
+
+    // Process commits using the analyzed graph structure
+    for (index, node) in commit_graph.nodes.iter().enumerate() {
+        let _next_node = commit_graph.nodes.get(index + 1);
+
+        // Find the original commit info for host badges
+        let commit = commits
+            .iter()
+            .find(|c| {
+                let hash = match c {
+                    CommitInfo::Missing(hash) => hash,
+                    CommitInfo::Complete { hash, .. } => hash,
+                };
+                hash == &node.hash
+            })
+            .unwrap();
+
+        // Collect hosts for this commit
+        let mut host_badges = Vec::new();
+        let hash = match commit {
+            CommitInfo::Missing(hash) => hash,
+            CommitInfo::Complete { hash, .. } => hash,
+        };
+        let Ok(commit_oid) = git2::Oid::from_str(hash) else {
+            tracing::warn!("Skipping commit with invalid OID format: '{hash}'");
+            continue;
+        };
+
+        // Add simple "main" badge for tip of main branch
+        if main_tip_oid.map(|tip| tip == commit_oid).unwrap_or(false) {
+            host_badges.push(r#"<span class="host-badge main-tip">main</span>"#.to_string());
+        }
+
+        for (hostname, states) in &host_states.host_states {
+            use crate::nixos::CommitState;
+
+            let is_current = states[CommitState::Current]
+                .map(|oid| oid == commit_oid)
+                .unwrap_or(false);
+            let is_booted = states[CommitState::Booted]
+                .map(|oid| oid == commit_oid)
+                .unwrap_or(false);
+            let is_nextboot = states[CommitState::NextBoot]
+                .map(|oid| oid == commit_oid)
+                .unwrap_or(false);
+
+            if is_current || is_booted || is_nextboot {
+                let clean_hostname = match &config.hostname_strip_suffix {
+                    Some(suffix) => hostname.replace(suffix.as_str(), ""),
+                    None => hostname.clone(),
+                };
+                let badge_class = match (is_current, is_booted, is_nextboot) {
+                    (true, true, true) => "current-booted-nextboot",
+                    (true, true, false) => "current-booted",
+                    (true, false, true) => "current-nextboot",
+                    (true, false, false) => "current-only",
+                    (false, true, true) => "booted-nextboot",
+                    (false, true, false) => "booted-only",
+                    (false, false, true) => "nextboot-only",
+                    (false, false, false) => unreachable!(),
+                };
+                host_badges.push(format!(
+                    r#"<span class="host-badge {badge_class}">{clean_hostname}</span>"#
+                ));
+            }
+        }
+
+        // Determine line classes
+        let mut line_classes = Vec::new();
+
+        // Check if we need dashed line (skipped commits between main commits)
+        if node.is_main_branch && index < commit_graph.nodes.len() - 1 {
+            let next_main_distance = commit_graph
+                .nodes
+                .iter()
+                .skip(index + 1)
+                .position(|n| n.is_main_branch)
+                .unwrap_or(0);
+            if next_main_distance > 0 {
+                line_classes.push("main-dashed");
+            }
+        }
+
+        // Check if this is the first commit (no line above)
+        if index == 0 {
+            line_classes.push("no-line-above");
+        }
+
+        // Check if this is the last commit or last main commit (no line below)
+        let has_main_commits_below = commit_graph
+            .nodes
+            .iter()
+            .skip(index + 1)
+            .any(|n| n.is_main_branch);
+        if !has_main_commits_below {
+            line_classes.push("no-line-below");
+        }
+
+        // Check if this commit has a branch coming off it
+        let has_branch_child = commit_graph
+            .nodes
+            .iter()
+            .any(|n| !n.is_main_branch && n.parents.contains(&node.hash));
+        if has_branch_child {
+            line_classes.push("has-branch");
+        }
+
+        // Format the commit date
+        let timestamp = match commit {
+            CommitInfo::Missing(_) => Utc::now(),
+            CommitInfo::Complete { timestamp, .. } => *timestamp,
+        };
+        let (relative_date, absolute_date) = format_relative_date(timestamp);
+
+        // Generate commit row with proper Gitea-style lines
+        html.push_str(r#"<div class="commit-row">"#);
+
+        // Add git graph lines and connections
+        html.push_str(r#"<div class="commit-line">"#);
+
+        // Main branch line (always present except for first/last)
+        if index > 0 && has_main_commits_below {
+            html.push_str(r#"<div class="git-graph-line main"></div>"#);
+        }
+
+        // Branch connections for non-main commits
+        if !node.is_main_branch {
+            html.push_str(r#"<div class="git-graph-connection branch-out angled"></div>"#);
+            html.push_str(r#"<div class="git-graph-line branch"></div>"#);
+        }
+
+        // Commit bubble
+        let mut bubble_classes = Vec::new();
+        if node.is_main_branch {
+            bubble_classes.push("main-branch");
+        } else {
+            bubble_classes.push("branch");
+        }
+
+        let message = match commit {
+            CommitInfo::Missing(hash) => {
+                format!("Missing commit ({})", &hash[..12.min(hash.len())])
+            }
+            CommitInfo::Complete { message, .. } => message.clone(),
+        };
+
+        html.push_str(&format!(
+            r#"<div class="commit-bubble {}" title="{}"></div>"#,
+            bubble_classes.join(" "),
+            message.replace("\"", "&quot;")
+        ));
+
+        html.push_str(r#"</div>"#); // Close commit-line
+
+        // Commit info
+        let hash_class = if matches!(commit, CommitInfo::Missing(_)) {
+            "commit-hash missing"
+        } else {
+            "commit-hash"
+        };
+
+        html.push_str(&format!(
+            r#"<div class="commit-info">
+                <div class="commit-left">
+                    <a href="{}" class="{}" target="_blank" title="{}">
+                        {}
+                    </a>
+                    <span class="commit-author">{}</span>
+                    <div class="host-badges">
+                        {}
+                    </div>
+                </div>
+                <div class="commit-right">
+                    <span class="commit-date" title="{}">{}</span>
+                </div>
+            </div>"#,
+            config.commit_web_url(hash),
+            hash_class,
+            message.replace("\"", "&quot;"),
+            commit.short_hash(),
+            match commit {
+                CommitInfo::Missing(_) => "Unknown",
+                CommitInfo::Complete { author, .. } => author,
+            },
+            host_badges.join(""),
+            absolute_date,
+            relative_date
+        ));
+
+        html.push_str(r#"</div>"#); // Close commit-row
+    }
+
+    // Add legend
+    html.push_str(
+        r#"
+        <div class="legend">
+            <div class="legend-items">
+                <div class="legend-item">
+                    <span class="legend-badge current-booted-nextboot">current & booted & nextboot</span>
+                    <span>Host is running this commit, booted from it, and will boot it next</span>
+                </div>
+                <div class="legend-item">
+                    <span class="legend-badge current-booted">current & booted</span>
+                    <span>Host is running this commit and booted from it</span>
+                </div>
+                <div class="legend-item">
+                    <span class="legend-badge current-nextboot">current & nextboot</span>
+                    <span>Host is running this commit and will boot it next</span>
+                </div>
+                <div class="legend-item">
+                    <span class="legend-badge current-only">current only</span>
+                    <span>Host is running this commit but not booted from it</span>
+                </div>
+                <div class="legend-item">
+                    <span class="legend-badge booted-nextboot">booted & nextboot</span>
+                    <span>Host booted from this commit and will boot it next</span>
+                </div>
+                <div class="legend-item">
+                    <span class="legend-badge booted-only">booted only</span>
+                    <span>Host booted from this commit but not currently running it</span>
+                </div>
+                <div class="legend-item">
+                    <span class="legend-badge nextboot-only">nextboot only</span>
+                    <span>Host will boot this commit next</span>
+                </div>
+            </div>
+        </div>
+    "#,
+    );
+
+    // Close git graph container
+    html.push_str("</div>");
+
+    html
+}
+
+#[derive(Debug, Clone)]
+struct CommitNode {
+    hash: String,
+    parents: Vec<String>,
+    is_main_branch: bool,
+}
+
+#[derive(Debug)]
+struct CommitGraph {
+    nodes: Vec<CommitNode>,
+}
+
+/// Analyze commit structure into a linear graph.
+/// TODO: Implement real graph analysis using git parent data for proper branch visualization.
+/// For now, all commits are treated as main-branch (linear timeline).
+fn analyze_commit_structure(commits: &[CommitInfo]) -> CommitGraph {
+    let mut nodes = Vec::new();
+
+    for (index, commit) in commits.iter().enumerate() {
+        // All commits treated as main branch (linear timeline)
+        let is_main_branch = true;
+
+        // Connect to the next commit in chronological order
+        let mut parents = Vec::new();
+        if index < commits.len() - 1 {
+            let next_commit = &commits[index + 1];
+            let hash = match next_commit {
+                CommitInfo::Missing(hash) => hash,
+                CommitInfo::Complete { hash, .. } => hash,
+            };
+            parents.push(hash.clone());
+        }
+
+        let hash = match commit {
+            CommitInfo::Missing(hash) => hash,
+            CommitInfo::Complete { hash, .. } => hash,
+        };
+
+        nodes.push(CommitNode {
+            hash: hash.clone(),
+            parents,
+            is_main_branch,
+        });
+    }
+
+    CommitGraph { nodes }
+}
+
+fn format_relative_date(timestamp: DateTime<Utc>) -> (String, String) {
+    let now = Utc::now();
+    let duration = now.signed_duration_since(timestamp);
+
+    let relative = if duration.num_days() >= 365 {
+        let years = duration.num_days() / 365;
+        if years == 1 {
+            "1 year ago".to_string()
+        } else {
+            format!("{years} years ago")
+        }
+    } else if duration.num_days() >= 30 {
+        let months = duration.num_days() / 30;
+        if months == 1 {
+            "1 month ago".to_string()
+        } else {
+            format!("{months} months ago")
+        }
+    } else if duration.num_days() >= 7 {
+        let weeks = duration.num_days() / 7;
+        if weeks == 1 {
+            "1 week ago".to_string()
+        } else {
+            format!("{weeks} weeks ago")
+        }
+    } else if duration.num_days() >= 1 {
+        let days = duration.num_days();
+        if days == 1 {
+            "1 day ago".to_string()
+        } else {
+            format!("{days} days ago")
+        }
+    } else if duration.num_hours() >= 1 {
+        let hours = duration.num_hours();
+        if hours == 1 {
+            "1 hour ago".to_string()
+        } else {
+            format!("{hours} hours ago")
+        }
+    } else if duration.num_minutes() >= 1 {
+        let minutes = duration.num_minutes();
+        if minutes == 1 {
+            "1 minute ago".to_string()
+        } else {
+            format!("{minutes} minutes ago")
+        }
+    } else {
+        "just now".to_string()
+    };
+
+    let absolute = timestamp.format("%Y-%m-%d %H:%M:%S UTC").to_string();
+
+    (relative, absolute)
+}
+
+#[cfg(test)]
+mod tests {
+
+    // Note: Tests are simplified for the new architecture
+    // Full integration tests would require actual etcd setup
+
+    // Tests for basic functionality would go here
+    // Full integration tests require real etcd and git setup
+}


### PR DESCRIPTION
With the addition of ogygia-hostinfod, distributed version tracking is now a first class ogygia feature. A similar status visualization site has been running at status.jakehillion.me for some time. This brings that concept into the ogygia-nix workspace as ogygia-dashboard, though with significant implementation differences: all hardcoded home-lab values have been removed in favor of required configuration fields, and the crate integrates with the existing ogygia.etcd NixOS module.

The new ogygia-dashboard crate is a Rust web service using axum, etcd-client, and git2 that visualizes NixOS host deployment states. It watches etcd for version data published by ogygia-hostinfod, clones a git repository to resolve commit metadata, and renders an HTML status page with host badges and a commit timeline. A NixOS module at nixos/dashboard generates TOML configuration from module options and runs the service with DynamicUser and security hardening. The dashboard is NOT auto-enabled since there is no productive way to expose web endpoints yet.

New workspace dependencies (chrono, git2, tempfile, enum-map) and build inputs (openssl, pkg-config) are added for libgit2 support. The flake exports the package, includes it in checks, and passes it as a module argument.

Test plan:
- CI