### PR TITLE
irisd: add CUSUM-based burst detection for bloom filter rebuilds

### DIFF
--- a/src/ogygia-irisd/src/bloom/burst.rs
+++ b/src/ogygia-irisd/src/bloom/burst.rs
@@ -1,0 +1,418 @@
+//! Burst detection for deletion events using a CUSUM algorithm.
+//!
+//! Detects bursts of deletion activity to suppress bloom-filter rebuilds
+//! during high-churn periods.  When a burst is active, `should_rebuild`
+//! returns `false` so that the filter is not rebuilt while the deletion
+//! rate is elevated.  After the burst subsides the detector enters a
+//! cooldown grace period before returning to `Steady`.
+
+use std::time::Duration;
+use std::time::Instant;
+
+/// Operating regime of the burst detector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Regime {
+    /// Normal steady-state operation.
+    Steady,
+    /// Deletion burst detected; rebuilds are suppressed.
+    Burst,
+    /// Cooldown period after a burst before returning to Steady.
+    Cooldown,
+}
+
+/// Detects bursts of deletion events using a CUSUM algorithm.
+pub struct BurstDetector {
+    k: f64,
+    h: f64,
+    max_cooldown: Duration,
+    cusum: f64,
+    regime: Regime,
+    burst_start: Option<Instant>,
+    cooldown_start: Option<Instant>,
+    last_tick: Instant,
+}
+
+impl BurstDetector {
+    /// Create a new burst detector.
+    ///
+    /// # Arguments
+    /// * `k` — CUSUM reference value (sensitivity).
+    /// * `h` — Threshold for entering the `Burst` regime.  `0.0` disables
+    ///   burst detection entirely.
+    /// * `max_cooldown` — Maximum time to stay in `Burst` before a rebuild
+    ///   is forced, and also the cooldown duration before returning to
+    ///   `Steady`.
+    pub fn new(k: f64, h: f64, max_cooldown: Duration) -> Self {
+        Self {
+            k,
+            h,
+            max_cooldown,
+            cusum: 0.0,
+            regime: Regime::Steady,
+            burst_start: None,
+            cooldown_start: None,
+            last_tick: Instant::now(),
+        }
+    }
+
+    /// Record a deletion event.
+    pub fn observe_deletion(&mut self) {
+        self.cusum = (self.cusum + 1.0 - self.k).max(0.0);
+        if self.h > 0.0 && self.cusum > self.h && self.regime != Regime::Burst {
+            self.regime = Regime::Burst;
+            self.burst_start = Some(Instant::now());
+        }
+    }
+
+    /// Advance the detector's internal clock to `now`, applying CUSUM
+    /// decay and evaluating regime transitions.
+    pub fn tick(&mut self, now: Instant) {
+        let elapsed = now.duration_since(self.last_tick);
+        self.last_tick = now;
+        self.cusum = (self.cusum - elapsed.as_secs_f64()).max(0.0);
+
+        match self.regime {
+            Regime::Burst => {
+                if self.cusum == 0.0 {
+                    if let Some(start) = self.burst_start {
+                        if now > start + self.max_cooldown {
+                            self.regime = Regime::Steady;
+                            self.burst_start = None;
+                        } else {
+                            self.regime = Regime::Cooldown;
+                            self.cooldown_start = Some(now);
+                        }
+                    } else {
+                        self.regime = Regime::Cooldown;
+                        self.cooldown_start = Some(now);
+                    }
+                }
+            }
+            Regime::Cooldown => {
+                if self.cusum > self.h {
+                    self.regime = Regime::Burst;
+                    self.burst_start = Some(now);
+                } else if let Some(start) = self.cooldown_start
+                    && now > start + self.max_cooldown
+                {
+                    self.regime = Regime::Steady;
+                }
+            }
+            Regime::Steady => {}
+        }
+    }
+
+    /// Current operating regime.
+    #[allow(dead_code)]
+    pub fn regime(&self) -> Regime {
+        self.regime
+    }
+
+    /// Current CUSUM value.
+    #[allow(dead_code)]
+    pub fn cusum(&self) -> f64 {
+        self.cusum
+    }
+
+    /// Whether a rebuild should proceed given the current deletion ratio
+    /// and time.
+    ///
+    /// Returns `false` during `Burst` or `Cooldown` to suppress rebuilds.
+    /// Returns `true` in `Steady` when `deletion_ratio` exceeds the
+    /// threshold (0.005).  Forces `true` if the detector has been in
+    /// `Burst` for longer than `max_cooldown`.
+    pub fn should_rebuild(&self, deletion_ratio: f64, now: Instant) -> bool {
+        const REBUILD_THRESHOLD: f64 = 0.005;
+        if self.h == 0.0 {
+            return deletion_ratio > REBUILD_THRESHOLD;
+        }
+        match self.regime {
+            Regime::Burst => {
+                if let Some(start) = self.burst_start
+                    && now > start + self.max_cooldown
+                {
+                    return true;
+                }
+                false
+            }
+            Regime::Cooldown => false,
+            Regime::Steady => deletion_ratio > REBUILD_THRESHOLD,
+        }
+    }
+
+    /// Mark that a rebuild has occurred, resetting CUSUM and regime.
+    pub fn mark_rebuilt(&mut self, _now: Instant) {
+        self.cusum = 0.0;
+        self.regime = Regime::Steady;
+        self.burst_start = None;
+        self.cooldown_start = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_steady_no_burst() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        for _ in 0..2 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_steady_to_burst() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+    }
+
+    #[test]
+    fn test_burst_to_cooldown() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        detector.tick(now + Duration::from_secs(5));
+        assert_eq!(detector.regime(), Regime::Cooldown);
+    }
+
+    #[test]
+    fn test_cooldown_to_steady() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(1));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        detector.tick(now + Duration::from_secs(5));
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_burst_resumed_from_cooldown() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        detector.tick(now + Duration::from_secs(5));
+        assert_eq!(detector.regime(), Regime::Cooldown);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+    }
+
+    #[test]
+    fn test_should_rebuild_steady_below_threshold() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        assert!(!detector.should_rebuild(0.001, now));
+    }
+
+    #[test]
+    fn test_should_rebuild_burst_suppresses() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert!(!detector.should_rebuild(0.01, now));
+    }
+
+    #[test]
+    fn test_should_rebuild_cooldown_suppresses() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        detector.tick(now + Duration::from_secs(5));
+        assert_eq!(detector.regime(), Regime::Cooldown);
+        assert!(!detector.should_rebuild(0.01, now + Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn test_should_rebuild_steady_above_threshold() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        assert!(detector.should_rebuild(0.01, now));
+    }
+
+    #[test]
+    fn test_forced_rebuild_after_max_cooldown() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_millis(100));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        assert!(detector.should_rebuild(0.01, now + Duration::from_millis(150)));
+    }
+
+    #[test]
+    fn test_cusum_reset_on_rebuild() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        assert!(detector.cusum() > 0.0);
+        detector.mark_rebuilt(now);
+        assert_eq!(detector.cusum(), 0.0);
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_disabled_burst_detection() {
+        let mut detector = BurstDetector::new(0.5, 0.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..100 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_rapid_deletions_trigger_burst() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(1));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..200 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        assert!(!detector.should_rebuild(0.01, now));
+        detector.tick(now + Duration::from_secs(200));
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_slow_trickle_does_not_trigger_burst() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for i in 0..200 {
+            detector.observe_deletion();
+            detector.tick(now + Duration::from_secs((i + 1) * 10));
+        }
+        assert_eq!(detector.regime(), Regime::Steady);
+        assert!(detector.should_rebuild(0.01, now + Duration::from_secs(200 * 10)));
+    }
+
+    #[test]
+    fn test_intermittent_burst_resets_cooldown() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        detector.tick(now + Duration::from_secs(5));
+        assert_eq!(detector.regime(), Regime::Cooldown);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+    }
+
+    #[test]
+    fn test_forced_rebuild_timing() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_millis(100));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        let later = now + Duration::from_millis(150);
+        assert!(detector.should_rebuild(0.01, later));
+        detector.mark_rebuilt(later);
+        assert_eq!(detector.cusum(), 0.0);
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_cusum_accumulation_pattern() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..5 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.cusum(), 2.5);
+        detector.tick(now);
+        assert_eq!(detector.cusum(), 2.5);
+        for _ in 0..2 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.cusum(), 3.5);
+        assert_eq!(detector.regime(), Regime::Burst);
+    }
+
+    #[test]
+    fn test_zero_h_disables_burst_detection() {
+        let mut detector = BurstDetector::new(0.5, 0.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..100 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Steady);
+        assert!(!detector.should_rebuild(0.001, now));
+        assert!(detector.should_rebuild(0.01, now));
+    }
+
+    #[test]
+    fn test_mark_rebuilt_resets_everything() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(60));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        assert!(detector.cusum() > 0.0);
+        detector.mark_rebuilt(now);
+        assert_eq!(detector.cusum(), 0.0);
+        assert_eq!(detector.regime(), Regime::Steady);
+    }
+
+    #[test]
+    fn test_cooldown_expires_allows_rebuild() {
+        let mut detector = BurstDetector::new(0.5, 3.0, Duration::from_secs(5));
+        let now = Instant::now();
+        detector.tick(now);
+        for _ in 0..7 {
+            detector.observe_deletion();
+        }
+        assert_eq!(detector.regime(), Regime::Burst);
+        let cooldown_time = now + Duration::from_secs(4);
+        detector.tick(cooldown_time);
+        assert_eq!(detector.regime(), Regime::Cooldown);
+        assert!(!detector.should_rebuild(0.01, cooldown_time));
+        let steady_time = now + Duration::from_secs(10);
+        detector.tick(steady_time);
+        assert_eq!(detector.regime(), Regime::Steady);
+        assert!(detector.should_rebuild(0.01, steady_time));
+    }
+}

