### PR TITLE
nixutils: introduce StoreHash type for store-path hashes

### DIFF
--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -12,6 +12,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use ogygia_nixutils::NarHash;
+use ogygia_nixutils::StoreHash;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::io::AsyncReadExt;
@@ -138,7 +139,8 @@ pub async fn get_local_narinfo(
 /// Ensures the NAR is cached so the response includes the real compressed
 /// FileHash and FileSize (needed for integrity validation and range requests).
 async fn try_local_store_narinfo(state: &AppState, hash: &str) -> Option<NarInfo> {
-    let path_info = match state.nix_db.find_path_info(hash).await {
+    let store_hash = hash.parse::<StoreHash>().ok()?;
+    let path_info = match state.nix_db.find_path_info(&store_hash).await {
         Ok(Some(info)) => info,
         Ok(None) => return None,
         Err(e) => {
@@ -252,7 +254,11 @@ async fn try_local_store_nar(
     expected_nar_hash: &str,
     range: Option<(u64, Option<u64>)>,
 ) -> Response {
-    let path_info = match state.nix_db.find_path_info(hash).await {
+    let store_hash = match hash.parse::<StoreHash>() {
+        Ok(h) => h,
+        Err(_) => return (StatusCode::NOT_FOUND, "Not found").into_response(),
+    };
+    let path_info = match state.nix_db.find_path_info(&store_hash).await {
         Ok(Some(info)) => info,
         Ok(None) => return (StatusCode::NOT_FOUND, "Not found").into_response(),
         Err(e) => {
@@ -376,13 +382,16 @@ pub async fn get_providers(
     axum::extract::Query(query): axum::extract::Query<ProvidersQuery>,
 ) -> Response {
     // Check local store
-    let local = state
-        .nix_db
-        .find_store_path(&hash)
-        .await
-        .ok()
-        .flatten()
-        .is_some();
+    let local = match hash.parse::<StoreHash>() {
+        Ok(store_hash) => state
+            .nix_db
+            .find_store_path(&store_hash)
+            .await
+            .ok()
+            .flatten()
+            .is_some(),
+        Err(_) => false,
+    };
 
     // Check peers via bloom lookup
     let peer_urls = &state.config.peers.urls;
@@ -482,20 +491,21 @@ pub async fn rescan(
             continue;
         }
 
-        // Extract hash from path
+        // Extract and validate the store-path hash.
         let hash = match path_str
             .strip_prefix("/nix/store/")
             .and_then(|s| s.get(..32))
+            .and_then(|h| h.parse::<StoreHash>().ok())
         {
-            Some(h) if h.len() == 32 && h.chars().all(|c| c.is_ascii_alphanumeric()) => h,
-            _ => {
+            Some(h) => h,
+            None => {
                 tracing::warn!("rescan: invalid hash in path: {}", path_str);
                 errors += 1;
                 continue;
             }
         };
 
-        state.local_bloom.insert(hash);
+        state.local_bloom.insert(hash.as_str());
         rescanned += 1;
 
         tracing::info!("rescan: indexed {}", path_str);

--- a/src/ogygia-irisd/src/store/scanner.rs
+++ b/src/ogygia-irisd/src/store/scanner.rs
@@ -66,7 +66,7 @@ impl StoreScanner {
 
         let indexed = hashes.len();
         for hash in &hashes {
-            self.bloom.insert(hash);
+            self.bloom.insert(hash.as_str());
         }
 
         tracing::info!("{}: {} paths indexed", label, indexed);

--- a/src/ogygia-irisd/src/store/watcher.rs
+++ b/src/ogygia-irisd/src/store/watcher.rs
@@ -14,6 +14,7 @@ use notify::RecommendedWatcher;
 use notify::RecursiveMode;
 use notify::Watcher;
 use ogygia_nixutils::NixDb;
+use ogygia_nixutils::StoreHash;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -101,12 +102,12 @@ impl StoreWatcher {
     ///
     /// Only indexes the path if it is serveable (signed or content-addressed).
     async fn process_create(&self, store_path: &str) {
-        let hash = match store_path
+        let Some(hash) = store_path
             .strip_prefix("/nix/store/")
             .and_then(|s| s.get(..32))
-        {
-            Some(h) if h.len() == 32 => h,
-            _ => return,
+            .and_then(|h| h.parse::<StoreHash>().ok())
+        else {
+            return;
         };
 
         let serveable = match self.nix_db.is_path_serveable(store_path).await {
@@ -118,7 +119,7 @@ impl StoreWatcher {
         };
 
         if serveable {
-            self.bloom.insert(hash);
+            self.bloom.insert(hash.as_str());
             tracing::debug!("Indexed new store path: {}", store_path);
         } else {
             tracing::debug!(

--- a/src/ogygia-nixutils/src/db.rs
+++ b/src/ogygia-nixutils/src/db.rs
@@ -21,6 +21,7 @@ use rusqlite::OptionalExtension;
 
 use crate::path_info::PathInfo;
 use crate::types::NarHash;
+use crate::types::StoreHash;
 
 /// Default path to the Nix SQLite database.
 const DEFAULT_DB_PATH: &str = "/nix/var/nix/db/db.sqlite";
@@ -134,11 +135,11 @@ impl NixDb {
         Ok(value)
     }
 
-    /// Find a store path by its 32-character hash prefix.
+    /// Find a store path by its store-path hash.
     ///
     /// Uses the unique index on `ValidPaths.path` for an O(log n) prefix
     /// lookup instead of scanning the `/nix/store` directory.
-    pub async fn find_store_path(&self, hash: &str) -> Result<Option<PathBuf>> {
+    pub async fn find_store_path(&self, hash: &StoreHash) -> Result<Option<PathBuf>> {
         let pattern = format!("/nix/store/{hash}-*");
         let path = self
             .query(move |conn| {
@@ -151,14 +152,14 @@ impl NixDb {
         Ok(path.map(PathBuf::from))
     }
 
-    /// Look up full path information by 32-character hash prefix.
+    /// Look up full path information by store-path hash.
     ///
     /// Returns the same [`PathInfo`] that `nix path-info --json` would, but via
     /// a direct, index-backed SQLite query and join. The `hash` column in the
     /// database is `<algo>:<hex>`; it is converted to the SRI form expected by
     /// narinfo consumers. Empty `deriver`/`ca` columns are normalised to `None`
     /// to match the command's `null` output.
-    pub async fn find_path_info(&self, hash: &str) -> Result<Option<PathInfo>> {
+    pub async fn find_path_info(&self, hash: &StoreHash) -> Result<Option<PathInfo>> {
         let pattern = format!("/nix/store/{hash}-*");
 
         let raw = self
@@ -228,17 +229,19 @@ impl NixDb {
     ///
     /// A path is serveable if it has signatures or is content-addressed. Used
     /// by the store scanner to populate the bloom filter in a single query.
-    pub async fn serveable_hashes(&self) -> Result<Vec<String>> {
-        self.query(|conn| {
-            let mut stmt = conn.prepare_cached(
-                "SELECT SUBSTR(path, 12, 32) FROM ValidPaths \
-                 WHERE (sigs IS NOT NULL AND sigs != '') \
-                    OR (ca IS NOT NULL AND ca != '')",
-            )?;
-            stmt.query_map([], |row| row.get::<_, String>(0))?
-                .collect::<rusqlite::Result<Vec<_>>>()
-        })
-        .await
+    pub async fn serveable_hashes(&self) -> Result<Vec<StoreHash>> {
+        let raw: Vec<String> = self
+            .query(|conn| {
+                let mut stmt = conn.prepare_cached(
+                    "SELECT SUBSTR(path, 12, 32) FROM ValidPaths \
+                     WHERE (sigs IS NOT NULL AND sigs != '') \
+                        OR (ca IS NOT NULL AND ca != '')",
+                )?;
+                stmt.query_map([], |row| row.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()
+            })
+            .await?;
+        raw.iter().map(|h| h.parse()).collect()
     }
 
     /// Check whether a store path is serveable (signed or content-addressed).
@@ -431,13 +434,13 @@ chmod -R a+rw /work
 
         for store_path in &paths {
             // "/nix/store/" is 11 chars; the hash is the next 32.
-            let hash = &store_path[11..43];
+            let hash: StoreHash = store_path[11..43].parse().expect("valid store hash");
             let expected = golden
                 .get(store_path)
                 .unwrap_or_else(|| panic!("path missing from golden: {store_path}"));
 
             let actual = db
-                .find_path_info(hash)
+                .find_path_info(&hash)
                 .await
                 .expect("find_path_info query")
                 .unwrap_or_else(|| panic!("path missing from NixDb: {store_path}"));
@@ -455,7 +458,7 @@ chmod -R a+rw /work
 
             // The hash prefix must resolve back to the full store path.
             assert_eq!(
-                db.find_store_path(hash)
+                db.find_store_path(&hash)
                     .await
                     .expect("find_store_path query")
                     .as_deref(),
@@ -472,6 +475,7 @@ chmod -R a+rw /work
             .await
             .expect("serveable_hashes query")
             .into_iter()
+            .map(|h| h.as_str().to_owned())
             .collect();
         for store_path in &paths {
             let hash = &store_path[11..43];

--- a/src/ogygia-nixutils/src/lib.rs
+++ b/src/ogygia-nixutils/src/lib.rs
@@ -17,3 +17,4 @@ pub use db::NixDb;
 pub use path_info::PathInfo;
 pub use path_info::parse_path_info_json;
 pub use types::NarHash;
+pub use types::StoreHash;

--- a/src/ogygia-nixutils/src/types.rs
+++ b/src/ogygia-nixutils/src/types.rs
@@ -92,6 +92,55 @@ fn expect_sha256(s: &str, sep: char) -> Result<&str> {
     Ok(payload)
 }
 
+/// The 32-character nixbase32 hash that prefixes a `/nix/store/<hash>-<name>`
+/// store path.
+///
+/// Validated on construction — 32 characters drawn from Nix's base32 alphabet —
+/// so a value of this type is always a well-formed store-path hash and can't be
+/// confused with an arbitrary string when used as a database lookup key.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct StoreHash(String);
+
+impl StoreHash {
+    /// Length of a store-path hash in nixbase32 characters.
+    const LEN: usize = 32;
+
+    /// The hash as its 32-character nixbase32 string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for StoreHash {
+    type Err = anyhow::Error;
+
+    /// Parse and validate a 32-character nixbase32 store-path hash.
+    fn from_str(s: &str) -> Result<Self> {
+        if s.len() != Self::LEN {
+            bail!(
+                "store-path hash must be {} characters, got {}: {s}",
+                Self::LEN,
+                s.len(),
+            );
+        }
+        if let Some(c) = s.chars().find(|&c| !is_nixbase32(c)) {
+            bail!("invalid nixbase32 character {c:?} in store-path hash: {s}");
+        }
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl std::fmt::Display for StoreHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Nix's base32 alphabet: digits plus lowercase consonants, omitting `e o u t`.
+fn is_nixbase32(c: char) -> bool {
+    matches!(c, '0'..='9' | 'a'..='d' | 'f'..='n' | 'p'..='s' | 'v'..='z')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,5 +185,36 @@ mod tests {
     #[test]
     fn nar_hash_from_hex_rejects_wrong_length() {
         assert!(NarHash::from_hex("abcd").is_err());
+    }
+
+    #[test]
+    fn store_hash_accepts_valid() {
+        let s = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let hash: StoreHash = s.parse().unwrap();
+        assert_eq!(hash.as_str(), s);
+        assert_eq!(hash.to_string(), s);
+    }
+
+    #[test]
+    fn store_hash_rejects_wrong_length() {
+        assert!(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .parse::<StoreHash>()
+                .is_err()
+        ); // 31
+        assert!(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .parse::<StoreHash>()
+                .is_err()
+        ); // 33
+    }
+
+    #[test]
+    fn store_hash_rejects_chars_outside_nixbase32() {
+        // e, o, u, t and uppercase are not in Nix's base32 alphabet.
+        for bad in ['e', 'o', 'u', 't', 'A'] {
+            let s = format!("{bad}{}", "a".repeat(31));
+            assert!(s.parse::<StoreHash>().is_err(), "should reject {bad:?}");
+        }
     }
 }


### PR DESCRIPTION
The 32-character nixbase32 hash that prefixes a store path was passed
around as a bare `&str` and used directly as a database lookup key, with
its length and character set re-checked ad hoc at each call site (and, in
the rescan handler, with a looser `is_ascii_alphanumeric` check that
admits non-nixbase32 characters).

Added a `StoreHash` newtype that validates the 32-character nixbase32
form on construction. The `NixDb` lookups (`find_path_info`,
`find_store_path`, `serveable_hashes`) now take and return `StoreHash`,
and irisd constructs one at each HTTP/store boundary, replacing the
hand-rolled length and alphabet checks in the handlers and store watcher.

Validating once at the boundary means an invalid hash can't reach a query
and the scattered, inconsistent checks collapse into a single type.

Test plan:
- Added StoreHash unit tests: valid hashes round-trip; wrong lengths and
  characters outside Nix's base32 alphabet are rejected.
- CI