### PR TITLE
hostinfod: use FQDN for etcd key paths from NixOS configuration

### DIFF
--- a/nixos/hostinfod/default.nix
+++ b/nixos/hostinfod/default.nix
@@ -55,6 +55,7 @@ in
 
       environment = {
         RUST_LOG = lib.mkDefault "info";
+        OGYGIA_HOSTNAME = config.networking.fqdn;
       };
     };
   };

--- a/nixos/tests/hostinfod-inotify.nix
+++ b/nixos/tests/hostinfod-inotify.nix
@@ -30,8 +30,9 @@ pkgs.testers.nixosTest {
       etcd.endpoints = [ "http://localhost:2379" ];
     };
 
-    # Set a custom hostname for predictable testing
+    # Set hostname and domain for predictable FQDN testing
     networking.hostName = "test-host";
+    networking.domain = "test.local";
   };
 
   testScript = ''
@@ -49,8 +50,8 @@ pkgs.testers.nixosTest {
     # Wait a moment for initial etcd write
     time.sleep(3)
     
-    # Check that initial values are in etcd
-    hostname = "test-host"
+    # Check that initial values are in etcd (using FQDN)
+    hostname = "test-host.test.local"
     
     # Test current system - should have a value (even if "unknown")
     result = machine.succeed("etcdctl get /ogygia/nixos/versions/{}/current --print-value-only".format(hostname))


### PR DESCRIPTION
The hostinfod daemon was using short hostnames for etcd key paths when
the hostname -f command returned unexpected results or failed. This
caused inconsistent naming where machines were identified by their
short hostname instead of their fully qualified domain name.

This commit sets the OGYGIA_HOSTNAME environment variable in the
systemd service configuration using the FQDN constructed from
networking.hostName and ogygia.domain. The Rust code already checks
this environment variable first in detect_hostname(), so no Rust
changes were needed.

This ensures consistent, predictable etcd key paths that properly
identify hosts by their full domain names.

Test plan:
- nix flake check --no-build passes
- Updated test expects FQDN (test-host.test.local) in etcd paths
- Existing Rust hostname detection fallback chain preserved