--- a/src/ogygia-irisd/src/bloom/local.rs
+++ b/src/ogygia-irisd/src/bloom/local.rs
@@ -9,9 +9,11 @@
 //! it with a cluster-derived measurement.
 
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use anyhow::Result;
 use arc_swap::ArcSwapOption;
@@ -82,6 +84,7 @@ pub struct LocalBloom {
     num_bits: usize,
     num_hashes: u32,
     rebuild_threshold: f64,
+    last_rebuild_at: Mutex<Instant>,
 }
 
 impl LocalBloom {
@@ -107,6 +110,7 @@ impl LocalBloom {
             num_bits,
             num_hashes,
             rebuild_threshold,
+            last_rebuild_at: Mutex::new(Instant::now()),
         }
     }
 
@@ -179,6 +183,10 @@ impl LocalBloom {
             Arc::clone(&state.filter)
         };
         self.read_bloom.store(Some(filter));
+        *self
+            .last_rebuild_at
+            .lock()
+            .expect("last_rebuild_at poisoned") = Instant::now();
     }
 
     /// Number of bits in the bloom filter (for peer bloom size validation).
@@ -191,14 +199,25 @@ impl LocalBloom {
         self.num_hashes
     }
 
+    /// Number of elements currently in the bloom filter.
     pub fn element_count(&self) -> usize {
         let state = self.write_bloom.read().expect("write_bloom poisoned");
         state.element_count.load(Ordering::Relaxed)
     }
 
