### PR TITLE
ogygia-irisd: add range request support and retry logic for NAR proxy

### DIFF
--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -7,11 +7,13 @@ use axum::Json;
 use axum::body::Body;
 use axum::extract::Path;
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::io::AsyncReadExt;
 use tokio_util::io::ReaderStream;
 
 use super::AppState;
@@ -170,7 +172,7 @@ pub async fn get_nar(State(state): State<Arc<AppState>>, Path(path): Path<String
         return (StatusCode::NOT_FOUND, "Not found").into_response();
     };
 
-    let local = try_local_store_nar(hash, nar_hash, &state.nar_cache).await;
+    let local = try_local_store_nar(hash, nar_hash, &state.nar_cache, None).await;
     if local.status() != StatusCode::NOT_FOUND {
         return local;
     }
@@ -182,9 +184,11 @@ pub async fn get_nar(State(state): State<Arc<AppState>>, Path(path): Path<String
 /// GET /local/nar/{path} — local-only NAR download (no peer fan-out)
 ///
 /// Used by peers to fetch NARs from this node's local store without
-/// triggering cascading fan-out across the cluster.
+/// triggering cascading fan-out across the cluster. Supports `Range`
+/// requests for resumable downloads.
 pub async fn get_local_nar(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path(path): Path<String>,
 ) -> Response {
     let Some((nar_hash, hash)) = parse_nar_path(&path) else {
@@ -192,7 +196,8 @@ pub async fn get_local_nar(
         return (StatusCode::NOT_FOUND, "Not found").into_response();
     };
 
-    try_local_store_nar(hash, nar_hash, &state.nar_cache).await
+    let range = parse_byte_range(&headers);
+    try_local_store_nar(hash, nar_hash, &state.nar_cache, range).await
 }
 
 /// Parse a NAR path into `(nar_hash, store_hash)`.
@@ -204,11 +209,41 @@ fn parse_nar_path(path: &str) -> Option<(&str, &str)> {
     (hash.len() == 32).then_some((nar_hash, hash))
 }
 
+/// Parse a `Range` header into `(start, Option<end>)`.
+///
+/// Supports `bytes=start-` (open-ended) and `bytes=start-end` (closed).
+/// Multi-range (comma-separated) and suffix ranges (`bytes=-N`) return `None`.
+fn parse_byte_range(headers: &HeaderMap) -> Option<(u64, Option<u64>)> {
+    let value = headers.get("range")?.to_str().ok()?;
+    let suffix = value.strip_prefix("bytes=")?;
+    // Reject multi-range
+    if suffix.contains(',') {
+        return None;
+    }
+    let (start_str, end_str) = suffix.split_once('-')?;
+    // Reject suffix ranges (empty start)
+    if start_str.is_empty() {
+        return None;
+    }
+    let start = start_str.parse::<u64>().ok()?;
+    let end = if end_str.is_empty() {
+        None
+    } else {
+        Some(end_str.parse::<u64>().ok()?)
+    };
+    Some((start, end))
+}
+
 /// Try to serve a NAR from the local store via the disk cache.
+///
+/// When `range` is `Some`, returns a `206 Partial Content` response for
+/// the requested byte range. Supports open-ended `(start, None)` and
+/// closed `(start, Some(end))` ranges.
 async fn try_local_store_nar(
     hash: &str,
     expected_nar_hash: &str,
     nar_cache: &NarCache,
+    range: Option<(u64, Option<u64>)>,
 ) -> Response {
     let Some(store_path) = find_store_path(hash).await else {
         return (StatusCode::NOT_FOUND, "Not found").into_response();
@@ -237,7 +272,7 @@ async fn try_local_store_nar(
     }
 
     // Get from cache or generate, opening the file under the RwLock
-    let (cached, file) = match nar_cache.ensure_and_open(hash, &store_path).await {
+    let (cached, mut file) = match nar_cache.ensure_and_open(hash, &store_path).await {
         Ok((cached, Some(file))) => (cached, file),
         Ok((_, None)) => {
             tracing::debug!("Cached NAR for {} evicted during open", hash);
@@ -249,19 +284,68 @@ async fn try_local_store_nar(
         }
     };
 
-    tracing::info!("Serving cached NAR for {}", store_path.display());
-    let body = Body::from_stream(ReaderStream::new(file));
-    let content_length = cached.file_size.to_string();
-    (
-        StatusCode::OK,
-        [
-            ("content-type", "application/zstd"),
-            ("content-length", content_length.as_str()),
-            ("x-ogygia-nar-file-hash", cached.file_hash.as_str()),
-        ],
-        body,
-    )
-        .into_response()
+    let file_size = cached.file_size;
+
+    match range {
+        Some((start, end)) => {
+            // Clamp end to file boundary
+            let end = end.map(|e| e.min(file_size - 1)).unwrap_or(file_size - 1);
+
+            if start >= file_size || (end < start) {
+                let content_range = format!("bytes */{}", file_size);
+                return (
+                    StatusCode::RANGE_NOT_SATISFIABLE,
+                    [("content-range", content_range.as_str())],
+                )
+                    .into_response();
+            }
+
+            if start > 0 {
+                use tokio::io::AsyncSeekExt;
+                if let Err(e) = file.seek(std::io::SeekFrom::Start(start)).await {
+                    tracing::error!("Failed to seek to {} for {}: {}", start, hash, e);
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "Seek failed").into_response();
+                }
+            }
+
+            let length = end - start + 1;
+            let body = Body::from_stream(ReaderStream::new(file.take(length)));
+            let content_length = length.to_string();
+            let content_range = format!("bytes {}-{}/{}", start, end, file_size);
+            tracing::info!(
+                "Serving cached NAR for {} (range {}-{})",
+                store_path.display(),
+                start,
+                end,
+            );
+            (
+                StatusCode::PARTIAL_CONTENT,
+                [
+                    ("content-type", "application/zstd"),
+                    ("content-length", content_length.as_str()),
+                    ("content-range", content_range.as_str()),
+                    ("x-ogygia-nar-file-hash", cached.file_hash.as_str()),
+                ],
+                body,
+            )
+                .into_response()
+        }
+        None => {
+            tracing::info!("Serving cached NAR for {}", store_path.display());
+            let body = Body::from_stream(ReaderStream::new(file));
+            let content_length = file_size.to_string();
+            (
+                StatusCode::OK,
+                [
+                    ("content-type", "application/zstd"),
+                    ("content-length", content_length.as_str()),
+                    ("x-ogygia-nar-file-hash", cached.file_hash.as_str()),
+                ],
+                body,
+            )
+                .into_response()
+        }
+    }
 }
 
 /// Query parameters for GET /providers/{hash}
@@ -408,4 +492,69 @@ pub async fn rescan(
     );
 
     (StatusCode::OK, Json(RescanResponse { rescanned, errors })).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers_with_range(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("range", value.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn test_parse_byte_range_open_ended() {
+        assert_eq!(
+            parse_byte_range(&headers_with_range("bytes=0-")),
+            Some((0, None))
+        );
+        assert_eq!(
+            parse_byte_range(&headers_with_range("bytes=100-")),
+            Some((100, None))
+        );
+        assert_eq!(
+            parse_byte_range(&headers_with_range("bytes=999999-")),
+            Some((999999, None)),
+        );
+    }
+
+    #[test]
+    fn test_parse_byte_range_closed() {
+        assert_eq!(
+            parse_byte_range(&headers_with_range("bytes=0-499")),
+            Some((0, Some(499))),
+        );
+        assert_eq!(
+            parse_byte_range(&headers_with_range("bytes=100-200")),
+            Some((100, Some(200))),
+        );
+    }
+
+    #[test]
+    fn test_parse_byte_range_missing() {
+        assert_eq!(parse_byte_range(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn test_parse_byte_range_suffix_range() {
+        // bytes=-500 (suffix range) is not supported
+        assert_eq!(parse_byte_range(&headers_with_range("bytes=-500")), None);
+    }
+
+    #[test]
+    fn test_parse_byte_range_multi_range() {
+        assert_eq!(
+            parse_byte_range(&headers_with_range("bytes=0-100,200-300")),
+            None,
+        );
+    }
+
+    #[test]
+    fn test_parse_byte_range_invalid() {
+        assert_eq!(parse_byte_range(&headers_with_range("invalid")), None);
+        assert_eq!(parse_byte_range(&headers_with_range("bytes=abc-")), None);
+        assert_eq!(parse_byte_range(&headers_with_range("bytes=0-abc")), None);
+    }
 }

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -1,13 +1,14 @@
 //! Shared application state and peer lookup logic.
 
+use std::pin::Pin;
 use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
+use bytes::Bytes;
 use futures::StreamExt;
-use futures::TryStreamExt;
 use futures::stream::FuturesUnordered;
 
 use crate::bloom::local::LocalBloom;
@@ -202,6 +203,11 @@ async fn fetch_narinfo_from_peer(
 }
 
 /// Fetch a NAR from a URL and return it as a streaming response.
+///
+/// On stream failure, retries the same URL using `Range` requests as long
+/// as each attempt makes progress (receives at least 1 byte). The
+/// `x-ogygia-nar-file-hash` header is validated on retries to ensure the
+/// peer is still serving the same file.
 async fn stream_nar_from_url(client: &reqwest::Client, url: &str) -> Option<Response> {
     let response = client.get(url).send().await.ok()?;
     if !response.status().is_success() {
@@ -215,18 +221,273 @@ async fn stream_nar_from_url(client: &reqwest::Client, url: &str) -> Option<Resp
         .unwrap_or("application/x-nix-nar")
         .to_string();
 
-    let body = Body::from_stream(
-        response
-            .bytes_stream()
-            .map_err(|e| std::io::Error::other(e.to_string())),
-    );
+    let expected_file_hash: String = response
+        .headers()
+        .get("x-ogygia-nar-file-hash")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)?;
 
-    Some(
-        (
-            StatusCode::OK,
-            [("content-type", content_type.as_str())],
-            body,
-        )
-            .into_response(),
-    )
+    let expected_total_size: u64 = response
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse().ok())?;
+
+    let body = Body::from_stream(stream_with_retry(
+        client.clone(),
+        url.to_string(),
+        expected_file_hash,
+        expected_total_size,
+        response,
+    ));
+
+    let builder = axum::http::Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", &content_type)
+        .header("content-length", expected_total_size);
+
+    Some(builder.body(body).unwrap().into_response())
+}
+
+type ByteStream = Pin<Box<dyn futures::Stream<Item = Result<Bytes, reqwest::Error>> + Send>>;
+
+/// State for the retrying NAR stream.
+struct RetryStreamState {
+    client: reqwest::Client,
+    url: String,
+    expected_file_hash: String,
+    expected_total_size: u64,
+    bytes_received: u64,
+    bytes_at_last_retry: u64,
+    stream: ByteStream,
+}
+
+/// Create a stream that transparently retries a NAR download using Range
+/// requests on failure.
+///
+/// Each call to the underlying stream either yields the next chunk or, on
+/// error, attempts a Range request to resume. Gives up if no progress was
+/// made since the last retry (zero bytes received).
+fn stream_with_retry(
+    client: reqwest::Client,
+    url: String,
+    expected_file_hash: String,
+    expected_total_size: u64,
+    initial_response: reqwest::Response,
+) -> impl futures::Stream<Item = Result<Bytes, std::io::Error>> {
+    let state = RetryStreamState {
+        client,
+        url,
+        expected_file_hash,
+        expected_total_size,
+        bytes_received: 0,
+        bytes_at_last_retry: 0,
+        stream: Box::pin(initial_response.bytes_stream()),
+    };
+
+    futures::stream::try_unfold(state, |mut state| async move {
+        loop {
+            match state.stream.next().await {
+                Some(Ok(chunk)) => {
+                    state.bytes_received += chunk.len() as u64;
+                    return Ok(Some((chunk, state)));
+                }
+                Some(Err(e)) => {
+                    tracing::warn!(
+                        "NAR stream from {} failed at byte {}: {}",
+                        state.url,
+                        state.bytes_received,
+                        e,
+                    );
+                }
+                None => {
+                    // Stream ended — check if this was a complete transfer
+                    if state.bytes_received >= state.expected_total_size {
+                        return Ok(None);
+                    }
+                    tracing::warn!(
+                        "NAR stream from {} ended prematurely at byte {}/{}",
+                        state.url,
+                        state.bytes_received,
+                        state.expected_total_size,
+                    );
+                }
+            }
+
+            // Check progress since last retry — give up if none
+            if state.bytes_received == state.bytes_at_last_retry {
+                return Err(std::io::Error::other(format!(
+                    "NAR stream from {} stalled at byte {} with no progress",
+                    state.url, state.bytes_received,
+                )));
+            }
+
+            tracing::info!(
+                "Retrying NAR stream from {} at byte {} (was {})",
+                state.url,
+                state.bytes_received,
+                state.bytes_at_last_retry,
+            );
+            state.bytes_at_last_retry = state.bytes_received;
+
+            // Brief backoff before retrying — the failure is external and
+            // hammering immediately is unlikely to help.
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // Attempt a Range request to resume
+            let retry_response = match state
+                .client
+                .get(&state.url)
+                .header("range", format!("bytes={}-", state.bytes_received))
+                .send()
+                .await
+            {
+                Ok(r) if r.status() == reqwest::StatusCode::PARTIAL_CONTENT => r,
+                Ok(r) => {
+                    return Err(std::io::Error::other(format!(
+                        "Range retry for {} returned {}",
+                        state.url,
+                        r.status(),
+                    )));
+                }
+                Err(e) => {
+                    return Err(std::io::Error::other(format!(
+                        "Range retry for {} failed: {}",
+                        state.url, e,
+                    )));
+                }
+            };
+
+            // Validate the peer is still serving the same file
+            let retry_hash = retry_response
+                .headers()
+                .get("x-ogygia-nar-file-hash")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            if retry_hash != state.expected_file_hash {
+                return Err(std::io::Error::other(format!(
+                    "file hash changed on retry for {}: expected {}, got {}",
+                    state.url, state.expected_file_hash, retry_hash,
+                )));
+            }
+
+            state.stream = Box::pin(retry_response.bytes_stream());
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::Ordering;
+
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    const FILE_HASH: &str = "sha256-test-hash";
+    const PAYLOAD_SIZE: usize = 1024;
+
+    /// Build the test payload — a deterministic 1024-byte sequence.
+    fn test_payload() -> Vec<u8> {
+        (0..PAYLOAD_SIZE).map(|i| (i % 256) as u8).collect()
+    }
+
+    /// Read from a socket until we see `\r\n\r\n` (end of HTTP headers).
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut buf = vec![0u8; 4096];
+        let mut filled = 0;
+        loop {
+            let n = socket.read(&mut buf[filled..]).await.unwrap();
+            assert!(n > 0, "client closed before sending full headers");
+            filled += n;
+            let s = std::str::from_utf8(&buf[..filled]).unwrap_or("");
+            if s.contains("\r\n\r\n") {
+                return s.to_string();
+            }
+        }
+    }
+
+    /// Raw TCP mock server that simulates a mid-transfer failure and
+    /// successful Range retry.
+    ///
+    /// - Request 1: sends 200 OK with Content-Length: 1024, streams 512 bytes,
+    ///   then closes the connection (simulating a network failure).
+    /// - Request 2: sends 206 Partial Content with the remaining 512 bytes.
+    async fn run_mock_server(listener: tokio::net::TcpListener, counter: Arc<AtomicU32>) {
+        let payload = test_payload();
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let n = counter.fetch_add(1, Ordering::SeqCst);
+            let payload = payload.clone();
+            tokio::spawn(async move {
+                read_http_request(&mut socket).await;
+
+                match n {
+                    0 => {
+                        // Send valid headers claiming 1024 bytes, then only
+                        // send 512 and close — exactly like a network failure.
+                        let headers = format!(
+                            "HTTP/1.1 200 OK\r\n\
+                             Content-Type: application/zstd\r\n\
+                             Content-Length: {PAYLOAD_SIZE}\r\n\
+                             X-Ogygia-NAR-File-Hash: {FILE_HASH}\r\n\
+                             \r\n"
+                        );
+                        let _ = socket.write_all(headers.as_bytes()).await;
+                        let _ = socket.write_all(&payload[..512]).await;
+                        let _ = socket.flush().await;
+                        let _ = socket.shutdown().await;
+                    }
+                    _ => {
+                        let remaining = &payload[512..];
+                        let headers = format!(
+                            "HTTP/1.1 206 Partial Content\r\n\
+                             Content-Type: application/zstd\r\n\
+                             Content-Length: {}\r\n\
+                             Content-Range: bytes 512-{}/{PAYLOAD_SIZE}\r\n\
+                             X-Ogygia-NAR-File-Hash: {FILE_HASH}\r\n\
+                             \r\n",
+                            remaining.len(),
+                            PAYLOAD_SIZE - 1,
+                        );
+                        let _ = socket.write_all(headers.as_bytes()).await;
+                        let _ = socket.write_all(remaining).await;
+                    }
+                }
+            });
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_stream_with_retry_resumes_after_failure() {
+        let counter = Arc::new(AtomicU32::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_counter = counter.clone();
+        tokio::spawn(async move {
+            run_mock_server(listener, server_counter).await;
+        });
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let url = format!("http://{}/nar/test", addr);
+
+        let response = stream_nar_from_url(&client, &url).await;
+        assert!(response.is_some(), "stream_nar_from_url should succeed");
+
+        let response = response.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), PAYLOAD_SIZE * 2)
+            .await
+            .expect("should collect full body");
+
+        assert_eq!(body.len(), PAYLOAD_SIZE);
+        assert_eq!(body.as_ref(), test_payload().as_slice());
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
 }


### PR DESCRIPTION
The distributed cache proxy would give up on a peer after a single stream failure, moving to the next peer even when the original peer was still available. Since the disk-backed NAR cache now serves stable content, interrupted transfers can be safely resumed.

Added HTTP Range request support to the /local/nar/ endpoint with open-ended and closed byte ranges, returning 206 Partial Content with Content-Range headers. The NAR cache open path now supports seeking to an arbitrary offset. The stream_nar_from_url proxy was rewritten to retry the same host using Range requests on stream failure, validating the x-ogygia-nar-file-hash header matches on each retry to ensure content consistency. Retries continue as long as each attempt makes progress (at least 1 byte received); zero-progress attempts are treated as permanent failures.

This allows the proxy to transparently recover from transient network failures without falling back to a different peer, while the file hash validation prevents resuming into stale or changed content.

Test plan:
- CI