### PR TITLE
ogygia-irisd: add x-ogygia-nar-file-hash header to local/nar endpoint

### DIFF
--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -257,6 +257,7 @@ async fn try_local_store_nar(
         [
             ("content-type", "application/zstd"),
             ("content-length", content_length.as_str()),
+            ("x-ogygia-nar-file-hash", cached.file_hash.as_str()),
         ],
         body,
     )


### PR DESCRIPTION
The local/nar endpoint did not expose the file hash of the compressed NAR being served, making it difficult for clients to verify integrity of the downloaded file without recomputing the hash themselves.

This commit adds the x-ogygia-nar-file-hash header to the response in try_local_store_nar, using the existing cached.file_hash field which contains the SHA-256 hash of the compressed NAR in SRI format (sha256-BASE64==).

This allows clients to verify the integrity of the compressed NAR file by comparing against the known hash without needing to recompute it.

Test plan:
- CI