### PR TITLE
ogygia-dashboard: handle invalid Oid values from etcd as None

### DIFF
--- a/src/ogygia-dashboard/src/etcd.rs
+++ b/src/ogygia-dashboard/src/etcd.rs
@@ -91,13 +91,30 @@ impl Etcd {
         states.host_states.clear();
 
         for kv in resp.kvs() {
-            let key = kv.key_str()?;
-            let value = kv.value_str()?;
+            let key = match kv.key_str() {
+                Ok(k) => k,
+                Err(e) => {
+                    tracing::warn!("Skipping etcd key with invalid UTF-8: {e}");
+                    continue;
+                }
+            };
+            let value = match kv.value_str() {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("Skipping etcd key '{key}' with invalid UTF-8 value: {e}");
+                    continue;
+                }
+            };
 
             if let Some((host, commit_state)) = parse_key(key, prefix) {
-                let commit = Oid::from_str(value)?;
-                states.host_states.entry(host.to_string()).or_default()[commit_state] =
-                    Some(commit);
+                let commit = Oid::from_str(value).ok();
+                if commit.is_none() {
+                    tracing::warn!(
+                        "Invalid git OID for host '{host}' state '{state}' (value: '{value}')",
+                        state = commit_state.as_ref()
+                    );
+                }
+                states.host_states.entry(host.to_string()).or_default()[commit_state] = commit;
             }
         }
 
@@ -125,31 +142,53 @@ impl Etcd {
                     continue;
                 };
 
-                let key = kv.key_str()?;
+                let key = match kv.key_str() {
+                    Ok(k) => k,
+                    Err(e) => {
+                        tracing::warn!("Skipping etcd watch event with invalid key UTF-8: {e}");
+                        continue;
+                    }
+                };
                 let Some((host, commit_state)) = parse_key(key, prefix) else {
                     continue;
                 };
 
                 match event.event_type() {
                     EventType::Put => {
-                        let value = kv.value_str()?;
-                        let commit = Oid::from_str(value)?;
+                        let value = match kv.value_str() {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Invalid UTF-8 value for host '{host}' state '{state}': {e}",
+                                    state = commit_state.as_ref()
+                                );
+                                continue;
+                            }
+                        };
+                        let commit = Oid::from_str(value).ok();
+                        if commit.is_none() {
+                            tracing::warn!(
+                                "Invalid git OID for host '{host}' state '{state}' (value: '{value}')",
+                                state = commit_state.as_ref()
+                            );
+                        }
 
                         let mut guard = self.states.lock().await;
                         let states = Arc::make_mut(&mut *guard);
-                        let old = states.host_states.entry(host.to_string()).or_default()
-                            [commit_state]
-                            .replace(commit);
+                        let entry = states.host_states.entry(host.to_string()).or_default();
+                        let old = entry[commit_state].take();
+                        entry[commit_state] = commit;
 
                         states.version += 1;
 
                         let old_str = old.map(|c| c.to_string()[..12].to_string());
+                        let new_str = commit.as_ref().map(|c| c.to_string()[..12].to_string());
                         tracing::info!(
                             "Host '{}' state '{}' changed from {} to {}",
                             host,
                             commit_state.as_ref(),
                             old_str.as_deref().unwrap_or("None"),
-                            &commit.to_string()[..12]
+                            new_str.as_deref().unwrap_or("None (invalid)"),
                         );
                     }
                     EventType::Delete => {

--- a/src/ogygia-dashboard/src/web.rs
+++ b/src/ogygia-dashboard/src/web.rs
@@ -574,6 +574,48 @@ fn generate_git_graph_html(
     font-weight: 500;
 }
 
+.host-badge.unknown {
+    background: #f3f4f6;
+    color: #6b7280;
+    border: 1px solid #d1d5db;
+}
+
+.unknown-hosts {
+    margin: 16px 0;
+    padding: 12px;
+    background: #fffbeb;
+    border-radius: 6px;
+    border: 1px solid #fcd34d;
+}
+
+.unknown-hosts-title {
+    font-weight: 600;
+    color: #92400e;
+    margin-bottom: 8px;
+}
+
+.unknown-hosts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.unknown-host-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+}
+
+.unknown-host-name {
+    font-weight: 500;
+    color: #1f2937;
+}
+
+.unknown-host-states {
+    color: #6b7280;
+}
+
 .legend {
     margin-top: 20px;
     padding: 12px;
@@ -864,6 +906,60 @@ fn generate_git_graph_html(
         ));
 
         html.push_str(r#"</div>"#); // Close commit-row
+    }
+
+    // Collect hosts with invalid (None) state values
+    let unknown_hosts: Vec<_> = host_states
+        .host_states
+        .iter()
+        .filter_map(|(hostname, states)| {
+            let invalid_states: Vec<_> = [
+                (
+                    crate::nixos::CommitState::Current,
+                    states[crate::nixos::CommitState::Current],
+                ),
+                (
+                    crate::nixos::CommitState::Booted,
+                    states[crate::nixos::CommitState::Booted],
+                ),
+                (
+                    crate::nixos::CommitState::NextBoot,
+                    states[crate::nixos::CommitState::NextBoot],
+                ),
+            ]
+            .iter()
+            .filter(|(_, oid)| oid.is_none())
+            .map(|(state, _)| state.as_ref().to_string())
+            .collect();
+
+            if invalid_states.is_empty() {
+                None
+            } else {
+                Some((hostname.clone(), invalid_states))
+            }
+        })
+        .collect();
+
+    if !unknown_hosts.is_empty() {
+        html.push_str(r#"<div class="unknown-hosts">"#);
+        html.push_str(
+            r#"<div class="unknown-hosts-title">Hosts with invalid state data from etcd</div>"#,
+        );
+        html.push_str(r#"<div class="unknown-hosts-list">"#);
+
+        for (hostname, invalid_states) in &unknown_hosts {
+            let clean_hostname = match &config.hostname_strip_suffix {
+                Some(suffix) => hostname.replace(suffix.as_str(), ""),
+                None => hostname.to_string(),
+            };
+            html.push_str(&format!(
+                r#"<div class="unknown-host-item"><span class="unknown-host-name">{}</span><span class="unknown-host-states">({})</span></div>"#,
+                clean_hostname,
+                invalid_states.join(", ")
+            ));
+        }
+
+        html.push_str(r#"</div></div>"#);
     }
 
     // Add legend


### PR DESCRIPTION
The dashboard crashed when etcd contained invalid git OID values because the parsing code propagated errors via the ? operator, causing the entire application to fail on startup or the watch loop to exit unexpectedly.

This commit converts Oid parsing errors into Option::None values in both load_all() and watch_loop(), logging warnings for each invalid entry. The web rendering layer now displays hosts with invalid state data in an "Unknown Hosts" section before the legend, showing which states (current/booted/nextboot) have corrupted data.

Treating etcd data as untrusted prevents crashes from malformed input while still surfacing the issue to operators through the dashboard UI and warning logs.

Test plan:
- cargo check passes for ogygia-dashboard crate
- Manual testing with invalid etcd values required to verify UI display