### PR TITLE
irisd: accept content-addressed paths from peers without requiring sigs

### DIFF
--- a/src/ogygia-irisd/src/nix/narinfo.rs
+++ b/src/ogygia-irisd/src/nix/narinfo.rs
@@ -84,6 +84,38 @@ impl NarInfo {
         })
     }
 
+    /// Check if this narinfo has a meaningful content-addressed (CA) field.
+    ///
+    /// Returns true if the CA field is present and contains non-whitespace content.
+    /// Empty or whitespace-only CA fields are not considered valid CA paths.
+    fn has_ca(&self) -> bool {
+        self.ca.as_ref().is_some_and(|s| !s.trim().is_empty())
+    }
+
+    /// Check if this narinfo is trusted for fetching from peers.
+    ///
+    /// A narinfo is trusted if:
+    /// - It is content-addressed (has a meaningful CA field), OR
+    /// - It has at least one signature from a trusted key, OR
+    /// - No trusted keys are configured (no trust restriction)
+    ///
+    /// This matches Nix's behavior where content-addressed paths are self-verifying
+    /// and don't require signatures.
+    pub fn is_trusted(&self, trusted_keys: &[String]) -> bool {
+        // Content-addressed paths are inherently trusted (self-verifying)
+        if self.has_ca() {
+            return true;
+        }
+
+        // If no trusted keys are configured, no trust restriction applies
+        if trusted_keys.is_empty() {
+            return true;
+        }
+
+        // Otherwise, require a trusted signature
+        self.has_trusted_signature(trusted_keys)
+    }
+
     /// Parse a narinfo file
     pub fn parse(content: &str) -> Result<Self> {
         let mut fields: HashMap<&str, &str> = HashMap::new();
@@ -258,5 +290,103 @@ Sig: my-cache-1:qrstuvwxyz123456
         assert!(!info.has_trusted_signature(&untrusted));
 
         assert!(!info.has_trusted_signature(&[]));
+    }
+
+    /// Helper to create a base NarInfo for testing
+    fn base_narinfo() -> NarInfo {
+        NarInfo {
+            store_path: "/nix/store/abc123-test".to_string(),
+            url: "nar/test.nar.zst".to_string(),
+            compression: Compression::Zstd,
+            file_hash: "sha256:abc".to_string(),
+            file_size: 100,
+            nar_hash: "sha256:def".to_string(),
+            nar_size: 200,
+            references: vec![],
+            deriver: None,
+            signatures: vec![],
+            ca: None,
+        }
+    }
+
+    #[test]
+    fn test_is_trusted_ca_no_sigs_with_trusted_keys() {
+        // CA path with no signatures, trusted keys configured → is_trusted returns true
+        let info = NarInfo {
+            ca: Some("fixed:sha256:abc".to_string()),
+            ..base_narinfo()
+        };
+        let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
+        assert!(info.is_trusted(&trusted_keys));
+    }
+
+    #[test]
+    fn test_is_trusted_ca_no_sigs_no_trusted_keys() {
+        // CA path with no signatures, no trusted keys → is_trusted returns true
+        let info = NarInfo {
+            ca: Some("fixed:sha256:abc".to_string()),
+            ..base_narinfo()
+        };
+        assert!(info.is_trusted(&[]));
+    }
+
+    #[test]
+    fn test_is_trusted_ca_with_trusted_sig() {
+        // CA path with trusted signature → is_trusted returns true
+        let info = NarInfo {
+            ca: Some("fixed:sha256:abc".to_string()),
+            signatures: vec!["cache.nixos.org-1:sig".to_string()],
+            ..base_narinfo()
+        };
+        let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
+        assert!(info.is_trusted(&trusted_keys));
+    }
+
+    #[test]
+    fn test_is_trusted_non_ca_with_trusted_sig() {
+        // Non-CA path with trusted signature → is_trusted returns true
+        let info = NarInfo {
+            signatures: vec!["cache.nixos.org-1:sig".to_string()],
+            ..base_narinfo()
+        };
+        let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
+        assert!(info.is_trusted(&trusted_keys));
+    }
+
+    #[test]
+    fn test_is_trusted_non_ca_without_sig() {
+        // Non-CA path without trusted signature → is_trusted returns false
+        let info = base_narinfo();
+        let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
+        assert!(!info.is_trusted(&trusted_keys));
+    }
+
+    #[test]
+    fn test_is_trusted_non_ca_empty_trusted_keys() {
+        // Non-CA path with empty trusted keys → is_trusted returns true (no trust restriction)
+        let info = base_narinfo();
+        assert!(info.is_trusted(&[]));
+    }
+
+    #[test]
+    fn test_is_trusted_empty_ca_string() {
+        // CA field with empty string Some("") → treated as non-CA (returns false without signatures)
+        let info = NarInfo {
+            ca: Some("".to_string()),
+            ..base_narinfo()
+        };
+        let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
+        assert!(!info.is_trusted(&trusted_keys));
+    }
+
+    #[test]
+    fn test_is_trusted_whitespace_ca_string() {
+        // CA field with whitespace Some("  ") → treated as non-CA
+        let info = NarInfo {
+            ca: Some("  ".to_string()),
+            ..base_narinfo()
+        };
+        let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
+        assert!(!info.is_trusted(&trusted_keys));
     }
 }

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -461,7 +461,10 @@ pub async fn rescan(
         };
 
         if !info.is_serveable() {
-            tracing::warn!("rescan: path has no signatures: {}", path_str);
+            tracing::warn!(
+                "rescan: path is not serveable (neither signed nor content-addressed): {}",
+                path_str
+            );
             errors += 1;
             continue;
         }

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -58,16 +58,20 @@ impl AppState {
                         continue;
                     };
 
