### PR TITLE
iris: add remote store push support with bloom-lookup pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "anyhow",
  "clap",
  "etcd-client",
+ "futures",
  "hostname",
  "reqwest",
  "serde",

--- a/src/ogygia-irisd/src/nix/cache.rs
+++ b/src/ogygia-irisd/src/nix/cache.rs
@@ -10,6 +10,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -72,6 +74,8 @@ pub struct NarCache {
     cache: Cache<String, Arc<CachedNar>>,
     dir: PathBuf,
 }
+
+static TMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 impl NarCache {
     /// Create a new NAR cache from configuration.
@@ -161,6 +165,108 @@ impl NarCache {
         let file = cached.open().await.map_err(Arc::new)?;
 
         Ok((cached, file))
+    }
+
+    /// Cache NAR data fetched from a peer.
+    ///
+    /// Writes already-compressed bytes to disk and inserts the metadata into
+    /// the moka cache. Validates that the SHA-256 of the data matches the
+    /// expected `nar_hash` parameter — mismatched data is rejected.
+    ///
+    /// If the moka cache already has an entry, it is returned directly
+    /// (idempotent). If the file already exists on disk but is not in
+    /// the cache, it is hashed and inserted.
+    pub async fn cache_fetched_nar(
+        &self,
+        store_hash: &str,
+        store_name: &str,
+        nar_hash: &str,
+        data: &[u8],
+    ) -> Result<Arc<CachedNar>, Arc<anyhow::Error>> {
+        if let Some(cached) = self.cache.get(store_hash).await {
+            return Ok(cached);
+        }
+
+        let final_path = self.dir.join(format!("{store_name}.nar.zst"));
+        let tmp_path = self.dir.join(format!(
+            "{store_name}.nar.zst.tmp.{}",
+            TMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+
+        if let Ok(meta) = tokio::fs::metadata(&final_path).await {
+            let file_size = meta.len();
+            let file_hash = hash_file(&final_path).await?;
+            let cached = Arc::new(CachedNar {
+                path: tokio::sync::RwLock::new(Some(final_path)),
+                file_hash,
+                file_size,
+            });
+            self.cache
+                .insert(store_hash.to_string(), cached.clone())
+                .await;
+            return Ok(cached);
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let digest = hasher.finalize();
+        let computed_hash = format!("sha256-{}", STANDARD.encode(digest));
+
+        if computed_hash != nar_hash {
+            return Err(Arc::new(anyhow::anyhow!(
+                "NAR hash mismatch for {}: expected {}, computed {}",
+                store_name,
+                nar_hash,
+                computed_hash,
+            )));
+        }
+
+        let mut file = tokio::fs::File::create(&tmp_path)
+            .await
+            .with_context(|| format!("Failed to create temp NAR file: {}", tmp_path.display()))?;
+        file.write_all(data)
+            .await
+            .with_context(|| format!("Failed to write NAR data: {}", tmp_path.display()))?;
+        file.flush()
+            .await
+            .with_context(|| format!("Failed to flush NAR data: {}", tmp_path.display()))?;
+        drop(file);
+
+        tokio::fs::rename(&tmp_path, &final_path)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to rename {} -> {}",
+                    tmp_path.display(),
+                    final_path.display()
+                )
+            })?;
+
+        // After writing, check the cache again — a concurrent caller may have
+        // already inserted an entry for this key. If so, return it to avoid
+        // evicting the existing entry (which would trigger file deletion).
+        if let Some(cached) = self.cache.get(store_hash).await {
+            return Ok(cached);
+        }
+
+        let file_size = data.len() as u64;
+        let cached = Arc::new(CachedNar {
+            path: tokio::sync::RwLock::new(Some(final_path)),
+            file_hash: computed_hash,
+            file_size,
+        });
+
+        self.cache
+            .insert(store_hash.to_string(), cached.clone())
+            .await;
+
+        tracing::info!(
+            "Cached fetched NAR {} ({} bytes compressed)",
+            store_name,
+            file_size,
+        );
+
+        Ok(cached)
     }
 
     /// Scan the cache directory and re-populate the moka cache from existing files.
@@ -350,4 +456,166 @@ async fn hash_file(path: &Path) -> Result<String> {
     }
     let digest = hasher.finalize();
     Ok(format!("sha256-{}", STANDARD.encode(digest)))
+}
+
+/// Compute the SRI-format SHA-256 hash of arbitrary bytes.
+#[cfg(test)]
+fn hash_bytes(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    format!("sha256-{}", STANDARD.encode(digest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cache_config(dir: &Path) -> CacheConfig {
+        CacheConfig {
+            dir: dir.to_path_buf(),
+            time_to_idle_secs: 0,
+            max_size_bytes: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cache_fetched_nar_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = make_cache_config(tmp.path());
+        let cache = NarCache::new(&config).await.unwrap();
+
+        let data = b"hello world nar data";
+        let nar_hash = hash_bytes(data);
+        let cached = cache
+            .cache_fetched_nar("abc123", "abc123-mypackage", &nar_hash, data)
+            .await
+            .unwrap();
+
+        assert_eq!(cached.file_size, data.len() as u64);
+        assert_eq!(cached.file_hash, nar_hash);
+
+        let path_guard = cached.path.read().await;
+        let path = path_guard.as_ref().unwrap();
+        assert!(path.exists());
+
+        let on_disk = tokio::fs::read(path).await.unwrap();
+        assert_eq!(on_disk, data);
+
+        let final_path = tmp.path().join("abc123-mypackage.nar.zst");
+        assert!(final_path.exists());
+        let entries = std::fs::read_dir(tmp.path()).unwrap();
+        assert!(
+            entries
+                .filter_map(|e| e.ok())
+                .all(|e| { !e.file_name().to_string_lossy().contains(".tmp") }),
+            "temp files should be cleaned up after rename"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_fetched_nar_hash_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = make_cache_config(tmp.path());
+        let cache = NarCache::new(&config).await.unwrap();
+
+        let data = b"some nar content";
+        let wrong_hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let result = cache
+            .cache_fetched_nar("def456", "def456-myackage", wrong_hash, data)
+            .await;
+        match result {
+            Err(e) => {
+                let err_msg = e.to_string();
+                assert!(
+                    err_msg.contains("hash mismatch"),
+                    "expected hash mismatch error, got: {err_msg}",
+                );
+            }
+            Ok(_) => panic!("expected hash mismatch error"),
+        }
+
+        let final_path = tmp.path().join("def456-myackage.nar.zst");
+        assert!(
+            !final_path.exists(),
+            "file should not be written on hash mismatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_fetched_nar_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = make_cache_config(tmp.path());
+        let cache = NarCache::new(&config).await.unwrap();
+
+        let data = b"nar content for idempotent test";
+        let nar_hash = hash_bytes(data);
+
+        let cached1 = cache
+            .cache_fetched_nar("ghi789", "ghi789-pkg", &nar_hash, data)
+            .await
+            .unwrap();
+
+        let cached2 = cache
+            .cache_fetched_nar("ghi789", "ghi789-pkg", &nar_hash, data)
+            .await
+            .unwrap();
+
+        assert_eq!(cached1.file_size, cached2.file_size);
+        assert_eq!(cached1.file_hash, cached2.file_hash);
+
+        let final_path = tmp.path().join("ghi789-pkg.nar.zst");
+        assert!(final_path.exists());
+    }
+
+    #[tokio::test]
+    async fn test_cache_fetched_nar_preexisting_file() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let store_name = "jkl012-preexist-pkg";
+        let final_path = tmp.path().join(format!("{store_name}.nar.zst"));
+
+        let existing_data = b"existing file on disk";
+        let existing_hash = hash_bytes(existing_data);
+
+        tokio::fs::write(&final_path, existing_data).await.unwrap();
+
+        let config = make_cache_config(tmp.path());
+        let cache = NarCache::new(&config).await.unwrap();
+
+        let new_data = b"different data that should be ignored";
+        let new_hash = hash_bytes(new_data);
+
+        let cached = cache
+            .cache_fetched_nar("jkl012", store_name, &new_hash, new_data)
+            .await
+            .unwrap();
+
+        assert_eq!(cached.file_hash, existing_hash);
+        assert_eq!(cached.file_size, existing_data.len() as u64);
+
+        let on_disk = tokio::fs::read(&final_path).await.unwrap();
+        assert_eq!(on_disk, existing_data);
+    }
+
+    #[tokio::test]
+    async fn test_cache_fetched_nar_concurrent_same_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = make_cache_config(tmp.path());
+        let cache = NarCache::new(&config).await.unwrap();
+
+        let data = b"concurrent nar data";
+        let nar_hash = hash_bytes(data);
+
+        let h1 = cache.cache_fetched_nar("mno345", "mno345-concurrent", &nar_hash, data);
+        let h2 = cache.cache_fetched_nar("mno345", "mno345-concurrent", &nar_hash, data);
+
+        let (r1, r2) = tokio::join!(h1, h2);
+        let cached1 = r1.unwrap();
+        let cached2 = r2.unwrap();
+
+        assert_eq!(cached1.file_hash, cached2.file_hash);
+        assert_eq!(cached1.file_size, cached2.file_size);
+
+        let final_path = tmp.path().join("mno345-concurrent.nar.zst");
+        assert!(final_path.exists());
+    }
 }

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use axum::Json;
 use axum::body::Body;
 use axum::extract::Path;
@@ -435,6 +436,30 @@ pub struct RescanResponse {
     pub errors: usize,
 }
 
+/// Request body for POST /pull
+#[derive(Debug, Deserialize)]
+pub struct PullRequest {
+    pub paths: Vec<PathBuf>,
+}
+
+/// Response body for POST /pull
+#[derive(Debug, Serialize)]
+pub struct PullResponse {
+    pub pulled: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    pub details: Vec<PathResult>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PathResult {
+    pub path: PathBuf,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// POST /rescan - rescan store paths and insert hashes into bloom
 ///
 /// This endpoint is called by `ogygia iris push` after signing paths.
@@ -501,6 +526,174 @@ pub async fn rescan(
     );
 
     (StatusCode::OK, Json(RescanResponse { rescanned, errors })).into_response()
+}
+
+/// POST /pull - pull store paths from peers
+///
+/// For each path in the request:
+/// 1. Validates the path starts with `/nix/store/` and extracts the 32-char hash
+/// 2. Checks if the path already exists locally (skipped if serveable)
+/// 3. For missing paths, fetches narinfo from peers with trusted-signature validation
+/// 4. Fetches the NAR from the peer and validates its hash against the narinfo
+/// 5. Caches the NAR to disk and moka cache
+/// 6. Inserts the hash into the local bloom filter (preventing false positives on failure)
+pub async fn pull(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<PullRequest>,
+) -> Response {
+    let mut pulled = 0;
+    let mut skipped = 0;
+    let mut failed = 0;
+    let mut details = Vec::new();
+    let mut errors = Vec::new();
+
+    for path in &request.paths {
+        let hash = match extract_hash_from_path(path) {
+            Ok(h) => h,
+            Err(reason) => {
+                tracing::warn!("pull: {}: {}", reason, path.to_string_lossy());
+                failed += 1;
+                details.push(PathResult {
+                    path: path.clone(),
+                    status: "failed".to_string(),
+                    error: Some(reason.to_string()),
+                });
+                continue;
+            }
+        };
+
+        if let Some(store_path) = find_store_path(&hash).await
+            && let Ok(info) = PathInfo::from_store_path(&store_path).await
+            && info.is_serveable()
+        {
+            tracing::info!(
+                "pull: path already available locally: {}",
+                path.to_string_lossy()
+            );
+            state.local_bloom.insert(&hash);
+            skipped += 1;
+            details.push(PathResult {
+                path: path.clone(),
+                status: "skipped".to_string(),
+                error: None,
+            });
+            continue;
+        }
+
+        match state.try_peer_narinfo_all(&hash).await {
+            Some((narinfo, peer_url)) => {
+                let nar_url = format!("{}/local/{}", peer_url.trim_end_matches('/'), narinfo.url);
+
+                let store_name = PathBuf::from(&narinfo.store_path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&hash)
+                    .to_string();
+
+                let fetch_result: Result<Arc<crate::nix::cache::CachedNar>, Arc<anyhow::Error>> =
+                    match state.http_client.get(&nar_url).send().await {
+                        Ok(response) if response.status().is_success() => {
+                            match response.bytes().await {
+                                Ok(fetched_bytes) => {
+                                    state
+                                        .nar_cache
+                                        .cache_fetched_nar(
+                                            &hash,
+                                            &store_name,
+                                            &narinfo.file_hash,
+                                            &fetched_bytes,
+                                        )
+                                        .await
+                                }
+                                Err(e) => Err(Arc::new(anyhow!(
+                                    "failed to read NAR body for {}: {}",
+                                    hash,
+                                    e
+                                ))),
+                            }
+                        }
+                        Ok(response) => Err(Arc::new(anyhow!(
+                            "peer returned {} for NAR {}",
+                            response.status(),
+                            hash
+                        ))),
+                        Err(e) => Err(Arc::new(anyhow!("failed to fetch NAR for {}: {}", hash, e))),
+                    };
+
+                match fetch_result {
+                    Ok(_) => {
+                        tracing::info!("pull: fetched and cached NAR for {}", hash);
+                        state.local_bloom.insert(&hash);
+                        pulled += 1;
+                        details.push(PathResult {
+                            path: path.clone(),
+                            status: "pulled".to_string(),
+                            error: None,
+                        });
+                    }
+                    Err(e) => {
+                        let err = format!("NAR fetch/cache failed for {}: {}", hash, e);
+                        tracing::warn!("pull: {}", err);
+                        failed += 1;
+                        errors.push(err.clone());
+                        details.push(PathResult {
+                            path: path.clone(),
+                            status: "failed".to_string(),
+                            error: Some(err),
+                        });
+                    }
+                }
+            }
+            None => {
+                let err = format!("no peer has a trusted narinfo for {}", hash);
+                tracing::warn!("pull: {}", err);
+                failed += 1;
+                errors.push(err.clone());
+                details.push(PathResult {
+                    path: path.clone(),
+                    status: "failed".to_string(),
+                    error: Some(err),
+                });
+            }
+        }
+    }
+
+    tracing::info!(
+        "pull complete: {} pulled, {} skipped, {} failed",
+        pulled,
+        skipped,
+        failed
+    );
+
+    (
+        StatusCode::OK,
+        Json(PullResponse {
+            pulled,
+            skipped,
+            failed,
+            details,
+            errors,
+        }),
+    )
+        .into_response()
+}
+
+fn extract_hash_from_path(path: &std::path::Path) -> Result<String, &'static str> {
+    let path_str = path.to_string_lossy();
+
+    if !path_str.starts_with("/nix/store/") {
+        return Err("path must start with /nix/store/");
+    }
+
+    match path_str
+        .strip_prefix("/nix/store/")
+        .and_then(|s| s.get(..32))
+    {
+        Some(h) if h.len() == 32 && h.chars().all(|c| c.is_ascii_alphanumeric()) => {
+            Ok(h.to_string())
+        }
+        _ => Err("invalid hash in path"),
+    }
 }
 
 #[cfg(test)]
@@ -638,5 +831,71 @@ mod tests {
                 .expect("content-type");
             assert_eq!(content_type, "application/octet-stream");
         }
+    }
+
+    #[test]
+    fn test_extract_hash_valid_path() {
+        let path = PathBuf::from("/nix/store/abc123def456ghi789jkl012mno345pq-hello-2.10");
+        assert_eq!(
+            extract_hash_from_path(&path),
+            Ok("abc123def456ghi789jkl012mno345pq".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_hash_rejects_non_store_path() {
+        let path = PathBuf::from("/tmp/some-file");
+        assert_eq!(
+            extract_hash_from_path(&path),
+            Err("path must start with /nix/store/")
+        );
+    }
+
+    #[test]
+    fn test_extract_hash_rejects_short_hash() {
+        let path = PathBuf::from("/nix/store/abc123-package");
+        assert_eq!(extract_hash_from_path(&path), Err("invalid hash in path"));
+    }
+
+    #[test]
+    fn test_extract_hash_rejects_special_chars() {
+        let path = PathBuf::from("/nix/store/abc123def456ghi789jkl012mno345!q-pkg");
+        assert_eq!(extract_hash_from_path(&path), Err("invalid hash in path"));
+    }
+
+    #[test]
+    fn test_pull_response_serialization() {
+        let response = PullResponse {
+            pulled: 2,
+            skipped: 1,
+            failed: 1,
+            details: vec![
+                PathResult {
+                    path: PathBuf::from("/nix/store/abc123def456ghi789jkl012mno345pq-foo"),
+                    status: "pulled".to_string(),
+                    error: None,
+                },
+                PathResult {
+                    path: PathBuf::from("/nix/store/xyz789abc123def456ghi012jkl345mno-bar"),
+                    status: "skipped".to_string(),
+                    error: None,
+                },
+                PathResult {
+                    path: PathBuf::from("/nix/store/11111111111111111111111111111111-baz"),
+                    status: "failed".to_string(),
+                    error: Some(
+                        "no peer has a trusted narinfo for 11111111111111111111111111111111"
+                            .to_string(),
+                    ),
+                },
+            ],
+            errors: vec![
+                "no peer has a trusted narinfo for 11111111111111111111111111111111".to_string(),
+            ],
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"pulled\":2"));
+        assert!(json.contains("\"skipped\":1"));
+        assert!(json.contains("\"failed\":1"));
     }
 }

--- a/src/ogygia-irisd/src/server/routes.rs
+++ b/src/ogygia-irisd/src/server/routes.rs
@@ -21,12 +21,17 @@ use super::handlers;
 /// Local-only routes (used for peer-to-peer, no fan-out):
 /// - GET /local/`<hash>`.narinfo - local-only store path info
 /// - GET /local/nar/`<path>` - local-only NAR download
+///
+/// Push/pull routes:
+/// - POST /rescan - rescan paths for updated signatures
+/// - POST /pull - pull paths from peers
 pub fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/nix-cache-info", get(handlers::nix_cache_info))
         .route("/bloom", get(handlers::get_bloom))
         .route("/providers/{hash}", get(handlers::get_providers))
         .route("/rescan", post(handlers::rescan))
+        .route("/pull", post(handlers::pull))
         // Local-only endpoints (no peer fan-out) — used by peers
         .route("/local/{narinfo_path}", get(handlers::get_local_narinfo))
         .route("/local/nar/{*path}", get(handlers::get_local_nar))

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -1,5 +1,6 @@
 //! Shared application state and peer lookup logic.
 
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -28,6 +29,36 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Check if a fetched narinfo is trusted and log the result.
+    ///
+    /// Returns `Some((narinfo, peer_url))` if trusted, `None` otherwise.
+    fn check_narinfo_trusted(
+        &self,
+        narinfo: NarInfo,
+        peer_url: String,
+        hash: &str,
+    ) -> Option<(NarInfo, String)> {
+        let trusted_keys = &self.config.trust.trusted_keys;
+        if !narinfo.is_trusted(trusted_keys) {
+            tracing::debug!(
+                "narinfo {} from {} is not trusted (no CA field or trusted signature), skipping",
+                hash,
+                peer_url
+            );
+            return None;
+        }
+        if narinfo.ca.is_some() {
+            tracing::info!(
+                "narinfo {} fetched from peer {} (content-addressed)",
+                hash,
+                peer_url
+            );
+        } else {
+            tracing::info!("narinfo {} fetched from peer {}", hash, peer_url);
+        }
+        Some((narinfo, peer_url))
+    }
+
     /// Try to fetch narinfo from peer via bloom filter lookup.
     ///
     /// Streams bloom lookups concurrently with narinfo fetches: as each
@@ -38,8 +69,6 @@ impl AppState {
         if peer_urls.is_empty() {
             return None;
         }
-
-        let trusted_keys = &self.config.trust.trusted_keys;
 
         let mut candidate_rx = self
             .peer_blooms
@@ -54,25 +83,10 @@ impl AppState {
                 biased;
 
                 Some(result) = narinfo_futs.next() => {
-                    let Some((peer_url, narinfo)): Option<(String, NarInfo)> = result else {
-                        continue;
-                    };
-
-                    if !narinfo.is_trusted(trusted_keys) {
-                        tracing::debug!(
-                            "narinfo {} from {} is not trusted (no CA field or trusted signature), skipping",
-                            hash,
-                            peer_url
-                        );
-                        continue;
-                    }
-
-                    if narinfo.ca.is_some() {
-                        tracing::info!("narinfo {} fetched from peer {} (content-addressed)", hash, peer_url);
-                    } else {
-                        tracing::info!("narinfo {} fetched from peer {}", hash, peer_url);
-                    }
-                    return Some((narinfo, peer_url));
+                    if let Some((peer_url, narinfo)) = result
+                        && let Some(r) = self.check_narinfo_trusted(narinfo, peer_url, hash) {
+                            return Some(r);
+                        }
                 }
 
                 Some(peer_url) = candidate_rx.recv() => {
@@ -84,6 +98,89 @@ impl AppState {
                 }
 
                 else => break,
+            }
+        }
+
+        None
+    }
+
+    /// Try to fetch narinfo from all peers (bloom-positive first, then the rest).
+    ///
+    /// Streams bloom lookups concurrently with narinfo fetches: as each
+    /// peer's bloom becomes available and matches the hash, a narinfo fetch
+    /// is started immediately. Once all blooms have resolved, any remaining
+    /// peers that were not bloom-positive are queried directly.
+    ///
+    /// This avoids double-querying bloom-positive peers: each peer is
+    /// queried at most once, either via the bloom-driven fast path or the
+    /// fallback direct query.
+    pub(super) async fn try_peer_narinfo_all(&self, hash: &str) -> Option<(NarInfo, String)> {
+        let peer_urls = &self.config.peers.urls;
+        if peer_urls.is_empty() {
+            return None;
+        }
+
+        let client = self.http_client.clone();
+        let hash = hash.to_string();
+
+        let mut queried = HashSet::new();
+        let mut narinfo_futs = FuturesUnordered::new();
+
+        let mut candidate_rx = self
+            .peer_blooms
+            .lookup_stream(peer_urls, &hash, &client)
+            .await;
+
+        loop {
+            tokio::select! {
+                biased;
+
+                Some(result) = narinfo_futs.next() => {
+                    if let Some((peer_url, narinfo)) = result
+                        && let Some(r) = self.check_narinfo_trusted(narinfo, peer_url, &hash) {
+                            return Some(r);
+                        }
+                }
+
+                Some(peer_url) = candidate_rx.recv() => {
+                    queried.insert(peer_url.clone());
+                    narinfo_futs.push(fetch_narinfo_from_peer(
+                        client.clone(),
+                        peer_url,
+                        hash.clone(),
+                    ));
+                }
+
+                else => break,
+            }
+        }
+
+        let remaining: Vec<String> = peer_urls
+            .iter()
+            .filter(|url| !queried.contains(*url))
+            .cloned()
+            .collect();
+
+        if !remaining.is_empty() {
+            tracing::info!(
+                "no bloom match for {}, querying {} remaining peers directly",
+                hash,
+                remaining.len()
+            );
+            for peer_url in remaining {
+                narinfo_futs.push(fetch_narinfo_from_peer(
+                    client.clone(),
+                    peer_url,
+                    hash.clone(),
+                ));
+            }
+        }
+
+        while let Some(result) = narinfo_futs.next().await {
+            if let Some((peer_url, narinfo)) = result
+                && let Some(r) = self.check_narinfo_trusted(narinfo, peer_url, &hash)
+            {
+                return Some(r);
             }
         }
 

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -10,6 +10,7 @@ irisd = [
     "dep:reqwest",
     "dep:serde_json",
     "dep:which",
+    "dep:futures",
 ]
 
 [dependencies]
@@ -28,3 +29,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde_json = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }

--- a/src/ogygia/src/iris/client.rs
+++ b/src/ogygia/src/iris/client.rs
@@ -23,6 +23,21 @@ struct RescanRequest {
     paths: Vec<PathBuf>,
 }
 
+/// Response from the pull endpoint
+#[derive(Debug, Deserialize)]
+pub struct PullResponse {
+    pub pulled: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    pub errors: Vec<String>,
+}
+
+/// Request body for pull endpoint
+#[derive(Debug, Serialize)]
+struct PullRequest {
+    paths: Vec<PathBuf>,
+}
+
 /// Client for communicating with irisd
 pub struct IrisdClient {
     base_url: String,
@@ -90,5 +105,50 @@ impl IrisdClient {
             .json()
             .await
             .context("Failed to parse rescan response")
+    }
+
+    /// Request irisd to pull specified store paths from peers.
+    ///
+    /// This fetches NARs for missing paths from configured peers,
+    /// validates them, and caches them locally.
+    pub async fn pull<I, P>(&self, paths: I) -> Result<PullResponse>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let paths: Vec<PathBuf> = paths
+            .into_iter()
+            .map(|p| p.as_ref().to_path_buf())
+            .collect();
+        let request = PullRequest { paths };
+
+        let url = format!("{}/pull", self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .with_context(|| format!("Failed to send POST request to {}", url))?;
+
+        let status = response.status();
+
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(anyhow!(
+                "irisd returned error {}: {}",
+                status.as_u16(),
+                body
+            ));
+        }
+
+        response
+            .json()
+            .await
+            .context("Failed to parse pull response")
     }
 }

--- a/src/ogygia/src/iris/push.rs
+++ b/src/ogygia/src/iris/push.rs
@@ -8,9 +8,13 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
+use anyhow::anyhow;
+use clap::ArgAction;
 use clap::Args;
+use futures::future::join_all;
 
 use super::client::IrisdClient;
+use super::client::PullResponse;
 use super::nix::compute_closure;
 use super::nix::parse_key_name;
 use super::nix::query_ultimate_paths;
@@ -35,6 +39,14 @@ pub struct PushArgs {
     /// Push only the specified paths, not their closures
     #[arg(long)]
     pub no_closure: bool,
+
+    /// Remote irisd URLs to pull from after local push (repeatable)
+    #[arg(
+        long,
+        env = "OGYGIA_IRISD_REMOTE_URL",
+        action = ArgAction::Append
+    )]
+    pub remote: Vec<String>,
 }
 
 /// Execute the push command
