### PR TITLE
irisd: add dual-TTL stale-while-revalidate for peer bloom filters

### DIFF
--- a/nixos/irisd/default.nix
+++ b/nixos/irisd/default.nix
@@ -60,6 +60,12 @@ in
         - `bloom.peer_bloom_ttl_secs` (int) — how long a peer's bloom
           filter is cached before re-fetching.
 
+        - `bloom.peer_bloom_max_age_secs` (int) — maximum age for a
+          peer's bloom filter before it is discarded. Between
+          `peer_bloom_ttl_secs` and this value, stale blooms are served
+          while a background re-fetch is attempted. Defaults to
+          2× `peer_bloom_ttl_secs`.
+
         - `peers.urls` (list of string) — peer irisd HTTP URLs for
           bloom-based store path lookup.
 

--- a/src/ogygia-irisd/Cargo.toml
+++ b/src/ogygia-irisd/Cargo.toml
@@ -62,3 +62,4 @@ notify = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/src/ogygia-irisd/src/bloom/peers.rs
+++ b/src/ogygia-irisd/src/bloom/peers.rs
@@ -7,7 +7,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -16,20 +15,43 @@ use rand::seq::SliceRandom;
 use tokio::sync::RwLock;
 use tokio::sync::RwLockReadGuard;
 use tokio::sync::mpsc;
+use tokio::time::Instant;
 
 use super::BLOOM_SEED;