-                    if !trusted_keys.is_empty() && !narinfo.has_trusted_signature(trusted_keys) {
+                    if !narinfo.is_trusted(trusted_keys) {
                         tracing::debug!(
-                            "narinfo {} from {} has no trusted signature, skipping",
+                            "narinfo {} from {} is not trusted (no CA field or trusted signature), skipping",
                             hash,
                             peer_url
                         );
                         continue;
                     }
 
-                    tracing::info!("narinfo {} fetched from peer {}", hash, peer_url);
+                    if narinfo.ca.is_some() {
+                        tracing::info!("narinfo {} fetched from peer {} (content-addressed)", hash, peer_url);
+                    } else {
+                        tracing::info!("narinfo {} fetched from peer {}", hash, peer_url);
+                    }
                     return Some((narinfo, peer_url));
                 }
 
@@ -123,9 +127,9 @@ impl AppState {
                         continue;
                     };
 
-                    if !trusted_keys.is_empty() && !narinfo.has_trusted_signature(trusted_keys) {
+                    if !narinfo.is_trusted(trusted_keys) {
                         tracing::debug!(
-                            "narinfo {} from {} has no trusted signature, skipping",
+                            "narinfo {} from {} is not trusted (no CA field or trusted signature), skipping",
                             hash,
                             peer_url
                         );
@@ -140,7 +144,11 @@ impl AppState {
                     let nar_url = format!("{}/local/{}", peer_url.trim_end_matches('/'), narinfo.url);
                     match stream_nar_from_url(&self.http_client, &nar_url).await {
                         Some(response) => {
-                            tracing::info!("Proxying NAR {} from peer {}", hash, peer_url);
+                            if narinfo.ca.is_some() {
+                                tracing::info!("Proxying NAR {} from peer {} (content-addressed)", hash, peer_url);
+                            } else {
+                                tracing::info!("Proxying NAR {} from peer {}", hash, peer_url);
+                            }
                             return response;
                         }
                         None => continue,

--- a/src/ogygia-irisd/src/store/watcher.rs
+++ b/src/ogygia-irisd/src/store/watcher.rs
@@ -118,7 +118,10 @@ impl StoreWatcher {
             self.bloom.insert(hash);
             tracing::debug!("Indexed new store path: {}", store_path);
         } else {
-            tracing::debug!("Skipping unsigned store path: {}", store_path);
+            tracing::debug!(
+                "Skipping not-serveable store path (neither signed nor content-addressed): {}",
+                store_path
+            );
         }
     }
 


### PR DESCRIPTION
Peer narinfo fetching rejected CA paths that lacked trusted signatures, but Nix never signs content-addressed paths -- they are self-verifying via their content hash. This meant irisd would refuse to fetch valid CA paths from peers when trusted keys were configured.

Add an is_trusted() method to NarInfo that returns true for content-addressed paths (has a non-empty CA field), paths with a trusted signature, or when no trust restriction is configured. Replace the two hand-rolled trust checks in state.rs with calls to this method. Update log messages to distinguish CA paths from signed paths. Handle the edge case where the CA field is empty or whitespace-only.

This matches Nix's own behavior where checkSignatures() returns maxSigs for CA paths, allowing them to be served without signature verification while still requiring trusted signatures for input-addressed paths.

Test plan:
- Added 8 new unit tests covering is_trusted() logic: CA paths with and without signatures, non-CA paths with and without signatures, empty trusted keys, and empty/whitespace CA field edge cases.
- All 32 package tests pass including the new trust tests.
- cargo clippy passes with no warnings.
- No stale has_trusted_signature references remain in state.rs.