### PR TITLE
nebula: add opinionated overlay network with content-addressed certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,10 +1873,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "which",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -239,6 +239,12 @@
               ogygiaModule = self.nixosModules.default;
             };
 
+            ogygia-nebula-module = import ./nixos/tests/nebula-module.nix {
+              inherit pkgs;
+              inherit (nixpkgs) lib;
+              ogygiaModule = self.nixosModules.default;
+            };
+
           } // lib.optionalAttrs (system == "x86_64-linux") {
             ogygia-irisd-local = import ./nixos/tests/irisd-local.nix {
               inherit pkgs system;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -19,12 +19,6 @@ in
       example = "https://git.example.com/user/nixos.git";
     };
 
-    nebula.ipv4 = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "This node's Nebula IPv4 address for internal P2P communication.";
-      example = "172.20.0.1";
-    };
   };
 
   imports = [
@@ -33,6 +27,7 @@ in
     ./config-generator
     ./etcd
     ./irisd
+    ./nebula
     ./hostinfod
     ./dashboard
   ];

--- a/nixos/nebula/default.nix
+++ b/nixos/nebula/default.nix
@@ -1,0 +1,279 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.ogygia.nebula;
+  topology = cfg.topology;
+
+  # Per nixos/'s pattern, every host in the fleet imports the same `topology`
+  # block and self-identifies against it via its FQDN. `fqdnOrHostName` falls
+  # back to the bare hostname when `networking.domain` is unset.
+  hostFqdn = config.networking.fqdnOrHostName;
+  hostRecord = topology.hosts.${hostFqdn} or null;
+
+  isLighthouse = builtins.elem hostFqdn topology.lighthouses;
+  isRelay = builtins.elem hostFqdn topology.relays;
+
+  hostIpv4 = if hostRecord != null then hostRecord.ipv4 else null;
+  hostSubnet = topology.subnet;
+
+  ready =
+    cfg.enable && cfg.pubKey != null && hostIpv4 != null
+    && hostSubnet != null && cfg.certDir != null;
+
+  caCertFile = if cfg.certDir != null then cfg.certDir + "/ca.crt" else null;
+
+  sortedGroups = lib.lists.unique (lib.sort (a: b: a < b) cfg.groups);
+
+  spec =
+    if !ready then null
+    else {
+      name = hostFqdn;
+      ipv4 = hostIpv4;
+      subnet = hostSubnet;
+      pubKey = cfg.pubKey;
+      groups = sortedGroups;
+      caFingerprint = builtins.hashFile "sha256" caCertFile;
+      version = 2;
+    };
+
+  specHash =
+    if spec == null then null
+    else builtins.substring 0 32 (builtins.hashString "sha256" (builtins.toJSON spec));
+
+  certPath =
+    if specHash == null then null
+    else cfg.certDir + "/${specHash}.crt";
+
+  # Auto-derive lighthouse/relay/staticHostMap from the shared topology block.
+  # On lighthouses themselves we leave the lists empty (they serve, not query).
+  derivedLighthouseIps =
+    if isLighthouse then [ ]
+    else map (l: topology.hosts.${l}.ipv4) topology.lighthouses;
+
+  derivedRelayIps =
+    if isRelay then [ ]
+    else map (r: topology.hosts.${r}.ipv4) topology.relays;
+
+  derivedStaticHostMap = lib.listToAttrs (map
+    (l: lib.nameValuePair topology.hosts.${l}.ipv4 [ topology.hosts.${l}.endpoint ])
+    topology.lighthouses);
+
+  firewallRuleType = lib.types.submodule {
+    freeformType = (pkgs.formats.yaml { }).type;
+  };
+
+  hostType = lib.types.submodule {
+    options = {
+      ipv4 = lib.mkOption {
+        type = lib.types.str;
+        description = "This host's Nebula IPv4 address (no CIDR mask).";
+        example = "10.42.0.1";
+      };
+      endpoint = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Publicly reachable `host:port` for this node. Required when the host
+          appears in `topology.lighthouses` (so other hosts can bootstrap a
+          tunnel via the public internet). Ignored for non-lighthouses.
+        '';
+        example = "lighthouse-1.public.example.com:4242";
+      };
+    };
+  };
+
+in
+{
+  options.ogygia.nebula = {
+    enable = lib.mkEnableOption "ogygia-managed Nebula overlay network";
+
+    pubKey = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        PEM-formatted Nebula public key for this host. Capture once with
+        `ogygia nebula keygen <host>` then paste verbatim. Must be set when
+        `ogygia.nebula.enable = true`; the build fails otherwise.
+      '';
+    };
+
+    groups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Group tags to embed in this host's Nebula certificate. Any module
+        in the host's configuration can append to this list — groups are
+        deduplicated and sorted before being incorporated into the cert
+        spec hash.
+      '';
+      example = [ "ssh" "etcd-server" ];
+    };
+
+    firewall.inbound = lib.mkOption {
+      type = lib.types.listOf firewallRuleType;
+      default = [ ];
+      description = ''
+        Inbound Nebula firewall rules. Mergeable across modules so service
+        modules can ship their own rules alongside the cert groups they need.
+      '';
+      example = [{ port = 22; proto = "tcp"; groups = [ "ssh" ]; }];
+    };
+
+    firewall.outbound = lib.mkOption {
+      type = lib.types.listOf firewallRuleType;
+      default = [{ port = "any"; proto = "any"; host = "any"; }];
+      description = "Outbound Nebula firewall rules. Default: allow-all.";
+    };
+
+    certDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Directory containing the Nebula CA cert and host certificates.
+        Layout (certs are content-addressed by specHash; the spec includes
+        the host's pubKey so the hash is globally unique):
+
+          <certDir>/ca.crt
+          <certDir>/<specHash>.crt
+
+        Typically set once in a shared module imported by every host.
+      '';
+      example = lib.literalExpression "./nebula";
+    };
+
+    topology = {
+      subnet = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          CIDR of the Nebula mesh, e.g. "10.42.0.0/16". Combined with each
+          host's `topology.hosts.<fqdn>.ipv4` to form the certificate's
+          `-networks` spec at signing time.
+        '';
+        example = "10.42.0.0/16";
+      };
+
+      hosts = lib.mkOption {
+        type = lib.types.attrsOf hostType;
+        default = { };
+        description = ''
+          Every host in the mesh, keyed by FQDN — must match the value of
+          `config.networking.fqdnOrHostName` on that host. Set fleet-wide
+          via a shared module imported by every node.
+        '';
+      };
+
+      lighthouses = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = ''
+          FQDNs of hosts that act as lighthouses. Each must appear in
+          `topology.hosts` with `endpoint` set.
+        '';
+      };
+
+      relays = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "FQDNs of hosts that act as Nebula relays.";
+      };
+    };
+
+    # Read-only derived values. `ipv4` is exposed for consumers like
+    # `ogygia.irisd` that need this host's Nebula address as a bare IP;
+    # `spec`/`specHash`/`certPath` are surfaced for the `ogygia nebula` CLI
+    # via `nix eval`. All null when the host has no topology record.
+    ipv4 = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      readOnly = true;
+      default = hostIpv4;
+      description = "This host's Nebula IPv4 address (derived from topology.hosts).";
+    };
+
+    spec = lib.mkOption {
+      type = lib.types.nullOr lib.types.attrs;
+      readOnly = true;
+      default = spec;
+      description = "Canonical cert spec; hashed into specHash.";
+    };
+
+    specHash = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      readOnly = true;
+      default = specHash;
+      description = "First 32 hex chars of sha256(toJSON spec).";
+    };
+
+    certPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      readOnly = true;
+      default = certPath;
+      description = "Path to this host's content-addressed certificate.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.pubKey != null;
+        message = ''
+          ogygia.nebula.pubKey must be set when ogygia.nebula.enable is true.
+
+          Bootstrap: set `ogygia.nebula.enable = lib.mkForce false;` on this
+          host, switch once, then run `ogygia nebula keygen <host>` and paste
+          the printed public key into `ogygia.nebula.pubKey`.
+        '';
+      }
+      {
+        assertion = cfg.certDir != null;
+        message = "ogygia.nebula.certDir must be set when ogygia.nebula.enable is true.";
+      }
+      {
+        assertion = topology.subnet != null;
+        message = "ogygia.nebula.topology.subnet must be set (e.g. \"10.42.0.0/16\").";
+      }
+      {
+        assertion = hostRecord != null;
+        message = ''
+          this host (${hostFqdn}) is not enrolled in ogygia.nebula.topology.hosts.
+          Add an entry `topology.hosts."${hostFqdn}" = { ipv4 = "..."; };` in
+          your shared fleet module.
+        '';
+      }
+    ] ++ map
+      (l: {
+        assertion = (topology.hosts.${l} or null) != null
+          && (topology.hosts.${l}.endpoint or null) != null;
+        message = "lighthouse ${l} must appear in ogygia.nebula.topology.hosts with `endpoint` set.";
+      })
+      topology.lighthouses;
+
+    systemd.tmpfiles.rules = [ "d /etc/nebula 0700 root root - -" ];
+
+    services.nebula.networks.ogygia = {
+      ca = caCertFile;
+      cert = certPath;
+      key = "/etc/nebula/host.key";
+      inherit isLighthouse isRelay;
+      lighthouses = derivedLighthouseIps;
+      relays = derivedRelayIps;
+      staticHostMap = derivedStaticHostMap;
+      tun.device = "neb.ogygia";
+      listen = {
+        host = "[::]";
+        # Lighthouses bind a known port so clients can reach them via
+        # staticHostMap; other hosts use an ephemeral port (Nebula's default
+        # when not lighthousing/relaying).
+        port = if isLighthouse || isRelay then 4242 else 0;
+      };
+      firewall = {
+        inbound = cfg.firewall.inbound;
+        outbound = cfg.firewall.outbound;
+      };
+    };
+
+    # The mesh handles its own host-firewall via the cert-group rules above;
+    # let local services bind freely on the tun.
+    networking.firewall.trustedInterfaces = [ "neb.ogygia" ];
+  };
+}

