### PR TITLE
ci: run tests via testquorum archive instead of the Nix sandbox

### DIFF
--- a/.github/testquorum.toml
+++ b/.github/testquorum.toml
@@ -1,0 +1,5 @@
+[managers.nix]
+attrset = "ci"
+
+[managers.cargo]
+nextest_archive = "nix://.#ci.${SYSTEM}.ogygia-nextest-archive"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        fetch-depth: 0
 
     - name: Install Nix
       uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
@@ -46,8 +48,7 @@ jobs:
       with:
         arguments: .#ci
 
-    - name: Build all outputs
-      run: nix-fast-build --no-nom --flake '.#ci' -j 2 --eval-workers 4
-
-    - name: Flake check
-      run: nix flake check
+    - name: Run tests
+      uses: testquorum/action@668f94d477b166a6dc9b8599f74f9e4d93dfc95f # main
+      with:
+        token: ${{ secrets.TESTQUORUM_TOKEN }}

--- a/flake.lock
+++ b/flake.lock
@@ -52,27 +52,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nix-fast-build",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -88,28 +67,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nix-fast-build": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1782550725,
-        "narHash": "sha256-Mwowugw1fYT10OPipRy9Xg7v4juvR/se5flIThpYU8A=",
-        "owner": "Mic92",
-        "repo": "nix-fast-build",
-        "rev": "c632a8b5acec04c929d521cf1d0af5707e11b9e3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "nix-fast-build",
         "type": "github"
       }
     },
@@ -135,9 +92,8 @@
         "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nix-fast-build": "nix-fast-build",
         "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "rust-analyzer-src": {
@@ -173,27 +129,6 @@
       }
     },
     "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-fast-build",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -24,12 +24,9 @@
 
     advisory-db.url = "github:rustsec/advisory-db";
     advisory-db.flake = false;
-
-    nix-fast-build.url = "github:Mic92/nix-fast-build";
-    nix-fast-build.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, treefmt-nix, fenix, crane, advisory-db, nix-fast-build }:
+  outputs = { self, nixpkgs, flake-utils, treefmt-nix, fenix, crane, advisory-db }:
     flake-utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ]
       (system:
         let
@@ -133,10 +130,35 @@
             '';
           });
 
+          ogygia-nextest-archive = craneLib.buildPackage (commonArgs // {
+            pname = "ogygia-nextest-archive";
+            inherit version cargoArtifacts;
+            doCheck = false;
+            doNotPostBuildInstallCargoBinaries = true;
+            nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+              pkgs.cargo-nextest
+              pkgs.zstd
+            ];
+            buildPhase = ''
+              runHook preBuild
+              cargo nextest archive --workspace --archive-file archive.tar.zst
+              # Decompress so Nix can scan the tar for store-path references and
+              # retain the test binaries' runtime deps; compressed, they're hidden.
+              unzstd archive.tar.zst
+              runHook postBuild
+            '';
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out
+              cp archive.tar $out/
+              runHook postInstall
+            '';
+          });
+
         in
         {
           packages = {
-            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard;
+            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard ogygia-nextest-archive;
             default = ogygia;
           };
 
@@ -151,8 +173,9 @@
 
           devShells.ci = pkgs.mkShell {
             packages = [
-              pkgs.jq
-              nix-fast-build.packages.${system}.nix-fast-build
+              toolchain
+              pkgs.cargo-nextest
+              pkgs.zstd
             ];
           };
 
@@ -180,13 +203,6 @@
             ogygia-deny = craneLib.cargoDeny {
               inherit src;
             };
-
-            ogygia-nextest = craneLib.cargoNextest (commonArgs // {
-              inherit cargoArtifacts;
-              partitions = 1;
-              partitionType = "count";
-              cargoNextestPartitionsExtraArgs = "--no-tests=pass";
-            });
 
             ogygia-cli-config = import ./nixos/tests/cli-config.nix {
               inherit pkgs;


### PR DESCRIPTION
The workspace tests ran as a single `cargo nextest` derivation inside the Nix sandbox, so tests that need real system interactions couldn't run and any one failure aborted the whole run with no way to retry individual tests.

Add an `ogygia-nextest-archive` flake output that reproducibly builds the test binaries with `cargo nextest archive`, and drive them from CI with testquorum-runner (via `.github/testquorum.toml`): the nix manager builds every `ci` attr as an individual test and the cargo backend runs each test from the archive outside the sandbox. The CI workflow swaps nix-fast-build and `nix flake check` for the testquorum action, and drops the now-unused nix-fast-build input.

Building the tests in Nix but executing them per-test on the runner gives real system access and lets individual tests be retried and ranked via the TestQuorum cloud, instead of an all-or-nothing sandboxed build.

Test plan:
- Built `.#ci.x86_64-linux.ogygia-nextest-archive`; output contains archive.tar
- `cargo nextest list --archive-file ... --workspace-remap .` enumerates the workspace tests
- `nix eval .#ci.x86_64-linux` lists ogygia-nextest-archive and no longer ogygia-nextest
- `nix fmt` reports the flake clean
- CI