+    /// Number of deletions recorded since the last rebuild.
     pub fn deletion_count(&self) -> usize {
         let state = self.write_bloom.read().expect("write_bloom poisoned");
         state.deletion_count.load(Ordering::Relaxed)
+    }
+
+    /// Timestamp of the most recent rebuild completion.
+    #[allow(dead_code)]
+    pub fn last_rebuild_at(&self) -> Instant {
+        *self
+            .last_rebuild_at
+            .lock()
+            .expect("last_rebuild_at poisoned")
     }
 }
 
@@ -260,5 +279,26 @@ mod tests {
 
         bloom.finish_rebuild();
         assert!(bloom.serialize().unwrap().is_some());
+    }
+
+    #[test]
+    fn last_rebuild_at_updates_on_finish_rebuild() {
+        let bloom = LocalBloom::new(0.01, 0.1);
+        let before = bloom.last_rebuild_at();
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        bloom.insert("abc123def456ghi789jkl012mno345pq");
+        bloom.finish_rebuild();
+
+        let after = bloom.last_rebuild_at();
+        assert!(
+            after > before,
+            "last_rebuild_at should advance after finish_rebuild"
+        );
+        assert!(
+            after.elapsed() < std::time::Duration::from_secs(1),
+            "last_rebuild_at should be very recent"
+        );
     }
 }

--- a/src/ogygia-irisd/src/bloom/mod.rs
+++ b/src/ogygia-irisd/src/bloom/mod.rs
@@ -3,6 +3,7 @@
 /// Fixed seed so all nodes produce compatible hashes.
 const BLOOM_SEED: u128 = 0x0009_791a_1215_b100_5eed_2025;
 
+pub mod burst;
 pub mod local;
 pub mod peers;
 pub mod wire;