--- a/nixos/tests/nebula-module.nix
+++ b/nixos/tests/nebula-module.nix
@@ -1,0 +1,206 @@
+{ pkgs, lib, ogygiaModule }:
+
+let
+  fakeCaCert = pkgs.writeText "ca.crt" "ogygia-test-ca-cert\n";
+  caFingerprint = builtins.hashFile "sha256" fakeCaCert;
+
+  expectedSpec = {
+    name = "testhost";
+    ipv4 = "10.42.0.5";
+    subnet = "10.42.0.0/16";
+    pubKey = "fake-pub-key-pem";
+    groups = [ "etcd-server" "ssh" ];
+    inherit caFingerprint;
+    version = 2;
+  };
+  expectedSpecHash = builtins.substring 0 32 (builtins.hashString "sha256" (builtins.toJSON expectedSpec));
+
+  certDir = pkgs.runCommand "ogygia-nebula-test-fixture" { } ''
+    mkdir -p $out
+    cp ${fakeCaCert} $out/ca.crt
+    echo "fake-cert-${expectedSpecHash}" > $out/${expectedSpecHash}.crt
+  '';
+
+  sharedTopology = {
+    subnet = "10.42.0.0/16";
+    hosts = {
+      "lighthouse-1" = { ipv4 = "10.42.0.1"; endpoint = "lh1.public.example.com:4242"; };
+      "testhost" = { ipv4 = "10.42.0.5"; };
+    };
+    lighthouses = [ "lighthouse-1" ];
+    relays = [ ];
+  };
+
+  baseModule = { lib, ... }: {
+    nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
+    networking.hostName = "testhost";
+    system.stateVersion = "25.05";
+    boot.loader.grub.enable = false;
+    fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
+    ogygia.nebula = {
+      enable = true;
+      pubKey = "fake-pub-key-pem";
+      groups = [ "ssh" "etcd-server" ];
+      inherit certDir;
+      topology = sharedTopology;
+    };
+  };
+
+  validSystem = lib.nixosSystem {
+    modules = [ ogygiaModule baseModule ];
+  };
+
+  firewallA = { ... }: {
+    ogygia.nebula.firewall.inbound = [
+      { port = 22; proto = "tcp"; groups = [ "ssh" ]; }
+    ];
+  };
+  firewallB = { ... }: {
+    ogygia.nebula.firewall.inbound = [
+      { port = 2379; proto = "tcp"; groups = [ "etcd-server" ]; }
+    ];
+    ogygia.nebula.groups = [ "client" ];
+  };
+
+  mergeSystem = lib.nixosSystem {
+    modules = [ ogygiaModule baseModule firewallA firewallB ];
+  };
+
+  failedAssertions = sys: builtins.filter (a: !a.assertion) sys.config.assertions;
+
+  noPubKeySystem = lib.nixosSystem {
+    modules = [
+      ogygiaModule
+      ({ ... }: {
+        nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
+        networking.hostName = "testhost";
+        system.stateVersion = "25.05";
+        boot.loader.grub.enable = false;
+        fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
+        ogygia.nebula = {
+          enable = true;
+          inherit certDir;
+          topology = sharedTopology;
+        };
+      })
+    ];
+  };
+
+  # Build the same fleet from a lighthouse's perspective to check
+  # auto-derivation of staticHostMap, isLighthouse, listen.port.
+  lighthouseSystem = lib.nixosSystem {
+    modules = [
+      ogygiaModule
+      ({ ... }: {
+        nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
+        networking.hostName = "lighthouse-1";
+        system.stateVersion = "25.05";
+        boot.loader.grub.enable = false;
+        fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
+        ogygia.nebula = {
+          enable = true;
+          pubKey = "fake-lh-pubkey";
+          inherit certDir;
+          topology = sharedTopology;
+        };
+      })
+    ];
+  };
+in
+pkgs.runCommand "ogygia-nebula-module"
+{
+  nativeBuildInputs = [ pkgs.jq ];
+  inherit expectedSpecHash;
+  actualSpecHash = validSystem.config.ogygia.nebula.specHash;
+  validCertPath = toString validSystem.config.ogygia.nebula.certPath;
+  serviceCert = toString validSystem.config.services.nebula.networks.ogygia.cert;
+  serviceCa = toString validSystem.config.services.nebula.networks.ogygia.ca;
+  serviceKey = validSystem.config.services.nebula.networks.ogygia.key;
+  tunDevice = validSystem.config.services.nebula.networks.ogygia.tun.device;
+  trustedIfaces = builtins.toJSON validSystem.config.networking.firewall.trustedInterfaces;
+  clientLighthouses = builtins.toJSON validSystem.config.services.nebula.networks.ogygia.lighthouses;
+  clientStaticHostMap = builtins.toJSON validSystem.config.services.nebula.networks.ogygia.staticHostMap;
+  clientIsLighthouse = lib.boolToString validSystem.config.services.nebula.networks.ogygia.isLighthouse;
+  clientListenPort = toString validSystem.config.services.nebula.networks.ogygia.listen.port;
+  lighthouseIsLighthouse = lib.boolToString lighthouseSystem.config.services.nebula.networks.ogygia.isLighthouse;
+  lighthouseLighthouses = builtins.toJSON lighthouseSystem.config.services.nebula.networks.ogygia.lighthouses;
+  lighthouseListenPort = toString lighthouseSystem.config.services.nebula.networks.ogygia.listen.port;
+  mergedInbound = builtins.toJSON mergeSystem.config.services.nebula.networks.ogygia.firewall.inbound;
+  mergedGroups = builtins.toJSON mergeSystem.config.ogygia.nebula.groups;
+  noPubFailedCount = toString (builtins.length (failedAssertions noPubKeySystem));
+  noPubFailedFirst =
+    let fas = failedAssertions noPubKeySystem;
+    in if fas == [ ] then "" else (builtins.head fas).message;
+} ''
+  set -eu
+
+  if [ "$actualSpecHash" != "$expectedSpecHash" ]; then
+    echo "specHash mismatch: got '$actualSpecHash', expected '$expectedSpecHash'" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$validCertPath" ]; then
+    echo "certPath does not exist on disk: $validCertPath" >&2
+    exit 1
+  fi
+  if [ "$serviceCert" != "$validCertPath" ]; then
+    echo "services.nebula.networks.ogygia.cert ($serviceCert) != certPath ($validCertPath)" >&2
+    exit 1
+  fi
+  if [ ! -f "$serviceCa" ]; then
+    echo "services.nebula.networks.ogygia.ca is missing: $serviceCa" >&2
+    exit 1
+  fi
+  if [ "$serviceKey" != "/etc/nebula/host.key" ]; then
+    echo "services.nebula.networks.ogygia.key has unexpected value: $serviceKey" >&2
+    exit 1
+  fi
+  if [ "$tunDevice" != "neb.ogygia" ]; then
+    echo "tun.device should be neb.ogygia, got: $tunDevice" >&2
+    exit 1
+  fi
+  echo "$trustedIfaces" | jq -e 'index("neb.ogygia") != null' >/dev/null
+
+  # Client-side: non-lighthouse derives the lighthouse Nebula IP and a static
+  # host map pointing at the lighthouse's public endpoint.
+  if [ "$clientIsLighthouse" != "false" ]; then
+    echo "client should not be a lighthouse, got: $clientIsLighthouse" >&2
+    exit 1
+  fi
+  if [ "$clientListenPort" != "0" ]; then
+    echo "client should listen on an ephemeral port, got: $clientListenPort" >&2
+    exit 1
+  fi
+  echo "$clientLighthouses" | jq -e '. == ["10.42.0.1"]' >/dev/null
+  echo "$clientStaticHostMap" | jq -e '."10.42.0.1" == ["lh1.public.example.com:4242"]' >/dev/null
+
+  # Lighthouse-side: identifies itself and does not list itself in lighthouses.
+  if [ "$lighthouseIsLighthouse" != "true" ]; then
+    echo "lighthouse-1 should be a lighthouse, got: $lighthouseIsLighthouse" >&2
+    exit 1
+  fi
+  if [ "$lighthouseListenPort" != "4242" ]; then
+    echo "lighthouse should listen on 4242, got: $lighthouseListenPort" >&2
+    exit 1
+  fi
+  echo "$lighthouseLighthouses" | jq -e '. == []' >/dev/null
+
+  echo "$mergedInbound" | jq -e 'length == 2' >/dev/null
+  echo "$mergedInbound" | jq -e 'map(select(.port == 22 and (.groups | index("ssh")))) | length == 1' >/dev/null
+  echo "$mergedInbound" | jq -e 'map(select(.port == 2379 and (.groups | index("etcd-server")))) | length == 1' >/dev/null
+
+  echo "$mergedGroups" | jq -e 'sort == ["client", "etcd-server", "ssh"]' >/dev/null
+
+  if [ "$noPubFailedCount" -lt "1" ]; then
+    echo "expected a failed assertion for missing pubKey" >&2
+    exit 1
+  fi
+  case "$noPubFailedFirst" in
+    *pubKey*) ;;
+    *) echo "expected pubKey-related assertion message, got: $noPubFailedFirst" >&2; exit 1 ;;
+  esac
+
+  mkdir -p $out
+  echo "spec_hash=$actualSpecHash" > $out/result
+  echo "cert_path=$validCertPath" >> $out/result
+''

