### PR TITLE
ogygia: remove ZooKeeper support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "bytes 1.11.1",
+ "bytes",
  "form_urlencoded",
  "futures-util",
  "http",
@@ -176,7 +176,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "http",
  "http-body",
@@ -232,18 +232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,21 +239,15 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -324,7 +306,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -389,7 +371,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -438,13 +420,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -470,7 +452,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -559,7 +541,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
 ]
 
@@ -622,22 +604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags 1.3.2",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +659,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -741,7 +707,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -754,7 +720,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "js-sys",
  "libc",
  "r-efi 5.3.0",
@@ -768,7 +734,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
@@ -797,7 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -842,18 +808,18 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "windows-link",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "itoa",
 ]
 
@@ -863,7 +829,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "http",
 ]
 
@@ -873,7 +839,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "http",
  "http-body",
@@ -894,12 +860,12 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "h2",
@@ -950,7 +916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
- "bytes 1.11.1",
+ "bytes",
  "futures-channel",
  "futures-util",
  "http",
@@ -1139,16 +1105,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if 1.0.4",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1194,20 +1151,10 @@ version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -1237,12 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,9 +1197,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -1343,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1370,9 +1311,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -1392,57 +1333,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
 ]
 
 [[package]]
@@ -1472,17 +1370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,7 +1382,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio 1.2.0",
+ "mio",
  "notify-types",
  "walkdir",
  "windows-sys 0.52.0",
@@ -1544,7 +1431,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "which",
- "zookeeper",
 ]
 
 [[package]]
@@ -1597,7 +1483,7 @@ dependencies = [
  "axum",
  "base64",
  "bincode",
- "bytes 1.11.1",
+ "bytes",
  "clap",
  "fastbloom",
  "futures",
@@ -1677,7 +1563,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1718,7 +1604,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1764,7 +1650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1782,7 +1668,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "prost-derive",
 ]
 
@@ -1803,7 +1689,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn",
  "tempfile",
 ]
 
@@ -1817,7 +1703,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1855,7 +1741,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
@@ -1875,7 +1761,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand",
@@ -1999,7 +1885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -2040,7 +1926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.4",
+ "cfg-if",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -2161,7 +2047,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2215,7 +2101,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2231,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2270,16 +2156,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "snowflake"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
-
-[[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2315,7 +2195,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2323,17 +2203,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2363,7 +2232,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2402,7 +2271,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2411,7 +2280,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2445,9 +2314,9 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2464,7 +2333,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2494,7 +2363,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2549,7 +2418,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
- "bytes 1.11.1",
+ "bytes",
  "h2",
  "http",
  "http-body",
@@ -2578,7 +2447,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2587,7 +2456,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
- "bytes 1.11.1",
+ "bytes",
  "prost",
  "tonic",
 ]
@@ -2603,7 +2472,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn",
  "tempfile",
  "tonic-build",
 ]
