### PR TITLE
ci: fix binary cache substituter for nix-fast-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         extra_nix_config: |
           accept-flake-config = true
+          extra-substituters = https://nixcache.jakehillion.me
+          extra-trusted-public-keys = nixcache.jakehillion.me-1:HQsjYdrcs3ilS/ngtlbTQXU4Xfsm+va5NN7yoK0wKMg=
           max-jobs = 2
 
     - name: Enter CI devShell

--- a/README.md
+++ b/README.md
@@ -372,17 +372,17 @@ This queries your local irisd, which checks peers' bloom filters and returns mat
 4. **NAR serving**: If found locally, irisd serves the NAR; if on a peer, it redirects/proxies
 5. **Caching**: Downloaded NARs are cached locally with configurable TTL and size limits
 
-## Cachix
+## Binary Cache
 
-Pre-built binaries are available via Cachix:
+Pre-built binaries are available from the project's Nix cache:
 
 ```nix
 nixConfig = {
   extra-substituters = [
-    "https://ogygia.cachix.org"
+    "https://nixcache.jakehillion.me"
   ];
   extra-trusted-public-keys = [
-    "ogygia.cachix.org-1:xb4bnMPeWgSP81Xs0Vl7ZU4Ez7Ul65qp/EoZ40pDaWo="
+    "nixcache.jakehillion.me-1:HQsjYdrcs3ilS/ngtlbTQXU4Xfsm+va5NN7yoK0wKMg="
   ];
 };
 ```


### PR DESCRIPTION
The CI pipeline was rebuilding all derivations from scratch on every run because nix-fast-build --skip-cached could not query the R2 binary cache. Although accept-flake-config = true was set, the flake's nixConfig substituters are only applied when Nix operations reference the flake directly (e.g. nix develop). The nix-fast-build/nix-eval-jobs subprocesses that evaluate and build derivations do not inherit these per-flake substituter settings, so store.queryMissing() never checked nixcache.jakehillion.me and reported all paths as uncached.

Add extra-substituters and extra-trusted-public-keys to the global Nix configuration via install-nix-action extra_nix_config so they are available to all Nix operations including nix-eval-jobs --check-cache-status. Also update the README to replace the stale Cachix section with the current R2 binary cache details.

Test plan:
- The next CI run should show nix-fast-build reporting builds: 0 for unchanged outputs, with paths fetched from nixcache.jakehillion.me during the build step rather than only from cache.nixos.org.