--- a/src/ogygia-nixutils/src/cli.rs
+++ b/src/ogygia-nixutils/src/cli.rs
@@ -12,6 +12,7 @@ use async_stream::try_stream;
 use futures::Stream;
 use futures::StreamExt;
 use futures::pin_mut;
+use serde::de::DeserializeOwned;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
@@ -54,6 +55,37 @@ impl Default for NixCli {
 }
 
 impl NixCli {
+    /// Evaluate a Nix installable to JSON via `nix eval --json <installable>`,
+    /// optionally transforming it with `--apply <expr>`, and deserialize the
+    /// result into `T`.
+    ///
+    /// `installable` is passed through verbatim, so the caller owns the
+    /// `flakeref#attr.path` string and any attribute quoting it needs.
+    pub async fn eval_json<T: DeserializeOwned>(
+        &self,
+        installable: &str,
+        apply: Option<&str>,
+    ) -> Result<T> {
+        let mut cmd = Command::new(&*self.bin);
+        cmd.args(["eval", "--json"]).arg(installable);
+        if let Some(expr) = apply {
+            cmd.args(["--apply", expr]);
+        }
+
+        let output = cmd
+            .output()
+            .await
+            .with_context(|| format!("failed to spawn nix eval for {installable}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!("nix eval {installable} failed: {}", stderr.trim()));
+        }
+
+        serde_json::from_slice(&output.stdout)
+            .with_context(|| format!("failed to parse nix eval output for {installable}"))
+    }
+
     /// Sign the store paths in `paths` with the key in `key_file`.
     pub async fn sign_paths<P>(&self, key_file: &Path, paths: impl Stream<Item = P>) -> Result<()>
     where

--- a/src/ogygia-nixutils/src/nix.rs
+++ b/src/ogygia-nixutils/src/nix.rs
@@ -86,6 +86,16 @@ impl Nix {
         self.db().await?.is_ultimate(store_path).await
     }
 
+    /// Evaluate a Nix installable to JSON, optionally transforming it with an
+    /// `--apply` expression, and deserialize the result into `T`.
+    pub async fn eval_json<T: serde::de::DeserializeOwned>(
+        &self,
+        installable: &str,
+        apply: Option<&str>,
+    ) -> Result<T> {
+        self.cli().eval_json(installable, apply).await
+    }
+
     /// Sign the store paths in `paths` with the key in `key_file`. Paths that
     /// already carry the key's signature are re-signed harmlessly; filter them
     /// out beforehand to avoid the work.

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -5,11 +5,16 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["irisd"]
+default = ["irisd", "nebula"]
 irisd = [
     "dep:reqwest",
     "dep:serde_json",
     "dep:futures",
+    "dep:ogygia-nixutils",
+]
+nebula = [
+    "dep:tempfile",
+    "dep:which",
     "dep:ogygia-nixutils",
 ]
 
@@ -22,10 +27,14 @@ etcd-client = { workspace = true }
 hostname = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "io-util"] }
 
 # Optional deps for irisd feature
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde_json = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 ogygia-nixutils = { path = "../ogygia-nixutils", optional = true }
+
+# Optional deps for nebula feature
+tempfile = { workspace = true, optional = true }
+which = { workspace = true, optional = true }

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -27,6 +27,8 @@
 
 #[cfg(feature = "irisd")]
 mod iris;