@@ -2635,7 +2504,7 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
- "bytes 1.11.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -2683,7 +2552,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2733,9 +2602,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -2787,9 +2656,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2863,7 +2732,7 @@ version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
- "cfg-if 1.0.4",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -2899,7 +2768,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3001,34 +2870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,12 +2877,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3064,7 +2899,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3075,7 +2910,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3306,7 +3141,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3322,7 +3157,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3371,16 +3206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,28 +3224,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3440,7 +3265,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -3480,7 +3305,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3488,32 +3313,6 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zookeeper"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2312b424380193701a7341cec0551b80d2e3afd827ea0d3440af67899156ce10"
-dependencies = [
- "byteorder",
- "bytes 0.5.6",
- "lazy_static",
- "log",
- "mio 0.6.23",
- "mio-extras",
- "snowflake",
- "zookeeper_derive",
-]
-
-[[package]]
-name = "zookeeper_derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42307291e3c8b2e4082e5647572da863f0470511d0ecb1618a4cd0a361549723"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
-zookeeper = "0.8"
 etcd-client = "0.18"
 hostname = "0.4"
 strum = { version = "0.27", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Named after Calypso's mythical island, Ogygia aims to help you build your own pr
 - **🎯 Impact Analysis**: Identify which hosts are affected by configuration changes before deployment
 - **📊 Fleet Visibility**: Real-time monitoring of what's running across your entire infrastructure
 - **🏗️ Distributed Builds**: Seamlessly leverage your fleet's compute power for faster Nix builds
-- **⚡ Distributed Systems**: First-class support for building resilient clusters (ZooKeeper, etcd, and beyond)
+- **⚡ Distributed Systems**: First-class support for building resilient clusters (etcd and beyond)
 
 Whether you're managing a handful of servers or orchestrating a complex distributed system, Ogygia is designed to grow with your infrastructure while maintaining the simplicity and reproducibility that makes Nix powerful.
 
@@ -111,7 +111,7 @@ ogygia status
 
 #### Local-Only Mode
 
-When ZooKeeper is not configured, the status command shows only the local host:
+When etcd is not configured, the status command shows only the local host:
 
 ```
 Ogygia config not found; showing local data only.
@@ -241,41 +241,32 @@ The status display shows "unknown" in these cases:
 - The etcd key is missing (publisher hasn't written data yet)
 - The system state path doesn't exist yet (e.g., before first reboot)
 
-### ZooKeeper Fleet Visibility
+#### Troubleshooting
 
-Ogygia can also connect to ZooKeeper to provide fleet-wide visibility. The status command will prefer etcd if both are configured.
+**Connection Failures**
 
-#### Configuration
+If the CLI cannot connect to etcd, it will display an error and fall back to local-only mode:
 
-```nix
-{
-  ogygia = {
-    enable = true;
-    domain = "example.com";
-    zookeeper = {
-      enable = true;
-      endpoints = [
-        "zk1.internal:2181"
-        "zk2.internal:2181"
-        "zk3.internal:2181"
-      ];
-      namespace = "/nixos/versions";
-      timeoutSeconds = 10;
-    };
-  };
-}
+```
+etcd fleet state (/nixos/versions via /run/current-system/sw/share/ogygia/config.toml):
+Failed to read etcd from /run/current-system/sw/share/ogygia/config.toml: failed to connect to etcd at ["http://etcd1:2379"]. Check that the endpoints are reachable and the etcd service is running. Connection timeout: 10s. Showing local data only.
+Host           ⚡ current    🥾 booted      🔜 next boot
+-------------------------------------------------------
+* web01 (local) a1b2c3d4e5f6  a1b2c3d4e5f6  g7h8i9j0k1l2
 ```
 
-#### ZooKeeper Data Structure
+**Common Issues:**
+- **etcd not running**: Ensure the etcd service is running on the configured endpoints
+- **Network connectivity**: Verify the host can reach the etcd endpoints (check firewall rules)
+- **Namespace doesn't exist**: This is normal before the publisher daemon creates the keys
+- **Permission denied**: Check etcd ACLs if authentication is enabled
 
-Same structure as etcd:
-```
-/nixos/versions/
-├── web01/
-│   ├── current
-│   ├── booted
-│   └── nextboot
-```
+**"unknown" Revisions**
+
+The status display shows "unknown" in these cases:
+- The build revision file doesn't exist (system not built with Ogygia enabled)
+- The etcd key is missing (publisher hasn't written data yet)
+- The system state path doesn't exist yet (e.g., before first reboot)
 
 **Hostname Detection Issues**
 
@@ -286,11 +277,9 @@ Ogygia detects the hostname using multiple fallback strategies:
 4. `hostname` command (short name)
 5. `gethostname()` syscall
 
-If hostname detection isn't working as expected, use the `OGYGIA_HOSTNAME` environment variable to override it
+If hostname detection isn't working as expected, use the `OGYGIA_HOSTNAME` environment variable to override it.
 
 ### Irisd Peer-to-Peer Binary Cache
-
-Ogygia includes **ogygia-irisd**, a peer-to-peer Nix binary cache that enables distributed builds across your fleet without relying on a central cache server.
 
 #### Overview
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,12 +11,6 @@ allow = [
     "CC0-1.0",
 ]
 
-[advisories]
-ignore = [
-    # net2 is an indirect dependency via zookeeper; no patched release exists yet.
-    "RUSTSEC-2020-0016",
-]
-
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"

--- a/nixos/config-generator/default.nix
+++ b/nixos/config-generator/default.nix
@@ -6,7 +6,7 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
-  # Build config data from all enabled backends
+  # Build config data from etcd backend
   etcdEnabled = cfg.etcd.endpoints != [ ];
   configData = {
     ogygia = {
@@ -16,12 +16,6 @@ let
         endpoints = cfg.etcd.endpoints;
         namespace = cfg.etcd.namespace;
         timeout_seconds = cfg.etcd.timeoutSeconds;
-      };
-    } // lib.optionalAttrs cfg.zookeeper.enable {
-      zookeeper = {
-        endpoints = cfg.zookeeper.endpoints;
-        namespace = cfg.zookeeper.namespace;
-        timeout_seconds = cfg.zookeeper.timeoutSeconds;
       };
     };
   };
