### PR TITLE
irisd: remove LocalBloom::contains in favour of direct store checks

### DIFF
--- a/src/ogygia-irisd/src/bloom/local.rs
+++ b/src/ogygia-irisd/src/bloom/local.rs
@@ -66,10 +66,10 @@ impl BloomState {
 /// Local bloom filter with phased replacement for safe rebuilds.
 ///
 /// Two slots hold the bloom state:
-/// - `read_bloom` (`ArcSwap<AtomicBloomFilter>`): serves `contains()`
-///   and `serialize()`. Only the filter — no counters. During a
-///   rebuild this still points to the old filter so existing paths
-///   remain visible.
+/// - `read_bloom` (`ArcSwap<AtomicBloomFilter>`): serves
+///   `serialize()`. Only the filter — no counters. During a rebuild
+///   this still points to the old filter so existing paths remain
+///   visible.
 /// - `write_bloom` (`RwLock<BloomState>`): receives `insert()` and
 ///   `mark_deletion()` calls via the read lock (cheap, concurrent).
 ///   A rebuild takes the write lock to swap in a fresh state,
@@ -117,11 +117,6 @@ impl LocalBloom {
         let state = self.write_bloom.read().expect("write_bloom poisoned");
         state.filter.insert(hash);
         state.element_count.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Check if a store path hash might be in the bloom filter.
-    pub fn contains(&self, hash: &str) -> bool {
-        self.read_bloom.load().contains(hash)
     }
 
     /// Record a deletion (bloom filters cannot remove elements).

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -373,7 +373,7 @@ pub async fn get_providers(
     axum::extract::Query(query): axum::extract::Query<ProvidersQuery>,
 ) -> Response {
     // Check local store
-    let local = state.local_bloom.contains(&hash) && find_store_path(&hash).await.is_some();
+    let local = find_store_path(&hash).await.is_some();
 
     // Check peers via bloom lookup
     let peer_urls = &state.config.peers.urls;


### PR DESCRIPTION
The LocalBloom::contains method was an unnecessary guard before the real store lookup in get_providers. Peers already check our bloom filter before querying us, so re-checking it locally serves no purpose. Worse, the local bloom could false-negative if it has not yet been updated with a recent insert, causing us to incorrectly report that we do not have a path we actually have.

Removed the contains method entirely and changed get_providers to check the local store directly via find_store_path, which always returns the factual answer. Updated the read_bloom doc comment to reflect that it now only serves serialize().

Test plan:
- cargo check -p ogygia-irisd passes
- Existing serialize roundtrip test still exercises LocalBloom construction and serialization without the removed method