+#[cfg(feature = "nebula")]
+mod nebula;
 mod status;
 
 use std::process;
@@ -52,6 +54,9 @@ enum Command {
     /// Interact with irisd binary cache
     #[cfg(feature = "irisd")]
     Iris(iris::IrisArgs),
+    /// Manage Nebula CA, host keys, and certificates
+    #[cfg(feature = "nebula")]
+    Nebula(nebula::NebulaArgs),
 }
 
 impl Command {
@@ -60,6 +65,8 @@ impl Command {
             Command::Status => status::show_status(),
             #[cfg(feature = "irisd")]
             Command::Iris(args) => args.run(),
+            #[cfg(feature = "nebula")]
+            Command::Nebula(args) => args.run(),
         }
     }
 }

--- a/src/ogygia/src/nebula/config.rs
+++ b/src/ogygia/src/nebula/config.rs
@@ -1,0 +1,54 @@
+//! Operator-side configuration for `ogygia nebula`.
+//!
+//! Fleet-wide settings resolve relative to the operator's current working
+//! directory (the flake root): certificates live in `<cwd>/nebula`. The CA
+//! key path comes from the environment (`OGYGIA_NEBULA_CA_KEY`), keeping the
+//! key out of the repo.
+
+use std::env;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+
+pub const ENV_CA_KEY: &str = "OGYGIA_NEBULA_CA_KEY";
+
+pub const DEFAULT_NETWORK_NAME: &str = "ogygia";
+pub const DEFAULT_VALIDITY_SECS: u64 = 90 * 86400;
+pub const DEFAULT_CA_DURATION_SECS: u64 = 10 * 365 * 86400;
+
+/// Resolved fleet configuration.
+#[derive(Debug)]
+pub struct Config {
+    /// Directory containing ca.crt and per-host certificates. Absolute.
+    pub cert_dir: PathBuf,
+    /// Absolute path to the CA certificate.
+    pub ca_cert_path: PathBuf,
+}
+
+impl Config {
+    /// Load configuration relative to the operator's current working directory.
+    pub fn load() -> Result<Self> {
+        let flake_root = env::current_dir().context("failed to read current directory")?;
+        let cert_dir = flake_root.join("nebula");
+        let ca_cert_path = cert_dir.join("ca.crt");
+        Ok(Self {
+            cert_dir,
+            ca_cert_path,
+        })
+    }
+
+    pub fn ca_key_path(&self) -> Result<PathBuf> {
+        env::var(ENV_CA_KEY).map(PathBuf::from).map_err(|_| {
+            anyhow!(
+                "{} is not set; point it at the CA private key on this machine",
+                ENV_CA_KEY
+            )
+        })
+    }
+
+    pub fn cert_path(&self, spec_hash: &str) -> PathBuf {
+        self.cert_dir.join(format!("{spec_hash}.crt"))
+    }
+}