@@ -34,8 +28,8 @@ let
   '';
 in
 {
-  # This module provides the shared config package that all backends contribute to
-  config = lib.mkIf (cfg.enable && cliCfg.enable && (etcdEnabled || cfg.zookeeper.enable)) {
+  # This module provides the shared config package that the etcd backend contributes to
+  config = lib.mkIf (cfg.enable && cliCfg.enable && etcdEnabled) {
     ogygia.cliConfig.package = configPackage;
 
     environment = {

--- a/nixos/config/default.nix
+++ b/nixos/config/default.nix
@@ -1,9 +1,5 @@
 { config, lib, pkgs, ... }:
 
-let
-  cfg = config.ogygia;
-  zkCfg = cfg.zookeeper;
-in
 {
   options.ogygia.cliConfig = {
     enable = lib.mkEnableOption "render shared configuration for the Ogygia CLI and tooling";
@@ -16,60 +12,18 @@ in
     };
   };
 
-  options.ogygia.zookeeper = {
-    enable = lib.mkEnableOption "ZooKeeper configuration rendering for Ogygia tooling";
-
-    endpoints = lib.mkOption {
-      type = with lib.types; listOf str;
-      default = [ ];
-      example = [ "zk-internal-1:2181" "zk-internal-2:2181" ];
-      description = ''
-        List of ZooKeeper endpoints in <host>:<port> form that publish host state
-        information. The CLI uses these endpoints to read global status data.
-
-        :::{.warning}
-        ZooKeeper support is deprecated and will be removed in a future version.
-        Please migrate to etcd, which is more actively supported and will receive all future features.
-        :::
-      '';
-    };
-
-    namespace = lib.mkOption {
-      type = lib.types.str;
-      default = "/nixos/versions";
-      description = ''
-        ZooKeeper znode prefix that contains host state information.
-
-        :::{.warning}
-        ZooKeeper support is deprecated and will be removed in a future version.
-        Please migrate to etcd, which is more actively supported and will receive all future features.
-        :::
-      '';
-    };
-
-    timeoutSeconds = lib.mkOption {
-      type = lib.types.int;
-      default = 10;
-      description = ''
-        Connection timeout used by the Ogygia CLI when contacting ZooKeeper.
-
-        :::{.warning}
-        ZooKeeper support is deprecated and will be removed in a future version.
-        Please migrate to etcd, which is more actively supported and will receive all future features.
-        :::
-      '';
-    };
-  };
-
-  config = lib.mkIf (cfg.enable && cfg.cliConfig.enable && zkCfg.enable)
-    (lib.warn
-      "ogygia: ZooKeeper support is deprecated and will be removed in a future version. Please migrate to etcd, which is more actively supported and will receive all future features."
-      {
-        assertions = lib.optionals zkCfg.enable [
-          {
-            assertion = zkCfg.endpoints != [ ];
-            message = "ogygia.zookeeper.endpoints must not be empty when ZooKeeper integration is enabled.";
-          }
-        ];
-      });
+  imports = [
+    (lib.mkRemovedOptionModule [ "ogygia" "zookeeper" "enable" ]
+      "ZooKeeper support has been removed. Please migrate to etcd. Set ogygia.etcd.endpoints to enable etcd integration instead."
+    )
+    (lib.mkRemovedOptionModule [ "ogygia" "zookeeper" "endpoints" ]
+      "ZooKeeper support has been removed. Please migrate to etcd. Set ogygia.etcd.endpoints to enable etcd integration instead."
+    )
+    (lib.mkRemovedOptionModule [ "ogygia" "zookeeper" "namespace" ]
+      "ZooKeeper support has been removed. Please migrate to etcd. Use ogygia.etcd.namespace for the etcd key prefix."
+    )
+    (lib.mkRemovedOptionModule [ "ogygia" "zookeeper" "timeoutSeconds" ]
+      "ZooKeeper support has been removed. Please migrate to etcd. Use ogygia.etcd.timeoutSeconds for the etcd connection timeout."
+    )
+  ];
 }

--- a/nixos/tests/cli-config.nix
+++ b/nixos/tests/cli-config.nix
@@ -21,50 +21,6 @@ let
   etcdOnlyConfigPackage = etcdOnlySystem.config.ogygia.cliConfig.package or
     (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
 
-  # Test zookeeper only configuration
-  zkOnlySystem = lib.nixosSystem {
-    modules = [
-      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
-      ogygiaModule
-      {
-        ogygia.enable = true;
-        ogygia.domain = "neb.test";
-        ogygia.zookeeper = {
-          enable = true;
-          endpoints = [ "zk1.internal:2181" "zk2.internal:2181" ];
-          namespace = "/cluster/nixos";
-          timeoutSeconds = 42;
-        };
-      }
-    ];
-  };
-
-  zkOnlyConfigPackage = zkOnlySystem.config.ogygia.cliConfig.package or
-    (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
-
-  # Test both etcd and zookeeper configuration
-  bothSystem = lib.nixosSystem {
-    modules = [
-      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
-      ogygiaModule
-      {
-        ogygia.enable = true;
-        ogygia.domain = "neb.test";
-        ogygia.etcd = {
-          endpoints = [ "http://etcd1.internal:2379" "http://etcd2.internal:2379" ];
-          namespace = "/cluster/nixos";
-          timeoutSeconds = 42;
-        };
-        ogygia.zookeeper = {
-          enable = true;
-          endpoints = [ "zk1.internal:2181" "zk2.internal:2181" ];
-          namespace = "/cluster/nixos";
-          timeoutSeconds = 42;
-        };
-      }
-    ];
-  };
-
   # Test deprecation warning with legacy enable flag
   etcdWithDeprecatedEnable = lib.nixosSystem {
     modules = [
@@ -80,9 +36,6 @@ let
       }
     ];
   };
-
-  bothConfigPackage = bothSystem.config.ogygia.cliConfig.package or
-    (throw ''Ogygia CLI config package not found. Ensure ogygia.cliConfig.enable is true when ogygia.enable = true.'');
 
 in
 pkgs.runCommand "ogygia-cli-config"
@@ -106,43 +59,6 @@ pkgs.runCommand "ogygia-cli-config"
   assert "zookeeper" not in og, "zookeeper should not be in config when only etcd is enabled"
   PY
 
-    # Test zookeeper only configuration
-    zkConf="${zkOnlyConfigPackage}/share/ogygia/config.toml"
-    python3 - <<'PY'
-  import tomllib
-  from pathlib import Path
-  conf = Path("${zkOnlyConfigPackage}/share/ogygia/config.toml")
-  data = tomllib.loads(conf.read_text())
-  og = data["ogygia"]
-  assert og["domain"] == "neb.test", og["domain"]
-  zk = og["zookeeper"]
-  assert zk["endpoints"] == ["zk1.internal:2181", "zk2.internal:2181"], zk["endpoints"]
-  assert zk["namespace"] == "/cluster/nixos", zk["namespace"]
-  assert zk["timeout_seconds"] == 42, zk["timeout_seconds"]
-  # etcd should not be present when only zookeeper is configured
-  assert "etcd" not in og, "etcd should not be in config when only zookeeper is enabled"
-  PY
-
-    # Test both etcd and zookeeper configuration
-    bothConf="${bothConfigPackage}/share/ogygia/config.toml"
-    python3 - <<'PY'
-  import tomllib
-  from pathlib import Path
-  conf = Path("${bothConfigPackage}/share/ogygia/config.toml")
-  data = tomllib.loads(conf.read_text())
-  og = data["ogygia"]
-  assert og["domain"] == "neb.test", og["domain"]
-  # Both etcd and zookeeper should be present
-  etcd = og["etcd"]
-  assert etcd["endpoints"] == ["http://etcd1.internal:2379", "http://etcd2.internal:2379"], etcd["endpoints"]
-  assert etcd["namespace"] == "/cluster/nixos", etcd["namespace"]
-  assert etcd["timeout_seconds"] == 42, etcd["timeout_seconds"]
-  zk = og["zookeeper"]
-  assert zk["endpoints"] == ["zk1.internal:2181", "zk2.internal:2181"], zk["endpoints"]
-  assert zk["namespace"] == "/cluster/nixos", zk["namespace"]
-  assert zk["timeout_seconds"] == 42, zk["timeout_seconds"]
-  PY
-
     # Test deprecation warning is emitted when enable is used
     deprecatedConf="${etcdWithDeprecatedEnable.config.ogygia.cliConfig.package}/share/ogygia/config.toml"
     python3 - <<'PY'
@@ -161,6 +77,4 @@ pkgs.runCommand "ogygia-cli-config"
 
     mkdir -p $out
     cp "$etcdConf" "$out/config-etcd.toml"
-    cp "$zkConf" "$out/config-zk.toml"
-    cp "$bothConf" "$out/config-both.toml"
 ''

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -17,7 +17,6 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
-zookeeper = { workspace = true }
 etcd-client = { workspace = true }
 hostname = { workspace = true }
 tracing = { workspace = true }

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -2,12 +2,12 @@
 //!
 //! Ogygia is a read-only CLI tool for viewing NixOS system build revisions
 //! across a fleet of hosts. It can operate in local-only mode (reading from
-//! the local filesystem) or fleet mode (fetching data from ZooKeeper).
+//! the local filesystem) or fleet mode (fetching data from etcd).
 //!
 //! # Usage
 //!
 //! ```bash
-//! # View status (local only if ZooKeeper not configured)
+//! # View status (local only if etcd not configured)
 //! ogygia status
 //!
 //! # Override configuration file location
@@ -47,7 +47,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Show build commits for the local host and ZooKeeper fleet
+    /// Show build commits for the local host and etcd fleet
     Status,
     /// Interact with irisd binary cache
     #[cfg(feature = "irisd")]

--- a/src/ogygia/src/status/mod.rs
+++ b/src/ogygia/src/status/mod.rs
@@ -6,7 +6,7 @@
 //! 1. **Local-only mode**: Shows revision information for the current host by
 //!    reading from standard NixOS system state paths.
 //!
-//! 2. **Fleet mode**: Connects to etcd or ZooKeeper to display
+//! 2. **Fleet mode**: Connects to etcd to display
 //!    revision information for all hosts in the fleet that have published their state.
 //!
 //! ## Architecture
@@ -27,12 +27,12 @@
 //!
 //! ## Note on Write Side
 //!
-//! This module only **reads** from etcd/ZooKeeper. A separate publisher daemon
+//! This module only **reads** from etcd. A separate publisher daemon
 //! (not included here) is responsible for writing host state.
 //!
 //! ## Module Organization
 //!
-//! - `state`: State gathering logic (filesystem, etcd, ZooKeeper, config loading)
+//! - `state`: State gathering logic (filesystem, etcd, config loading)
 //! - `display`: Rendering and formatting logic (tables, truncation, trimming)
 //! - `tests`: Unit tests for both state and display modules
 
@@ -48,7 +48,6 @@ use state::HostMatcher;
 use state::collect_local_state;
 use state::detect_hostname;
 use state::fetch_etcd_state;
-use state::fetch_zookeeper_state;
 use state::load_cli_config;
 use tracing::info;
 use tracing::warn;
@@ -59,7 +58,7 @@ use tracing::warn;
 /// 1. Loading configuration (if available)
 /// 2. Detecting the local hostname
 /// 3. Collecting local system state
-/// 4. Optionally fetching fleet state from etcd or ZooKeeper
+/// 4. Optionally fetching fleet state from etcd
 /// 5. Rendering the status table
 ///
 /// If no backend is configured or connection fails, gracefully falls back
@@ -76,7 +75,6 @@ pub fn show_status() -> Result<()> {
 
     match cli_config.as_ref() {
         Some(cli_config) => {
-            // Prefer etcd, fallback to ZooKeeper (deprecated)
             if let Some(etcd) = cli_config.etcd.as_ref() {
                 info!(
                     namespace = %etcd.namespace,
@@ -107,42 +105,10 @@ pub fn show_status() -> Result<()> {
                         print_host_table(&[local_state], domain_suffix);
                     }
                 }
-            } else if let Some(zookeeper) = cli_config.zookeeper.as_ref() {
-                warn!(
-                    "ZooKeeper support is deprecated and will be removed in a future version. \
-                     Please migrate to etcd, which is more actively supported and will receive all future features."
-                );
-                info!(
-                    namespace = %zookeeper.namespace,
-                    config = %cli_config.path.display(),
-                    "ZooKeeper fleet state"
-                );
-
-                match fetch_zookeeper_state(zookeeper, Some(&host_matcher)) {
-                    Ok(remote_states) => {
-                        // Combine local and remote states
-                        let mut all_states = vec![local_state];
-                        all_states.extend(remote_states);
-
-                        if all_states.len() == 1 {
-                            info!("only the local host is currently registered in ZooKeeper");
-                        }
-
-                        print_host_table(&all_states, domain_suffix);
-                    }
-                    Err(error) => {
-                        warn!(
-                            config = %cli_config.path.display(),
-                            %error,
-                            "failed to read ZooKeeper, showing local data only"
-                        );
-                        print_host_table(&[local_state], domain_suffix);
-                    }
-                }
             } else {
                 info!(
                     config = %cli_config.path.display(),
-                    "etcd/ZooKeeper settings not found, showing local data only"
+                    "etcd settings not found, showing local data only"
                 );
                 print_host_table(&[local_state], domain_suffix);
             }

--- a/src/ogygia/src/status/state.rs
+++ b/src/ogygia/src/status/state.rs
@@ -3,7 +3,6 @@
 //! This module handles all data collection from:
 //! - Local filesystem (reading system state paths and build revision files)
 //! - etcd (fetching fleet-wide host state)
-//! - ZooKeeper (fetching fleet-wide host state)
 //! - Configuration files (loading TOML config)
 //! - Hostname detection (environment, commands, syscalls)
 //!
@@ -25,15 +24,11 @@ use etcd_client::ConnectOptions;
 use etcd_client::GetOptions;
 use hostname::get as get_hostname;
 use serde::Deserialize;
-use zookeeper::WatchedEvent;
-use zookeeper::Watcher;
-use zookeeper::ZkError;
-use zookeeper::ZooKeeper;
 
 /// Number of system states tracked per host (current, booted, next boot).
 pub const STATE_COUNT: usize = 3;
 
-/// Minimum ZooKeeper connection timeout in seconds.
+/// Minimum connection timeout in seconds.
 const MIN_TIMEOUT_SECONDS: u64 = 1;
 
 /// Relative path from system closure to the build revision file.
@@ -53,7 +48,7 @@ const CONFIG_OVERRIDE_ENV: &str = "OGYGIA_CONFIG";
 pub struct SystemStateData {
     /// Absolute path on the local filesystem where this system state is stored.
     pub base_path: &'static str,
-    /// Name of the key in etcd/ZooKeeper under the host's namespace that stores this state.
+    /// Name of the key in etcd under the host's namespace that stores this state.
     pub key_name: &'static str,
 }
 
@@ -82,7 +77,7 @@ pub type StateValues = [Option<String>; STATE_COUNT];
 /// Display formatting (truncation, domain trimming) is handled elsewhere.
 #[derive(Clone, Debug)]
 pub struct HostState {
-    /// Full hostname (FQDN or short name, as stored in etcd/ZooKeeper or detected locally).
+    /// Full hostname (FQDN or short name, as stored in etcd or detected locally).
     pub host: String,
     /// Build revisions for current, booted, and next boot states (full strings, not truncated).
     pub values: StateValues,
@@ -99,25 +94,12 @@ pub struct CliConfig {
     pub domain_suffix: Option<String>,
     /// Optional etcd connection configuration.
     pub etcd: Option<EtcdCliConfig>,
-    /// Optional ZooKeeper connection configuration.
-    pub zookeeper: Option<ZookeeperCliConfig>,
 }
 
 /// Processed etcd configuration ready for connection.
 #[derive(Debug)]
 pub struct EtcdCliConfig {
     /// List of etcd endpoints in "http://host:port" format.
-    pub endpoints: Vec<String>,
-    /// Normalized namespace path (starts with /, no trailing /).
-    pub namespace: String,
-    /// Connection timeout duration.
-    pub timeout: Duration,
-}
-
-/// Processed ZooKeeper configuration ready for connection.
-#[derive(Debug)]
-pub struct ZookeeperCliConfig {
-    /// List of ZooKeeper endpoints in "host:port" format.
     pub endpoints: Vec<String>,
     /// Normalized namespace path (starts with /, no trailing /).
     pub namespace: String,
@@ -162,85 +144,6 @@ fn read_revision(base_path: &Path) -> Option<String> {
         }
         Err(error) => Some(format!("error: {}", error)),
     }
-}
-
-/// Fetches host state data from ZooKeeper.
-///
-/// Connects to ZooKeeper, lists all hosts under the configured namespace,
-/// and reads their build revisions for all three system states.
-///
-/// Returns raw data with full hostnames (no domain trimming) and full revision
-/// strings (no truncation).
-///
-/// # Arguments
-///
-/// * `config` - ZooKeeper connection and namespace configuration
-/// * `exclude_host` - Optional hostname matcher to exclude (typically the local host)
-///
-/// # Returns
-///
-/// A vector of host state rows, sorted alphabetically by hostname.
-/// Missing znodes are represented as `None`.
-pub fn fetch_zookeeper_state(
-    config: &ZookeeperCliConfig,
-    exclude_host: Option<&HostMatcher>,
-) -> Result<Vec<HostState>> {
-    let connection_string = config.endpoints.join(",");
-    let zk =
-        ZooKeeper::connect(&connection_string, config.timeout, NoopWatcher).with_context(|| {
-            format!(
-                "failed to connect to ZooKeeper at {}. \
-                 Check that the endpoints are reachable and the ZooKeeper service is running. \
-                 Connection timeout: {:?}",
-                connection_string, config.timeout
-            )
-        })?;
-
-    let hosts = zk.get_children(&config.namespace, false).with_context(|| {
-        format!(
-            "failed to list hosts under {}. \
-                 The namespace may not exist yet, or you may not have read permissions. \
-                 This is normal if no publisher daemon has written data yet",
-            config.namespace
-        )
-    })?;
-
-    let mut rows = Vec::with_capacity(hosts.len());
-    for host in hosts {
-        if exclude_host
-            .map(|matcher| matcher.matches(&host))
-            .unwrap_or(false)
-        {
-            continue;
-        }
-
-        let mut values = empty_state_values();
-        let host_path = join_zk_path(&config.namespace, &host);
-
-        for (idx, state) in SYSTEM_STATE_DATA.iter().enumerate() {
-            let path = join_zk_path(&host_path, state.key_name);
-            match zk.get_data(&path, false) {
-                Ok((data, _)) => {
-                    if let Some(value) = parse_zk_revision_bytes(&data) {
-                        values[idx] = Some(value);
-                    }
-                }
-                Err(ZkError::NoNode) => { /* missing state is acceptable */ }
-                Err(error) => {
-                    return Err(anyhow!(error)).with_context(|| format!("failed to read {path}"));
-                }
-            }
-        }
-
-        rows.push(HostState {
-            host,
-            values,
-            is_local: false,
-        });
-    }
-
-    rows.sort_by(|a, b| a.host.cmp(&b.host));
-    Ok(rows)
 }
 
 /// Fetches host state data from etcd.
@@ -392,36 +295,6 @@ fn parse_etcd_value(data: &[u8]) -> Option<String> {
     }
 }
 
-/// Parses build revision bytes from ZooKeeper znode data.
-///
-/// Returns the full revision string (not truncated).
-/// Returns `None` if the data is not valid UTF-8, is empty, or contains only whitespace.
-fn parse_zk_revision_bytes(data: &[u8]) -> Option<String> {
-    let text = std::str::from_utf8(data).ok()?.trim();
-    if text.is_empty() {
-        None
-    } else {
-        Some(text.to_string())
-    }
-}
-
-/// Joins two ZooKeeper path components, handling slashes correctly.
-///
-/// ZooKeeper paths are always forward-slash separated strings (not platform-specific
-/// filesystem paths), so we need custom logic to handle edge cases like root paths
-/// and ensure no double slashes.
-pub fn join_zk_path(prefix: &str, child: &str) -> String {
-    if prefix == "/" {
-        format!("/{}", child.trim_start_matches('/'))
-    } else {
-        format!(
-            "{}/{}",
-            prefix.trim_end_matches('/'),
-            child.trim_start_matches('/')
-        )
-    }
-}
-
 /// Loads the Ogygia CLI configuration from the filesystem.
 ///
 /// Searches for configuration files in the following order:
@@ -448,13 +321,12 @@ pub fn load_cli_config() -> Result<Option<CliConfig>> {
             path,
             domain_suffix: None,
             etcd: None,
-            zookeeper: None,
         }));
     };
 
     let domain_suffix = ogygia_cfg.domain.and_then(|d| normalize_domain(&d));
 
-    // Parse etcd configuration (preferred)
+    // Parse etcd configuration
     let etcd = match ogygia_cfg.etcd {
         Some(raw_etcd) => {
             if raw_etcd.endpoints.is_empty() {
@@ -495,47 +367,14 @@ pub fn load_cli_config() -> Result<Option<CliConfig>> {
         None => None,
     };
 
-    // Parse ZooKeeper configuration
-    let zookeeper = match ogygia_cfg.zookeeper {
-        Some(raw_zk) => {
-            if raw_zk.endpoints.is_empty() {
-                return Err(anyhow!(
-                    "ZooKeeper config {} does not define any endpoints. \
-                     Add endpoints in the format [\"host1:2181\", \"host2:2181\"]",
-                    path.display()
-                ));
-            }
-
-            // Validate endpoint format
-            for endpoint in &raw_zk.endpoints {
-                if !endpoint.contains(':') {
-                    return Err(anyhow!(
-                        "Invalid ZooKeeper endpoint '{}' in {}. \
-                         Endpoints must be in 'host:port' format (e.g., 'zk1.example.com:2181')",
-                        endpoint,
-                        path.display()
-                    ));
-                }
-            }
-
-            Some(ZookeeperCliConfig {
-                endpoints: raw_zk.endpoints,
-                namespace: normalize_namespace(&raw_zk.namespace),
-                timeout: Duration::from_secs(raw_zk.timeout_seconds.max(MIN_TIMEOUT_SECONDS)),
-            })
-        }
-        None => None,
-    };
-
     Ok(Some(CliConfig {
         path,
         domain_suffix,
         etcd,
-        zookeeper,
     }))
 }
 
-/// Normalizes a ZooKeeper namespace path.
+/// Normalizes a namespace path.
 ///
 /// Ensures the path:
 /// - Starts with `/`
@@ -609,9 +448,6 @@ struct RawOgygiaConfig {
     /// etcd connection settings.
     #[serde(default)]
     etcd: Option<RawEtcdConfig>,
-    /// ZooKeeper connection settings.
-    #[serde(default)]
-    zookeeper: Option<RawZookeeperConfig>,
 }
 
 /// Raw etcd configuration section from TOML.
@@ -628,20 +464,6 @@ struct RawEtcdConfig {
     timeout_seconds: u64,
 }
 
-/// Raw ZooKeeper configuration section from TOML.
-#[derive(Debug, Deserialize)]
-struct RawZookeeperConfig {
-    /// List of ZooKeeper server endpoints (e.g., ["zk1:2181", "zk2:2181"]).
-    #[serde(default)]
-    endpoints: Vec<String>,
-    /// ZooKeeper namespace path where host data is stored.
-    #[serde(default = "default_zookeeper_namespace")]
-    namespace: String,
-    /// Connection timeout in seconds.
-    #[serde(default = "default_timeout_seconds")]
-    timeout_seconds: u64,
-}
-
 /// Default connection timeout in seconds.
 const fn default_timeout_seconds() -> u64 {
     10
@@ -650,21 +472,6 @@ const fn default_timeout_seconds() -> u64 {
 /// Default etcd namespace for host data storage.
 fn default_etcd_namespace() -> String {
     "/ogygia".to_string()
-}
-
-/// Default ZooKeeper namespace for host data storage.
-fn default_zookeeper_namespace() -> String {
-    "/nixos/versions".to_string()
-}
-
-/// No-op watcher for ZooKeeper connections.
-///
-/// We don't need to react to ZooKeeper events since we only perform
-/// one-shot reads, so this watcher does nothing.
-struct NoopWatcher;
-
-impl Watcher for NoopWatcher {
-    fn handle(&self, _: WatchedEvent) {}
 }
 
 /// Detects the current hostname using multiple fallback strategies.

--- a/src/ogygia/src/status/tests.rs
+++ b/src/ogygia/src/status/tests.rs
@@ -7,7 +7,6 @@ use super::state::HostState;
 use super::state::STATE_COUNT;
 use super::state::empty_state_values;
 use super::state::join_etcd_path;
-use super::state::join_zk_path;
 use super::state::normalize_domain;
 use super::state::normalize_namespace;
 
@@ -61,41 +60,6 @@ fn test_hostname_matcher_empty_short_name() {
     // Edge case: hostname that is just a dot
     let matcher = HostMatcher::new(".");
     assert!(matcher.matches("."));
-}
-
-// ============================================================================
-// ZooKeeper path manipulation tests
-// ============================================================================
-
-#[test]
-fn test_join_zk_path_normal() {
-    assert_eq!(join_zk_path("/foo", "bar"), "/foo/bar");
-}
-
-#[test]
-fn test_join_zk_path_with_trailing_slash() {
-    assert_eq!(join_zk_path("/foo/", "bar"), "/foo/bar");
-}
-
-#[test]
-fn test_join_zk_path_with_leading_slash() {
-    assert_eq!(join_zk_path("/foo", "/bar"), "/foo/bar");
-}
-
-#[test]
-fn test_join_zk_path_both_slashes() {
-    assert_eq!(join_zk_path("/foo/", "/bar"), "/foo/bar");
-}
-
-#[test]
-fn test_join_zk_path_root_prefix() {
-    assert_eq!(join_zk_path("/", "bar"), "/bar");
-    assert_eq!(join_zk_path("/", "/bar"), "/bar");
-}
-
-#[test]
-fn test_join_zk_path_multi_level() {
-    assert_eq!(join_zk_path("/a/b/c", "d/e"), "/a/b/c/d/e");
 }
 
 // ============================================================================


### PR DESCRIPTION
ZooKeeper support was deprecated and is now fully removed. Users previously relying on ZooKeeper for fleet state need to migrate to etcd.

The NixOS options are converted to mkRemovedOptionModule entries that instruct users to migrate to etcd. The Rust code removes all ZooKeeper imports, configuration parsing, state fetching, and tests. The zookeeper dependency is removed from Cargo.toml and Cargo.lock.

Removing ZooKeeper simplifies the codebase and focuses fleet state on etcd, which is the actively supported backend.

Test plan:
- Existing etcd-only tests in nixos/tests/cli-config.nix cover the remaining configuration path.
- Updated Rust tests to remove ZooKeeper-specific assertions.
- Manually verified that no zookeeper references remain outside of the removed-options declarations and test comments about ZooKeeper absence.