--- a/src/ogygia-irisd/src/config.rs
+++ b/src/ogygia-irisd/src/config.rs
@@ -50,6 +50,15 @@ pub struct BloomConfig {
     /// Maximum age for peer bloom cache in seconds (defaults to 2× TTL)
     #[serde(default)]
     pub peer_bloom_max_age_secs: Option<u64>,
+    /// CUSUM reference value for burst detection
+    #[serde(default = "default_burst_k")]
+    pub burst_k: f64,
+    /// CUSUM decision threshold for burst detection (0.0 = disabled)
+    #[serde(default = "default_burst_h")]
+    pub burst_h: f64,
+    /// Max seconds to defer rebuilds during burst (0 = disabled)
+    #[serde(default = "default_burst_max_cooldown_secs")]
+    pub burst_max_cooldown_secs: u64,
 }
 
 fn default_false_positive_rate() -> f64 {
@@ -62,6 +71,18 @@ fn default_rebuild_threshold() -> f64 {
 
 fn default_peer_bloom_ttl_secs() -> u64 {
     300
+}
+
+fn default_burst_k() -> f64 {
+    1.0
+}
+
+fn default_burst_h() -> f64 {
+    0.0
+}
+
+fn default_burst_max_cooldown_secs() -> u64 {
+    0
 }
 
 impl BloomConfig {
@@ -80,6 +101,9 @@ impl Default for BloomConfig {
             rebuild_threshold: default_rebuild_threshold(),
             peer_bloom_ttl_secs: default_peer_bloom_ttl_secs(),
             peer_bloom_max_age_secs: None,
+            burst_k: default_burst_k(),
+            burst_h: default_burst_h(),
+            burst_max_cooldown_secs: default_burst_max_cooldown_secs(),
         }
     }
 }
@@ -167,6 +191,15 @@ pub fn load_config(path: Option<&Path>) -> Result<Config> {
             "bloom.peer_bloom_max_age_secs ({}) must be >= bloom.peer_bloom_ttl_secs ({})",
             config.bloom.max_age_secs(),
             config.bloom.peer_bloom_ttl_secs
+        );
+    }
+
+    // Validate burst configuration: if burst detection is enabled, cooldown must be > 0
+    if config.bloom.burst_h > 0.0 && config.bloom.burst_max_cooldown_secs == 0 {
+        anyhow::bail!(
+            "bloom.burst_max_cooldown_secs must be > 0 when bloom.burst_h is enabled (got burst_h={}, burst_max_cooldown_secs={})",
+            config.bloom.burst_h,
+            config.bloom.burst_max_cooldown_secs
         );
     }
 
@@ -308,6 +341,78 @@ peer_bloom_max_age_secs = 200
         assert!(err_msg.contains("peer_bloom_ttl_secs"));
 
         // Clean up
+        let _ = std::fs::remove_file(&config_path);
+    }
+
+    #[test]
+    fn test_burst_config_defaults() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!((config.bloom.burst_k - 1.0).abs() < f64::EPSILON);
+        assert!((config.bloom.burst_h - 0.0).abs() < f64::EPSILON);
+        assert_eq!(config.bloom.burst_max_cooldown_secs, 0);
+    }
+
+    #[test]
+    fn test_burst_config_explicit() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+
+[bloom]
+burst_k = 2.0
+burst_h = 5.0
+burst_max_cooldown_secs = 60
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!((config.bloom.burst_k - 2.0).abs() < f64::EPSILON);
+        assert!((config.bloom.burst_h - 5.0).abs() < f64::EPSILON);
+        assert_eq!(config.bloom.burst_max_cooldown_secs, 60);
+    }
+
+    #[test]
+    fn test_burst_config_validation_rejects_zero_cooldown() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+
+[bloom]
+burst_h = 5.0
+burst_max_cooldown_secs = 0
+"#;
+        let temp_dir = std::env::temp_dir();
+        let config_path = temp_dir.join("test_invalid_burst.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        let result = load_config(Some(&config_path));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("burst_max_cooldown_secs"));
+        assert!(err_msg.contains("burst_h"));
+
+        let _ = std::fs::remove_file(&config_path);
+    }
+
+    #[test]
+    fn test_burst_config_validation_accepts_disabled() {
+        let toml = r#"
+[server]
+listen = ["127.0.0.1:35742"]
+
+[bloom]
+burst_h = 0.0
+burst_max_cooldown_secs = 0
+"#;
+        let temp_dir = std::env::temp_dir();
+        let config_path = temp_dir.join("test_disabled_burst.toml");
+        std::fs::write(&config_path, toml).unwrap();
+
+        let result = load_config(Some(&config_path));
+        assert!(result.is_ok());
+
         let _ = std::fs::remove_file(&config_path);
     }
 }