--- a/src/ogygia/src/nebula/flake_eval.rs
+++ b/src/ogygia/src/nebula/flake_eval.rs
@@ -1,0 +1,75 @@
+//! Helpers for extracting per-host Nebula state from the flake via `nix eval`.
+//!
+//! Reads `nixosConfigurations.<host>.config.ogygia.nebula.{enable,spec,specHash}`
+//! without ever importing the host certificate (which may be missing on a fresh
+//! checkout — that's exactly when rekey runs). The `nix eval` mechanics live in
+//! [`ogygia_nixutils::Nix`]; this module only owns the `ogygia.nebula` schema.
+
+use anyhow::Result;
+use ogygia_nixutils::Nix;
+use serde::Deserialize;
+
+/// The spec recorded by the NixOS module. Mirrors `ogygia.nebula.spec`.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct HostSpec {
+    pub name: String,
+    pub ipv4: String,
+    pub subnet: String,
+    #[serde(rename = "pubKey")]
+    pub pub_key: String,
+    #[serde(default)]
+    pub groups: Vec<String>,
+    #[serde(rename = "caFingerprint")]
+    pub ca_fingerprint: String,
+    pub version: u32,
+}
+
+/// Per-host evaluation result. `spec` is `None` when the host has nebula
+/// disabled or hasn't been bootstrapped yet.
+#[derive(Debug)]
+pub struct HostInfo {
+    pub host: String,
+    pub enabled: bool,
+    pub spec_hash: Option<String>,
+    pub spec: Option<HostSpec>,
+}
+
+/// List the names of every host in `flake_ref#nixosConfigurations`.
+pub async fn list_hosts(nix: &Nix, flake_ref: &str) -> Result<Vec<String>> {
+    nix.eval_json(
+        &format!("{flake_ref}#nixosConfigurations"),
+        Some("builtins.attrNames"),
+    )
+    .await
+}
+
+/// Evaluate `ogygia.nebula.{enable,specHash,spec}` for a single host.
+///
+/// Selects only those three attributes so evaluation never touches
+/// `certPath` — importing a missing cert is exactly what rekey exists to
+/// resolve. The host name is quoted as a single attribute-path component,
+/// so FQDN attribute names containing dots work.
+pub async fn host_info(nix: &Nix, flake_ref: &str, host: &str) -> Result<HostInfo> {
+    #[derive(Deserialize)]
+    struct Raw {
+        enable: bool,
+        #[serde(rename = "specHash")]
+        spec_hash: Option<String>,
+        spec: Option<HostSpec>,
+    }
+
+    let raw: Raw = nix
+        .eval_json(
+            &format!("{flake_ref}#nixosConfigurations.\"{host}\".config.ogygia.nebula"),
+            Some("cfg: { inherit (cfg) enable specHash spec; }"),
+        )
+        .await?;
+
+    Ok(HostInfo {
+        host: host.to_string(),
+        enabled: raw.enable,
+        spec_hash: raw.spec_hash,
+        spec: raw.spec,
+    })
+}

--- a/src/ogygia/src/nebula/init.rs
+++ b/src/ogygia/src/nebula/init.rs
@@ -1,0 +1,108 @@
+//! `ogygia nebula init` — bootstrap a brand-new CA.
+
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use clap::Args;
+
+use super::config::Config;
+use super::config::DEFAULT_CA_DURATION_SECS;
+use super::config::DEFAULT_NETWORK_NAME;
+use super::nebula_cert;
+
+#[derive(Args)]
+pub struct InitArgs {
+    /// Network name embedded in the CA certificate (also the nebula network name).
+    #[arg(long)]
+    pub name: Option<String>,
+    /// CA validity in seconds. Defaults to ten years.
+    #[arg(long, default_value_t = DEFAULT_CA_DURATION_SECS)]
+    pub duration: u64,
+    /// Overwrite an existing CA cert/key if present.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub fn run(args: &InitArgs) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+    runtime.block_on(async_run(args))
+}
+
+async fn async_run(args: &InitArgs) -> Result<()> {
+    let config = Config::load()?;
+    let name = args
+        .name
+        .clone()
+        .unwrap_or_else(|| DEFAULT_NETWORK_NAME.to_string());
+
+    let ca_key_path = match std::env::var(super::config::ENV_CA_KEY) {
+        Ok(p) => PathBuf::from(p),
+        Err(_) => nebula_cert::default_ca_key_path(),
+    };
+
+    if !args.force {
+        if config.ca_cert_path.exists() {
+            return Err(anyhow!(
+                "CA cert already exists at {}; pass --force to overwrite",
+                config.ca_cert_path.display()
+            ));
+        }
+        if ca_key_path.exists() {
+            return Err(anyhow!(
+                "CA key already exists at {}; pass --force to overwrite",
+                ca_key_path.display()
+            ));
+        }
+    }
+
+    if let Some(parent) = config.ca_cert_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    if let Some(parent) = ca_key_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+        // Ensure the parent directory of the CA key is 0700.
+        let mut perms = std::fs::metadata(parent)?.permissions();
+        use std::os::unix::fs::PermissionsExt;
+        perms.set_mode(0o700);
+        std::fs::set_permissions(parent, perms)?;
+    }
+
+    tracing::info!(
+        ca_cert = %config.ca_cert_path.display(),
+        ca_key = %ca_key_path.display(),
+        "creating Nebula CA"
+    );
+
+    nebula_cert::create_ca(&name, &config.ca_cert_path, &ca_key_path, args.duration).await?;
+
+    // Tighten CA key permissions to 0600 even if nebula-cert already did so.
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).mode(0o600);
+    if let Ok(_f) = opts.open(&ca_key_path) {
+        // touching with mode 0o600 has no portable way to chmod a closed file —
+        // fall back to direct permission set:
+    }
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&ca_key_path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(&ca_key_path, perms)?;
+
+    println!("Nebula CA created:");
+    println!("  cert: {}", config.ca_cert_path.display());
+    println!("  key:  {}", ca_key_path.display());
+    println!();
+    println!(
+        "Set OGYGIA_NEBULA_CA_KEY={} in your shell to sign host certs.",
+        ca_key_path.display()
+    );
+
+    Ok(())
+}

