### PR TITLE
irisd: default trusted_keys to Nix daemon's trusted-public-keys

### DIFF
--- a/nixos/irisd/default.nix
+++ b/nixos/irisd/default.nix
@@ -145,6 +145,9 @@ in
       };
     };
 
+    # Trust the same keys as the Nix daemon by default
+    ogygia.irisd.settings.trust.trusted_keys = lib.mkDefault config.nix.settings.trusted-public-keys;
+
     # Configure Nix daemon to use irisd as a preferred substituter
     nix.settings = lib.mkIf cfg.configureNixDaemon {
       substituters = lib.mkBefore [ substituterUrl ];


### PR DESCRIPTION
The irisd module required manual duplication of signing keys between nix.settings.trusted-public-keys and ogygia.irisd.settings.trust.trusted_keys, which is error-prone and easy to forget when adding new keys.

Added a mkDefault assignment so that ogygia.irisd.settings.trust.trusted_keys defaults to config.nix.settings.trusted-public-keys. This ensures irisd automatically trusts the same keys the Nix daemon already trusts, while still allowing users to override with their own list if needed.

Test plan:
- CI validates the NixOS module builds and existing tests pass
- mkDefault priority (1000) ensures user overrides take precedence