@@ -126,7 +138,10 @@ async fn async_run(args: &PushArgs) -> Result<()> {
         tracing::info!("Signed {} paths", sign_result.signed);
     }
 
-    let paths_to_rescan: Vec<_> = unsigned.into_iter().map(|p| &p.path).collect();
+    let paths_to_rescan: Vec<PathBuf> = unsigned
+        .into_iter()
+        .map(|p| p.path.clone().into())
+        .collect();
 
     // Notify irisd to rescan the newly signed paths
     tracing::info!(
@@ -134,7 +149,7 @@ async fn async_run(args: &PushArgs) -> Result<()> {
         paths_to_rescan.len()
     );
     let rescan_result = client
-        .rescan(paths_to_rescan)
+        .rescan(&paths_to_rescan)
         .await
         .context("Failed to rescan paths")?;
 
@@ -146,6 +161,105 @@ async fn async_run(args: &PushArgs) -> Result<()> {
 
     if rescan_result.errors > 0 {
         anyhow::bail!("{} paths failed during rescan", rescan_result.errors);
+    }
+
+    // Handle remote pulls if --remote is specified
+    if !args.remote.is_empty() {
+        // Validate that remote URLs don't match local irisd_url
+        for remote_url in &args.remote {
+            if remote_url.trim_end_matches('/') == args.irisd_url.trim_end_matches('/') {
+                return Err(anyhow!(
+                    "remote URL {} must differ from local irisd URL",
+                    remote_url
+                ));
+            }
+        }
+
+        // Use the same paths that were rescanned locally for remote pulls
+        let paths_to_advertise = paths_to_rescan.clone();
+
+        if paths_to_advertise.is_empty() {
+            tracing::info!("No paths to advertise to remotes");
+            return Ok(());
+        }
+
+        tracing::info!(
+            "Initiating remote pulls to {} remotes...",
+            args.remote.len()
+        );
+
+        // Spawn concurrent tasks for each remote
+        let remote_futures: Vec<_> = args
+            .remote
+            .iter()
+            .map(|remote_url| {
+                let remote_url = remote_url.clone();
+                let paths = paths_to_advertise.clone();
+
+                async move {
+                    tracing::info!("Initiating remote pull to {}", remote_url);
+
+                    let remote_client = match IrisdClient::new(&remote_url) {
+                        Ok(client) => client,
+                        Err(e) => {
+                            tracing::error!("Failed to create client for {}: {}", remote_url, e);
+                            return (remote_url, Err(e));
+                        }
+                    };
+
+                    let result = remote_client.pull(&paths).await;
+                    (remote_url, result)
+                }
+            })
+            .collect();
+
+        // Wait for all remote pulls to complete
+        let remote_results: Vec<(String, Result<PullResponse>)> = join_all(remote_futures).await;
+
+        // Log results and aggregate errors
+        let mut total_pulled = 0usize;
+        let mut total_skipped = 0usize;
+        let mut total_failed = 0usize;
+        let mut remote_errors = Vec::new();
+
+        for (remote_url, result) in remote_results {
+            match result {
+                Ok(response) => {
+                    tracing::info!(
+                        "Remote pull to {}: {} pulled, {} skipped, {} failed",
+                        remote_url,
+                        response.pulled,
+                        response.skipped,
+                        response.failed
+                    );
+                    total_pulled += response.pulled;
+                    total_skipped += response.skipped;
+                    total_failed += response.failed;
+                    if !response.errors.is_empty() {
+                        remote_errors.push(format!(
+                            "{}: {}",
+                            remote_url,
+                            response.errors.join(", ")
+                        ));
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Remote pull to {} failed: {}", remote_url, e);
+                    remote_errors.push(format!("{}: {}", remote_url, e));
+                }
+            }
+        }
+
+        tracing::info!(
+            "Remote pulls complete: {} pulled, {} skipped, {} failed across all remotes",
+            total_pulled,
+            total_skipped,
+            total_failed
+        );
+
+        if !remote_errors.is_empty() {
+            anyhow::bail!("Remote pull errors:\n  {}", remote_errors.join("\n  "));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
The `ogygia iris push` command previously only notified the local daemon about
newly signed paths. Users needed a way to push store paths to remote irisd
daemons to enable multi-hop distribution across a fleet.

Added a new `POST /pull` endpoint that triggers the remote daemon to pull
NARs from its configured peers via bloom filter lookup (with refresh-on-miss).
Implemented `cache_fetched_nar()` for caching remotely-fetched NARs and made
the `--remote` flag repeatable for parallel pushes to multiple remotes.

This approach reuses existing peer-to-peer infrastructure while adding the
necessary primitives for remote cache warming and multi-hop distribution.

Test plan:
- `nix flake check` passes (clippy, tests, formatting, NixOS VM tests)
- `cargo test --workspace` - 38 new tests for cache_fetched_nar, bloom refresh,
  pull handler bloom lookup, signature validation, NAR fetch/cache, and CLI
- VM tests: ogygia-irisd-push and ogygia-irisd-local pass
- Manual testing: verified --remote repeatable flag, --no-block mode,
  self-pull prevention, and no-peers error handling