--- a/src/ogygia/src/nebula/keygen.rs
+++ b/src/ogygia/src/nebula/keygen.rs
@@ -1,0 +1,118 @@
+//! `ogygia nebula keygen <host>` — run `nebula-cert keygen` on a remote host.
+//!
+//! SSHs in, generates the private key into /etc/nebula/host.key with the right
+//! permissions, then `cat`s the public key back to the operator's stdout. The
+//! public key is not persisted on the host: it lives only in the flake config
+//! (`ogygia.nebula.pubKey`). Refuses to clobber an existing key unless --force.
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use clap::Args;
+use tokio::process::Command;
+
+#[derive(Args)]
+pub struct KeygenArgs {
+    /// SSH target (e.g. `user@host`, defaults to using the bare host as the target).
+    pub host: String,
+    /// SSH user (overrides any user component baked into `host`).
+    #[arg(long)]
+    pub user: Option<String>,
+    /// Overwrite an existing keypair on the host.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub fn run(args: &KeygenArgs) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+    runtime.block_on(async_run(args))
+}
+
+async fn async_run(args: &KeygenArgs) -> Result<()> {
+    let ssh_target = ssh_target(args);
+
+    // Heredoc-quoted to keep the remote script verbatim.
+    let force_flag = if args.force { "1" } else { "0" };
+    let remote_script = format!(
+        r#"set -eu
+FORCE={force_flag}
+sudo mkdir -p /etc/nebula
+sudo chmod 0700 /etc/nebula
+if [ "$FORCE" != "1" ] && [ -f /etc/nebula/host.key ]; then
+    echo "/etc/nebula/host.key already exists on this host; pass --force to overwrite" >&2
+    exit 2
+fi
+TMPDIR=$(sudo mktemp -d)
+trap 'sudo rm -rf "$TMPDIR"' EXIT
+sudo nebula-cert keygen -out-key "$TMPDIR/host.key" -out-pub "$TMPDIR/host.pub"
+sudo install -m 0600 "$TMPDIR/host.key" /etc/nebula/host.key
+sudo cat "$TMPDIR/host.pub"
+"#
+    );
+
+    tracing::info!(target = %ssh_target, "running nebula-cert keygen on host");
+
+    let output = Command::new("ssh")
+        .arg("-T")
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg(&ssh_target)
+        .arg("--")
+        .arg("bash")
+        .arg("-s")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .context("failed to spawn ssh")?
+        .write_stdin_and_wait(remote_script.as_bytes())
+        .await?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "remote keygen failed on {ssh_target} (exit {})",
+            output.status.code().unwrap_or(-1)
+        ));
+    }
+
+    let pub_pem =
+        String::from_utf8(output.stdout).context("public key output was not valid UTF-8")?;
+    let pub_pem = pub_pem.trim_end_matches('\n');
+
+    println!("{pub_pem}");
+    eprintln!();
+    eprintln!(
+        "Paste the above into your flake as `ogygia.nebula.pubKey`, then run `ogygia nebula rekey -a`."
+    );
+    Ok(())
+}
+
+fn ssh_target(args: &KeygenArgs) -> String {
+    match &args.user {
+        Some(u) => format!("{u}@{}", args.host),
+        None => args.host.clone(),
+    }
+}
+
+trait ChildExt {
+    async fn write_stdin_and_wait(self, data: &[u8]) -> Result<std::process::Output>;
+}
+
+impl ChildExt for tokio::process::Child {
+    async fn write_stdin_and_wait(mut self, data: &[u8]) -> Result<std::process::Output> {
+        use tokio::io::AsyncWriteExt;
+        if let Some(mut stdin) = self.stdin.take() {
+            stdin
+                .write_all(data)
+                .await
+                .context("failed to write to ssh stdin")?;
+            stdin.shutdown().await.ok();
+        }
+        self.wait_with_output()
+            .await
+            .context("failed to await ssh process")
+    }
+}

--- a/src/ogygia/src/nebula/mod.rs
+++ b/src/ogygia/src/nebula/mod.rs
@@ -1,0 +1,41 @@
+//! `ogygia nebula` subcommand: manage Nebula CA, host keys, and certificates.
+//!
+//! Mirrors agenix-rekey's UX: declarative cert spec per host in NixOS config,
+//! a CLI that walks the flake and signs missing certificates via
+//! `nebula-cert`. Host private keys never enter the operator's machine.
+
+pub mod config;
+pub mod flake_eval;
+pub mod init;
+pub mod keygen;
+pub mod nebula_cert;
+pub mod rekey;
+
+use clap::Args;
+use clap::Subcommand;
+
+#[derive(Args)]
+pub struct NebulaArgs {
+    #[command(subcommand)]
+    pub command: NebulaCommand,
+}
+
+#[derive(Subcommand)]
+pub enum NebulaCommand {
+    /// Initialize a new Nebula CA for this fleet
+    Init(init::InitArgs),
+    /// Generate a host keypair on a remote machine via SSH
+    Keygen(keygen::KeygenArgs),
+    /// Sign missing certificates for hosts whose spec has no matching .crt
+    Rekey(rekey::RekeyArgs),
+}
+
+impl NebulaArgs {
+    pub fn run(&self) -> anyhow::Result<()> {
+        match &self.command {
+            NebulaCommand::Init(args) => init::run(args),
+            NebulaCommand::Keygen(args) => keygen::run(args),
+            NebulaCommand::Rekey(args) => rekey::run(args),
+        }
+    }
+}