--- a/src/ogygia-irisd/src/main.rs
+++ b/src/ogygia-irisd/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -111,7 +112,7 @@ async fn main() -> Result<()> {
     // HTTP server: started before the store scan so we serve peer lookups
     // immediately. GET /bloom returns 503 until the initial scan completes.
     tasks.push(tokio::spawn(server::start(
-        config,
+        Arc::clone(&config),
         Arc::clone(&local_bloom),
         Arc::clone(&peer_blooms),
         http_client,
@@ -139,8 +140,17 @@ async fn main() -> Result<()> {
     if !cli.no_watch {
         let bloom = Arc::clone(&local_bloom);
         let token = token.clone();
+        let burst_detector = Arc::new(Mutex::new(bloom::burst::BurstDetector::new(
+            config.bloom.burst_k,
+            config.bloom.burst_h,
+            Duration::from_secs(config.bloom.burst_max_cooldown_secs),
+        )));
         tasks.push(tokio::spawn(async move {
-            let watcher = Arc::new(store::watcher::StoreWatcher::new(bloom, rebuild_tx));
+            let watcher = Arc::new(store::watcher::StoreWatcher::new(
+                bloom,
+                rebuild_tx,
+                burst_detector,
+            ));
             watcher.start(token).await
         }));
     }

--- a/src/ogygia-irisd/src/store/watcher.rs
+++ b/src/ogygia-irisd/src/store/watcher.rs
@@ -6,6 +6,8 @@
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Instant;
 
 use anyhow::Result;
 use notify::Config;
@@ -24,12 +26,21 @@ use crate::nix::store::PathInfo;
 pub struct StoreWatcher {
     bloom: Arc<LocalBloom>,
     rebuild_tx: mpsc::Sender<()>,
+    burst_detector: Arc<Mutex<crate::bloom::burst::BurstDetector>>,
 }
 
 impl StoreWatcher {
     /// Create a new store watcher with a channel for requesting rebuilds.
-    pub fn new(bloom: Arc<LocalBloom>, rebuild_tx: mpsc::Sender<()>) -> Self {
-        Self { bloom, rebuild_tx }
+    pub fn new(
+        bloom: Arc<LocalBloom>,
+        rebuild_tx: mpsc::Sender<()>,
+        burst_detector: Arc<Mutex<crate::bloom::burst::BurstDetector>>,
+    ) -> Self {
+        Self {
+            bloom,
+            rebuild_tx,
+            burst_detector,
+        }
     }
 
     /// Start watching /nix/store for new and removed paths
@@ -130,13 +141,41 @@ impl StoreWatcher {
         self.bloom.mark_deletion();
         tracing::debug!("Noted store path removal: {}", store_path);
 
-        if self.bloom.needs_rebuild() {
+        self.burst_detector
+            .lock()
+            .expect("burst_detector poisoned")
+            .observe_deletion();
+
+        let bloom = &self.bloom;
+        let deletion_ratio = if bloom.element_count() == 0 {
+            0.0
+        } else {
+            bloom.deletion_count() as f64 / bloom.element_count() as f64
+        };
+
+        let now = Instant::now();
+        self.burst_detector
+            .lock()
+            .expect("burst_detector poisoned")
+            .tick(now);
+
+        let should_rebuild = self
+            .burst_detector
+            .lock()
+            .expect("burst_detector poisoned")
+            .should_rebuild(deletion_ratio, now);
+
+        if should_rebuild && self.bloom.needs_rebuild() {
             tracing::info!(
                 "Bloom filter deletion threshold exceeded ({} deletions / {} elements), requesting rebuild",
                 self.bloom.deletion_count(),
                 self.bloom.element_count(),
             );
             let _ = self.rebuild_tx.try_send(());
+            self.burst_detector
+                .lock()
+                .expect("burst_detector poisoned")
+                .mark_rebuilt(now);
         }
     }
 }


### PR DESCRIPTION
During nix store gc, deletions arrive in massive bursts via inotify, triggering repeated bloom filter rebuilds. Each rebuild rescans the entire store, causing unnecessary disk load and wasted work.

This change adds a BurstDetector using the CUSUM (cumulative sum) algorithm to distinguish burst deletion patterns from steady trickle deletions. When a burst is detected, rebuilds are deferred until the burst subsides or a configurable max cooldown is reached.

The implementation uses a three-state regime (Steady/Burst/Cooldown) with per-event CUSUM tracking. All parameters are configurable via bloom config fields (burst_k, burst_h, burst_max_cooldown_secs). By default burst detection is disabled (burst_h = 0.0), preserving existing behavior until explicitly enabled.

Test plan:
- Added 20 burst detector tests covering regime transitions, CUSUM accumulation, forced rebuild timing, and edge cases
- Added 4 config tests for parsing, defaults, and validation
- All 70 irisd tests pass, clippy clean with no warnings