+
+enum Freshness {
+    Fresh,
+    Stale,
+    Expired,
+}
 
 #[derive(Default)]
 struct PeerBloomEntry {
     bloom: Option<BloomFilter>,
-    fetched_at: Option<Instant>,
+    fetched_at: Option<Instant>,      // last *successful* fetch
+    last_attempt_at: Option<Instant>, // last fetch attempt (success or failure)
 }
 
 impl PeerBloomEntry {
-    fn is_fresh(&self, ttl: Duration) -> bool {
+    fn recently_attempted(&self, min_interval: Duration) -> bool {
+        self.last_attempt_at
+            .map(|t| t.elapsed() < min_interval)
+            .unwrap_or(false)
+    }
+
+    fn freshness(&self, ttl: Duration, max_age: Duration) -> Freshness {
         match self.fetched_at {
-            Some(t) => t.elapsed() < ttl,
-            None => false,
+            None => Freshness::Expired,
+            Some(t) => {
+                let elapsed = t.elapsed();
+                if elapsed < ttl {
+                    Freshness::Fresh
+                } else if elapsed < max_age {
+                    Freshness::Stale
+                } else {
+                    Freshness::Expired
+                }
+            }
         }
     }
 }
@@ -38,15 +60,22 @@ impl PeerBloomEntry {
 pub struct PeerBlooms {
     peers: RwLock<HashMap<String, Arc<RwLock<PeerBloomEntry>>>>,
     ttl: Duration,
+    max_age: Duration,
     expected_bloom_bits: usize,
     num_hashes: u32,
 }
 
 impl PeerBlooms {
-    pub fn new(ttl: Duration, expected_bloom_bits: usize, num_hashes: u32) -> Self {
+    pub fn new(
+        ttl: Duration,
+        max_age: Duration,
+        expected_bloom_bits: usize,
+        num_hashes: u32,
+    ) -> Self {
         Self {
             peers: RwLock::new(HashMap::new()),
             ttl,
+            max_age,
             expected_bloom_bits,
             num_hashes,
         }
@@ -62,13 +91,22 @@ impl PeerBlooms {
         entries.shuffle(&mut rand::rng());
 
         let ttl = self.ttl;
+        let max_age = self.max_age;
         let expected_bits = self.expected_bloom_bits;
         let num_hashes = self.num_hashes;
         let futs = entries.into_iter().map(|(url, entry)| {
             let client = client.clone();
             async move {
-                let _guard =
-                    ensure_peer_fresh(&entry, &url, &client, ttl, expected_bits, num_hashes).await;
+                let _guard = ensure_peer_fresh(
+                    &entry,
+                    &url,
+                    &client,
+                    ttl,
+                    max_age,
+                    expected_bits,
+                    num_hashes,
+                )
+                .await;
             }
         });
         futures::future::join_all(futs).await;
@@ -121,6 +159,7 @@ impl PeerBlooms {
         let (tx, rx) = mpsc::unbounded_channel();
         let entries = self.get_or_create_entries(peer_urls).await;
         let ttl = self.ttl;
+        let max_age = self.max_age;
         let expected_bits = self.expected_bloom_bits;
         let num_hashes = self.num_hashes;
 
@@ -129,8 +168,16 @@ impl PeerBlooms {
             let client = client.clone();
             let hash = hash.to_string();
             tokio::spawn(async move {
-                let guard =
-                    ensure_peer_fresh(&entry, &url, &client, ttl, expected_bits, num_hashes).await;
+                let guard = ensure_peer_fresh(
+                    &entry,
+                    &url,
+                    &client,
+                    ttl,
+                    max_age,
+                    expected_bits,
+                    num_hashes,
+                )
+                .await;
 
                 if guard.bloom.as_ref().is_some_and(|b| b.contains(&hash)) {
                     let _ = tx.send(url);
@@ -146,14 +193,19 @@ impl PeerBlooms {
     /// Remove expired entries, freeing their memory.
     pub async fn evict_expired(&self) {
         let mut peers = self.peers.write().await;
+        let max_age = self.max_age;
         let ttl = self.ttl;
         peers.retain(|url, entry| match entry.try_read() {
             Ok(guard) => {
-                let fresh = guard.is_fresh(ttl);
-                if !fresh {
+                let within_max_age = match guard.fetched_at {
+                    Some(t) => t.elapsed() < max_age,
+                    None => false,
+                };
+                let recently_attempted = guard.recently_attempted(ttl);
+                if !within_max_age && !recently_attempted {
                     tracing::debug!("evicting expired bloom for {}", url);
                 }
-                fresh
+                within_max_age || recently_attempted
             }
             // Currently being written (refresh in progress), keep it.
             Err(_) => true,
@@ -166,13 +218,21 @@ impl PeerBlooms {
     /// expired. All entry locks are taken in parallel via `join_all`.
     pub async fn next_eviction_time(&self) -> Option<Instant> {
         let peers = self.peers.read().await;
+        let max_age = self.max_age;
         let ttl = self.ttl;
 
         let futs: Vec<_> = peers
             .values()
             .map(|entry| async move {
                 let guard = entry.read().await;
-                guard.fetched_at.map(|t| t + ttl)
+                let fetched_deadline = guard.fetched_at.map(|t| t + max_age);
+                let attempt_deadline = guard.last_attempt_at.map(|t| t + ttl);
+                match (fetched_deadline, attempt_deadline) {
+                    (Some(f), Some(a)) => Some(f.max(a)),
+                    (Some(f), None) => Some(f),
+                    (None, Some(a)) => Some(a),
+                    (None, None) => None,
+                }
             })
             .collect();
 
@@ -183,8 +243,8 @@ impl PeerBlooms {
             .min()
     }
 
-    pub fn ttl(&self) -> Duration {
-        self.ttl
+    pub fn max_age(&self) -> Duration {
+        self.max_age
     }
 
     /// Get or create per-peer entries for all configured URLs.
@@ -250,47 +310,80 @@ async fn fetch_bloom(
 /// Refresh a single peer's bloom filter if it is stale, returning
 /// a read guard to the entry.
 ///
-/// Checks freshness under a read lock first; if stale, acquires a write
-/// lock with a double-check to avoid redundant fetches when multiple
-/// tasks race to refresh the same peer. The write guard is downgraded
-/// to a read guard before returning.
+/// Uses a three-state freshness model:
+/// - **Fresh**: return read guard immediately (fast path).
+/// - **Stale** (between TTL and max_age): spawn a background refresh
+///   and return the stale data immediately (stale-while-revalidate).
+/// - **Expired** (beyond max_age): block on a fetch, discarding stale data
+///   first (same as the original two-state behavior).
 async fn ensure_peer_fresh<'a>(
-    entry: &'a RwLock<PeerBloomEntry>,
+    entry: &'a Arc<RwLock<PeerBloomEntry>>,
     url: &str,
     client: &reqwest::Client,
     ttl: Duration,
+    max_age: Duration,
     expected_bits: usize,
     num_hashes: u32,
 ) -> RwLockReadGuard<'a, PeerBloomEntry> {
     // Fast path: check freshness under read lock.
     {
         let guard = entry.read().await;
-        if guard.is_fresh(ttl) {
-            return guard;
+        match guard.freshness(ttl, max_age) {
+            Freshness::Fresh => return guard,
+            Freshness::Stale if guard.recently_attempted(ttl) => return guard,
+            Freshness::Stale | Freshness::Expired => {}
         }
     }
 
     // Slow path: write lock with double-check.
     let mut guard = entry.write().await;
-    if guard.is_fresh(ttl) {
-        return guard.downgrade();
+    match guard.freshness(ttl, max_age) {
+        Freshness::Fresh => return guard.downgrade(),
+        Freshness::Stale if guard.recently_attempted(ttl) => return guard.downgrade(),
+        Freshness::Stale => {
+            // Stale-while-revalidate: serve stale data, spawn background refresh.
+            guard.last_attempt_at = Some(Instant::now());
+            let read_guard = guard.downgrade();
+
+            let entry_clone = Arc::clone(entry);
+            let client = client.clone();
+            let url = url.to_string();
+            tokio::spawn(async move {
+                let result = fetch_bloom(&url, &client, expected_bits, num_hashes).await;
+                let mut guard = entry_clone.write().await;
+                match result {
+                    Ok(bloom) => {
+                        guard.bloom = Some(bloom);
+                        guard.fetched_at = Some(Instant::now());
+                    }
+                    Err(e) => {
+                        tracing::warn!("background bloom fetch failed for {}: {}", url, e);
+                    }
+                }
+            });
+
+            return read_guard;
+        }
+        Freshness::Expired if guard.recently_attempted(ttl) => {
+            guard.bloom = None;
+            return guard.downgrade();
+        }
+        Freshness::Expired => {}
     }
 
-    // Discard expired bloom before attempting refresh.
+    // Expired path: discard stale data, block on fetch.
+    guard.last_attempt_at = Some(Instant::now());
     guard.bloom = None;
 
     match fetch_bloom(url, client, expected_bits, num_hashes).await {
         Ok(bloom) => {
             guard.bloom = Some(bloom);
+            guard.fetched_at = Some(Instant::now());
         }
         Err(e) => {
             tracing::warn!("failed to fetch bloom from {}: {}", url, e);
         }
     }
-
-    // Record the attempt time regardless of success/failure
-    // so we don't retry unreachable peers on every request.
-    guard.fetched_at = Some(Instant::now());
 
     guard.downgrade()
 }
@@ -344,5 +437,141 @@ mod tests {
         assert!(bloom.contains("abc123def456ghi789jkl012mno345pq"));
         assert!(bloom.contains("xyz789abc123def456ghi012jkl345mno"));
         assert!(!bloom.contains("000000000000000000000000000000aa"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_fresh() {
+        let entry = PeerBloomEntry {
+            bloom: None,
+            fetched_at: Some(Instant::now()),
+            last_attempt_at: None,
+        };
+        let ttl = Duration::from_secs(5);
+        let max_age = Duration::from_secs(10);
+        assert!(matches!(entry.freshness(ttl, max_age), Freshness::Fresh));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_stale() {
+        let entry = PeerBloomEntry {
+            bloom: None,
+            fetched_at: Some(Instant::now()),
+            last_attempt_at: None,
+        };
+        let ttl = Duration::from_secs(5);
+        let max_age = Duration::from_secs(10);
+        tokio::time::advance(Duration::from_secs(7)).await;
+        assert!(matches!(entry.freshness(ttl, max_age), Freshness::Stale));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_expired() {
+        let entry = PeerBloomEntry {
+            bloom: None,
+            fetched_at: Some(Instant::now()),
+            last_attempt_at: None,
+        };
+        let ttl = Duration::from_secs(5);
+        let max_age = Duration::from_secs(10);
+        tokio::time::advance(Duration::from_secs(15)).await;
+        assert!(matches!(entry.freshness(ttl, max_age), Freshness::Expired));
+    }
+
+    #[test]
+    fn test_freshness_no_fetched_at() {
+        let entry = PeerBloomEntry {
+            bloom: None,
+            fetched_at: None,
+            last_attempt_at: None,
+        };
+        let ttl = Duration::from_secs(5);
+        let max_age = Duration::from_secs(10);
+        assert!(matches!(entry.freshness(ttl, max_age), Freshness::Expired));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_evict_keeps_stale_removes_expired() {
+        let peer_blooms = PeerBlooms::new(Duration::from_secs(5), Duration::from_secs(10), 1024, 2);
+
+        // Insert entry A at time 0 (will become expired after 15s)
+        {
+            let mut peers = peer_blooms.peers.write().await;
+            let entry = PeerBloomEntry {
+                fetched_at: Some(Instant::now()),
+                ..Default::default()
+            };
+            peers.insert(
+                "http://expired-peer:35742".to_string(),
+                Arc::new(RwLock::new(entry)),
+            );
+        }
+
+        // Advance 7s, then insert entry B (will be stale at 15s total)
+        tokio::time::advance(Duration::from_secs(7)).await;
+        {
+            let mut peers = peer_blooms.peers.write().await;
+            let entry = PeerBloomEntry {
+                fetched_at: Some(Instant::now()),
+                ..Default::default()
+            };
+            peers.insert(
+                "http://stale-peer:35742".to_string(),
+                Arc::new(RwLock::new(entry)),
+            );
+        }
+
+        // Advance 8 more seconds.
+        // Entry A: elapsed = 15s > max_age=10s → Expired
+        // Entry B: elapsed = 8s, > ttl=5s but < max_age=10s → Stale
+        tokio::time::advance(Duration::from_secs(8)).await;
+
+        peer_blooms.evict_expired().await;
+
+        let peers = peer_blooms.peers.read().await;
+        assert!(
+            !peers.contains_key("http://expired-peer:35742"),
+            "expired entry should have been evicted"
+        );
+        assert!(
+            peers.contains_key("http://stale-peer:35742"),
+            "stale entry should have been kept"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_next_eviction_time_uses_max_age() {
+        let peer_blooms = PeerBlooms::new(Duration::from_secs(5), Duration::from_secs(10), 1024, 2);
+        {
+            let mut peers = peer_blooms.peers.write().await;
+            let entry = PeerBloomEntry {
+                fetched_at: Some(Instant::now()),
+                ..Default::default()
+            };
+            peers.insert(
+                "http://test-peer:35742".to_string(),
+                Arc::new(RwLock::new(entry)),
+            );
+        }
+
+        let eviction_time = peer_blooms.next_eviction_time().await;
+        // fetched_at + max_age, not fetched_at + ttl
+        assert_eq!(
+            eviction_time,
+            Some(Instant::now() + Duration::from_secs(10))
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_freshness_no_stale_window_when_max_age_equals_ttl() {
+        let entry = PeerBloomEntry {
+            bloom: None,
+            fetched_at: Some(Instant::now()),
+            last_attempt_at: None,
+        };
+        let ttl = Duration::from_secs(5);
+        let max_age = Duration::from_secs(5); // same as ttl — no stale window
+        tokio::time::advance(Duration::from_secs(6)).await;
+        // Should be Expired directly — no Stale state possible
+        assert!(matches!(entry.freshness(ttl, max_age), Freshness::Expired));
     }
 }

--- a/src/ogygia-irisd/src/config.rs
+++ b/src/ogygia-irisd/src/config.rs
@@ -47,6 +47,9 @@ pub struct BloomConfig {
     /// Peer bloom cache TTL in seconds
     #[serde(default = "default_peer_bloom_ttl_secs")]
     pub peer_bloom_ttl_secs: u64,
+    /// Maximum age for peer bloom cache in seconds (defaults to 2× TTL)
+    #[serde(default)]
+    pub peer_bloom_max_age_secs: Option<u64>,
 }
 
 fn default_false_positive_rate() -> f64 {
@@ -61,12 +64,22 @@ fn default_peer_bloom_ttl_secs() -> u64 {
     300
 }
 
+impl BloomConfig {
+    /// Returns the maximum age for peer bloom cache in seconds.
+    /// Defaults to 2× the TTL if not explicitly configured.
+    pub fn max_age_secs(&self) -> u64 {
+        self.peer_bloom_max_age_secs
+            .unwrap_or(self.peer_bloom_ttl_secs * 2)
+    }
+}
+
 impl Default for BloomConfig {
     fn default() -> Self {
         Self {
             false_positive_rate: default_false_positive_rate(),
             rebuild_threshold: default_rebuild_threshold(),
             peer_bloom_ttl_secs: default_peer_bloom_ttl_secs(),
+            peer_bloom_max_age_secs: None,
         }
     }
 }
@@ -147,6 +160,15 @@ pub fn load_config(path: Option<&Path>) -> Result<Config> {
 
     let config: Config = toml::from_str(&content)
         .with_context(|| format!("Failed to parse config file: {}", config_path.display()))?;
+
+    // Validate bloom configuration: max_age must be >= ttl
+    if config.bloom.max_age_secs() < config.bloom.peer_bloom_ttl_secs {
+        anyhow::bail!(
+            "bloom.peer_bloom_max_age_secs ({}) must be >= bloom.peer_bloom_ttl_secs ({})",
+            config.bloom.max_age_secs(),
+            config.bloom.peer_bloom_ttl_secs
+        );
+    }
 
     Ok(config)
 }
@@ -233,5 +255,59 @@ listen = ["127.0.0.1:35742"]
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert!(config.trust.trusted_keys.is_empty());
+    }
+
+    #[test]
+    fn test_parse_config_max_age_default() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+
+[bloom]
+peer_bloom_ttl_secs = 300
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.bloom.peer_bloom_ttl_secs, 300);
+        assert_eq!(config.bloom.max_age_secs(), 600);
+    }
+
+    #[test]
+    fn test_parse_config_max_age_explicit() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+
+[bloom]
+peer_bloom_ttl_secs = 300
+peer_bloom_max_age_secs = 900
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.bloom.peer_bloom_ttl_secs, 300);
+        assert_eq!(config.bloom.max_age_secs(), 900);
+    }
+
+    #[test]
+    fn test_config_max_age_validation() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+
+[bloom]
+peer_bloom_ttl_secs = 300
+peer_bloom_max_age_secs = 200
+"#;
+        // Write to a temp file and test load_config validation
+        let temp_dir = std::env::temp_dir();
+        let config_path = temp_dir.join("test_invalid_max_age.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        let result = load_config(Some(&config_path));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("peer_bloom_max_age_secs"));
+        assert!(err_msg.contains("peer_bloom_ttl_secs"));
+
+        // Clean up
+        let _ = std::fs::remove_file(&config_path);
     }
 }

--- a/src/ogygia-irisd/src/main.rs
+++ b/src/ogygia-irisd/src/main.rs
@@ -3,13 +3,13 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
 use tokio::signal;
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
 
@@ -57,6 +57,7 @@ async fn main() -> Result<()> {
     ));
     let peer_blooms = Arc::new(bloom::peers::PeerBlooms::new(
         Duration::from_secs(config.bloom.peer_bloom_ttl_secs),
+        Duration::from_secs(config.bloom.max_age_secs()),
         local_bloom.num_bits(),
         local_bloom.num_hashes(),
     ));
@@ -154,7 +155,7 @@ async fn main() -> Result<()> {
                     .next_eviction_time()
                     .await
                     .map(|t| t.saturating_duration_since(Instant::now()))
-                    .unwrap_or(peer_blooms.ttl());
+                    .unwrap_or(peer_blooms.max_age());
                 tokio::select! {
                     _ = token.cancelled() => {
                         tracing::info!("Peer bloom eviction shutting down");

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -599,7 +599,12 @@ mod tests {
             Arc::new(AppState {
                 config: Arc::new(config),
                 local_bloom,
-                peer_blooms: Arc::new(PeerBlooms::new(Duration::from_secs(300), 0, 0)),
+                peer_blooms: Arc::new(PeerBlooms::new(
+                    Duration::from_secs(300),
+                    Duration::from_secs(600),
+                    0,
+                    0,
+                )),
                 http_client: reqwest::Client::new(),
                 nar_cache,
             })


### PR DESCRIPTION
Peer bloom filters used a single TTL that controlled both when blooms were discarded and when re-fetches were triggered. This meant that once a bloom expired, requests would block waiting for a fresh fetch from the peer, adding latency to cache lookups.

This commit adds a second TTL (peer_bloom_max_age_secs) implementing stale-while-revalidate semantics following DNS RFC 8767 / HTTP RFC 5861. After the fresh TTL expires, stale blooms are served immediately while a background fetch is triggered. Only after the max age expires are blooms discarded and requests blocked on a fetch. A refreshing flag on each entry prevents thundering herd when multiple requests hit the same stale peer. The max_age defaults to 2x the TTL if not explicitly set, and config validation rejects max_age < ttl. PeerBloomEntry.fetched_at was switched from std::time::Instant to tokio::time::Instant to enable time-controlled testing.

This allows peer bloom lookups to continue serving cached data during background revalidation, reducing request latency while still ensuring blooms age out and are eventually refreshed.

Test plan:
- All 45 tests pass including 7 new dual-TTL freshness tests.
- cargo clippy -- -D warnings passes with zero warnings.
- Config validation rejects max_age < ttl with descriptive error.
- Config without max_age defaults to 2x ttl.
- Stale blooms served immediately (non-blocking) while background fetch runs.
- Expired blooms block on fetch (preserved behavior).
- Eviction uses max_age, keeping stale entries, removing expired ones.