--- a/src/ogygia/src/nebula/nebula_cert.rs
+++ b/src/ogygia/src/nebula/nebula_cert.rs
@@ -1,0 +1,153 @@
+//! Wrapper around the `nebula-cert` binary.
+//!
+//! Lazily discovers `nebula-cert` on PATH or in known NixOS fallback
+//! locations and exposes async helpers for the subcommands ogygia needs:
+//! `sign`, `keygen`, `ca`.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use tokio::process::Command;
+
+const FALLBACKS: &[&str] = &[
+    "/run/current-system/sw/bin/nebula-cert",
+    "/nix/var/nix/profiles/default/bin/nebula-cert",
+];
+
+static BIN: OnceLock<&'static str> = OnceLock::new();
+
+pub fn bin() -> &'static str {
+    BIN.get_or_init(|| {
+        if which::which("nebula-cert").is_ok() {
+            tracing::debug!("using nebula-cert from PATH");
+            return "nebula-cert";
+        }
+        for path in FALLBACKS {
+            if Path::new(path).exists() {
+                tracing::debug!("using nebula-cert fallback: {}", path);
+                return path;
+            }
+        }
+        tracing::warn!("nebula-cert not found on PATH or in fallback locations");
+        "nebula-cert"
+    })
+}
+
+/// Inputs to `nebula-cert sign`.
+pub struct SignArgs<'a> {
+    pub ca_cert: &'a Path,
+    pub ca_key: &'a Path,
+    pub in_pub: &'a Path,
+    pub name: &'a str,
+    pub networks: &'a str,
+    pub groups: &'a [String],
+    pub duration_seconds: u64,
+    pub out_cert: &'a Path,
+}
+
+/// Run `nebula-cert sign` and write the result to `out_cert`.
+///
+/// When the CA key is encrypted, `nebula-cert` prompts for the passphrase on
+/// the controlling terminal, so stdin/stdout/stderr are inherited rather than
+/// captured — otherwise the prompt would be swallowed and the read would hit a
+/// closed stdin.
+pub async fn sign(args: SignArgs<'_>) -> Result<()> {
+    let duration = format!("{}s", args.duration_seconds);
+    let groups = args.groups.join(",");
+
+    let mut cmd = Command::new(bin());
+    cmd.arg("sign");
+    cmd.arg("-ca-key").arg(args.ca_key);
+    cmd.arg("-ca-crt").arg(args.ca_cert);
+    cmd.arg("-in-pub").arg(args.in_pub);
+    cmd.arg("-name").arg(args.name);
+    cmd.arg("-networks").arg(args.networks);
+    if !groups.is_empty() {
+        cmd.arg("-groups").arg(&groups);
+    }
+    cmd.arg("-duration").arg(&duration);
+    cmd.arg("-out-crt").arg(args.out_cert);
+
+    let status = cmd
+        .status()
+        .await
+        .context("failed to spawn nebula-cert sign")?;
+
+    if !status.success() {
+        return Err(anyhow!("nebula-cert sign failed (see output above)"));
+    }
+    Ok(())
+}
+
+/// Compute the host-IP-plus-mask string passed to `nebula-cert sign -networks`,
+/// e.g. ipv4 "10.42.0.1" + subnet "10.42.0.0/16" → "10.42.0.1/16".
+pub fn network_spec(ipv4: &str, subnet: &str) -> Result<String> {
+    let mask = subnet
+        .split_once('/')
+        .map(|(_, m)| m)
+        .ok_or_else(|| anyhow!("subnet must be CIDR (got {subnet})"))?;
+    Ok(format!("{ipv4}/{mask}"))
+}
+
+/// Materialise a PEM string into a tempfile, returning a handle that deletes
+/// itself on drop. Used to pass `pubKey` content to `nebula-cert sign -in-pub`.
+pub fn pem_to_tempfile(pem: &str) -> Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+    let mut tf = tempfile::Builder::new()
+        .prefix("ogygia-nebula-pub-")
+        .suffix(".pem")
+        .tempfile()
+        .context("failed to create tempfile for pubkey")?;
+    tf.as_file_mut()
+        .write_all(pem.as_bytes())
+        .context("failed to write pubkey tempfile")?;
+    if !pem.ends_with('\n') {
+        tf.as_file_mut()
+            .write_all(b"\n")
+            .context("failed to write pubkey tempfile newline")?;
+    }
+    Ok(tf)
+}
+
+/// Resolve `nebula-cert ca` invocation: generate a new CA cert+key pair.
+pub async fn create_ca(
+    name: &str,
+    out_cert: &Path,
+    out_key: &Path,
+    duration_seconds: u64,
+) -> Result<()> {
+    let duration = format!("{}s", duration_seconds);
+    let mut cmd = Command::new(bin());
+    cmd.arg("ca");
+    cmd.arg("-name").arg(name);
+    cmd.arg("-out-crt").arg(out_cert);
+    cmd.arg("-out-key").arg(out_key);
+    cmd.arg("-duration").arg(&duration);
+    let output = cmd
+        .output()
+        .await
+        .context("failed to spawn nebula-cert ca")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("nebula-cert ca failed: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+/// Default CA key path under the user's config home.
+pub fn default_ca_key_path() -> PathBuf {
+    let base = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".config"))
+        })
+        .unwrap_or_else(|| PathBuf::from(".config"));
+    base.join("ogygia").join("nebula").join("ca.key")
+}

--- a/src/ogygia/src/nebula/rekey.rs
+++ b/src/ogygia/src/nebula/rekey.rs
@@ -1,0 +1,194 @@
+//! `ogygia nebula rekey` — sign missing host certificates by walking the flake.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use clap::Args;
+use ogygia_nixutils::Nix;
+
+use super::config::Config;
+use super::config::DEFAULT_VALIDITY_SECS;
+use super::flake_eval;
+use super::nebula_cert;
+use super::nebula_cert::SignArgs;
+
+#[derive(Args)]
+pub struct RekeyArgs {
+    /// Process every host in the flake.
+    #[arg(short = 'a', long)]
+    pub all: bool,
+    /// Process a single host.
+    #[arg(long)]
+    pub host: Option<String>,
+    /// Re-sign even if a matching cert already exists.
+    #[arg(long)]
+    pub force: bool,
+    /// Show what would happen without writing anything.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Flake reference; defaults to the current directory.
+    #[arg(long, default_value = ".")]
+    pub flake: String,
+}
+
+pub fn run(args: &RekeyArgs) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime")?;
+    runtime.block_on(async_run(args))
+}
+
+async fn async_run(args: &RekeyArgs) -> Result<()> {
+    if !args.all && args.host.is_none() {
+        return Err(anyhow!("specify -a/--all or --host <name>"));
+    }
+    if args.all && args.host.is_some() {
+        return Err(anyhow!("-a and --host are mutually exclusive"));
+    }
+
+    let config = Config::load()?;
+    let ca_key = if !args.dry_run {
+        Some(config.ca_key_path()?)
+    } else {
+        None
+    };
+
+    let nix = Nix::default();
+
+    let targets: Vec<String> = if let Some(host) = &args.host {
+        vec![host.clone()]
+    } else {
+        flake_eval::list_hosts(&nix, &args.flake).await?
+    };
+
+    let mut current_cert_paths: HashSet<PathBuf> = HashSet::new();
+    let mut signed = 0usize;
+    let mut skipped = 0usize;
+
+    for host in &targets {
+        let info = flake_eval::host_info(&nix, &args.flake, host).await?;
+        if !info.enabled {
+            tracing::debug!(%host, "skipping (nebula disabled)");
+            skipped += 1;
+            continue;
+        }
+        let (spec, spec_hash) = match (info.spec.as_ref(), info.spec_hash.as_ref()) {
+            (Some(s), Some(h)) => (s, h),
+            _ => {
+                tracing::warn!(%host, "nebula.spec is null (pubKey not set?); skipping");
+                skipped += 1;
+                continue;
+            }
+        };
+
+        let cert_path = config.cert_path(spec_hash);
+        current_cert_paths.insert(cert_path.clone());
+
+        if cert_path.exists() && !args.force {
+            tracing::info!(%host, hash = %spec_hash, "cert up to date");
+            skipped += 1;
+            continue;
+        }
+
+        if args.dry_run {
+            println!("would sign {}", cert_path.display());
+            continue;
+        }
+
+        let parent = cert_path
+            .parent()
+            .ok_or_else(|| anyhow!("invalid cert path"))?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+
+        let pub_tempfile = nebula_cert::pem_to_tempfile(&spec.pub_key)?;
+        let networks = nebula_cert::network_spec(&spec.ipv4, &spec.subnet)?;
+
+        sign_with_atomic_rename(
+            &cert_path,
+            SignArgs {
+                ca_cert: &config.ca_cert_path,
+                ca_key: ca_key.as_deref().expect("checked above"),
+                in_pub: pub_tempfile.path(),
+                name: &info.host,
+                networks: &networks,
+                groups: &spec.groups,
+                duration_seconds: DEFAULT_VALIDITY_SECS,
+                out_cert: &cert_path,
+            },
+        )
+        .await?;
+
+        println!("signed {}", cert_path.display());
+        signed += 1;
+    }
+
+    let pruned = if args.all && !args.dry_run {
+        prune_orphans(&config.cert_dir, &current_cert_paths)?
+    } else {
+        0
+    };
+
+    eprintln!("rekey: {signed} signed, {skipped} unchanged, {pruned} orphans pruned");
+    Ok(())
+}
+
+async fn sign_with_atomic_rename(final_path: &Path, args: SignArgs<'_>) -> Result<()> {
+    let tmp = tempfile::Builder::new()
+        .prefix(".ogygia-nebula-sign-")
+        .suffix(".crt")
+        .tempfile_in(final_path.parent().unwrap())
+        .context("failed to create signing tempfile")?;
+    let tmp_path = tmp.path().to_path_buf();
+    drop(tmp); // close before nebula-cert writes
+
+    let sign_args = SignArgs {
+        out_cert: &tmp_path,
+        ..args
+    };
+    nebula_cert::sign(sign_args).await?;
+    std::fs::rename(&tmp_path, final_path).with_context(|| {
+        format!(
+            "failed to rename {} -> {}",
+            tmp_path.display(),
+            final_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn prune_orphans(cert_dir: &Path, keep: &HashSet<PathBuf>) -> Result<usize> {
+    let mut pruned = 0usize;
+    if !cert_dir.exists() {
+        return Ok(0);
+    }
+    for entry in std::fs::read_dir(cert_dir)
+        .with_context(|| format!("failed to read {}", cert_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("crt") {
+            continue;
+        }
+        // Never prune the CA cert.
+        if path.file_name().and_then(|n| n.to_str()) == Some("ca.crt") {
+            continue;
+        }
+        if keep.contains(&path) {
+            continue;
+        }
+        std::fs::remove_file(&path)
+            .with_context(|| format!("failed to remove orphan {}", path.display()))?;
+        tracing::info!(path = %path.display(), "pruned orphan cert");
+        pruned += 1;
+    }
+    Ok(pruned)
+}


### PR DESCRIPTION
Ogygia defers overlay networking to the operator (the README says to
run irisd on Nebula/Tailscale/etc.) and carries only a stub
`ogygia.nebula.ipv4` option that irisd reads for its listen address.
There is no managed path for certificates or mesh topology, and nothing
enforces that a host meant to be on the mesh actually has the cert it
needs.

A new `nixos/nebula` module wraps `services.nebula.networks.ogygia`:
per-host configuration is identity only (`pubKey`, mergeable `groups`
and `firewall` rules) while a fleet-wide `topology` block (subnet,
hosts keyed by FQDN, lighthouses, relays) derives each host's roles,
`staticHostMap`, and listen port, with the tun trusted by the host
firewall so Nebula's cert-group rules govern mesh traffic. The cert
spec (name/ipv4/subnet/pubKey/groups/CA fingerprint) is hashed into a
read-only `specHash`, and the host cert is imported from
`<certDir>/<specHash>.crt` as a Nix path so a missing file fails
evaluation. A new `ogygia nebula` CLI (init, keygen, rekey) walks
`nixosConfigurations`, signs missing certs with `nebula-cert sign
-in-pub` (private keys are generated on-host over SSH and never leave
it), and prunes orphaned certs.

Content-addressing certs by their spec turns any identity change into
a new file the operator must sign, so configuration and certificate
can never silently drift. A build-time `pubKey != null` assertion
means a deployed host either has a working mesh identity or was
explicitly opted out with `enable = lib.mkForce false`.

Test plan:
- CI (`ogygia-nebula-module` exercises spec-hash determinism, cert
  path resolution, services.nebula wiring, topology auto-derivation
  from lighthouse and non-lighthouse perspectives, firewall and groups
  merging across modules, tun device naming, trustedInterfaces, and
  the missing-pubKey assertion; `ogygia-clippy`,
  `ogygia-nextest-archive`, `ogygia-doc`, `formatting`, `ogygia-deny`
  cover the Rust additions).
- Manually verified `ogygia nebula --help` and each subcommand's
  `--help` output, and `ogygia nebula rekey -a --dry-run` against a
  fixture flake (default `--flake .` and explicit path, dotted FQDN
  attribute names, disabled hosts skipped).
- End-to-end signing against a real `nebula-cert` CA and a
  `nixos-rebuild switch` on a live host are not covered automatically
  and will be smoke-tested by the operator.