### PR TITLE
irisd: type NarInfo and cached-NAR hash fields as NarHash

### DIFF
--- a/src/ogygia-irisd/src/nix/cache.rs
+++ b/src/ogygia-irisd/src/nix/cache.rs
@@ -15,9 +15,8 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use async_compression::tokio::bufread::ZstdEncoder;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD;
 use moka::future::Cache;
+use ogygia_nixutils::NarHash;
 use sha2::Digest;
 use sha2::Sha256;
 use tokio::io::AsyncReadExt;
@@ -36,8 +35,8 @@ pub struct CachedNar {
     /// so the fd keeps the inode alive even after unlink.
     path: tokio::sync::RwLock<Option<PathBuf>>,
 
-    /// SHA-256 of the compressed file content, in SRI format (`sha256-BASE64==`).
-    pub file_hash: String,
+    /// SHA-256 of the compressed file content.
+    pub file_hash: NarHash,
 
     /// Size of the compressed file in bytes.
     pub file_size: u64,
@@ -310,8 +309,7 @@ async fn generate_cached_nar(cache_dir: &Path, store_path: &Path) -> Result<Arc<
         ));
     }
 
-    let digest = hasher.finalize();
-    let file_hash = format!("sha256-{}", STANDARD.encode(digest));
+    let file_hash = NarHash::from_bytes(hasher.finalize().into());
 
     tokio::fs::rename(&tmp_path, &final_path)
         .await
@@ -336,8 +334,8 @@ async fn generate_cached_nar(cache_dir: &Path, store_path: &Path) -> Result<Arc<
     }))
 }
 
-/// Compute the SHA-256 hash of a file in SRI format.
-async fn hash_file(path: &Path) -> Result<String> {
+/// Compute the SHA-256 hash of a file.
+async fn hash_file(path: &Path) -> Result<NarHash> {
     let mut file = tokio::fs::File::open(path).await?;
     let mut hasher = Sha256::new();
     let mut buf = vec![0u8; 8192];
@@ -348,6 +346,5 @@ async fn hash_file(path: &Path) -> Result<String> {
         }
         hasher.update(&buf[..n]);
     }
-    let digest = hasher.finalize();
-    Ok(format!("sha256-{}", STANDARD.encode(digest)))
+    Ok(NarHash::from_bytes(hasher.finalize().into()))
 }

--- a/src/ogygia-irisd/src/nix/narinfo.rs
+++ b/src/ogygia-irisd/src/nix/narinfo.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use anyhow::anyhow;
+use ogygia_nixutils::NarHash;
 use ogygia_nixutils::PathInfo;
 
 /// Parsed narinfo file
@@ -16,11 +17,11 @@ pub struct NarInfo {
     /// Compression type
     pub compression: Compression,
     /// Hash of compressed file
-    pub file_hash: String,
+    pub file_hash: NarHash,
     /// Size of compressed file
     pub file_size: u64,
     /// Hash of uncompressed NAR
-    pub nar_hash: String,
+    pub nar_hash: NarHash,
     /// Size of uncompressed NAR
     pub nar_size: u64,
     /// Store path references
@@ -137,20 +138,22 @@ impl NarInfo {
             .transpose()?
             .unwrap_or(Compression::None);
 
-        let file_hash = fields
-            .get("FileHash")
-            .ok_or_else(|| anyhow!("Missing FileHash"))?
-            .to_string();
+        let file_hash = NarHash::from_sri(
+            fields
+                .get("FileHash")
+                .ok_or_else(|| anyhow!("Missing FileHash"))?,
+        )?;
 
         let file_size = fields
             .get("FileSize")
             .ok_or_else(|| anyhow!("Missing FileSize"))?
             .parse()?;
 
-        let nar_hash = fields
-            .get("NarHash")
-            .ok_or_else(|| anyhow!("Missing NarHash"))?
-            .to_string();
+        let nar_hash = NarHash::from_sri(
+            fields
+                .get("NarHash")
+                .ok_or_else(|| anyhow!("Missing NarHash"))?,
+        )?;
 
         let nar_size = fields
             .get("NarSize")
@@ -241,10 +244,11 @@ pub fn narinfo_from_path_info(info: &PathInfo) -> NarInfo {
         store_path: info.path.clone(),
         url,
         compression: Compression::Zstd,
-        // Placeholders until the NAR is generated and compressed.
-        file_hash: info.nar_hash.to_sri(),
+        // FileHash is a placeholder (the NAR hash) until the NAR is generated
+        // and compressed, at which point the caller fills in the real value.
+        file_hash: info.nar_hash,
         file_size: info.nar_size,
-        nar_hash: info.nar_hash.to_sri(),
+        nar_hash: info.nar_hash,
         nar_size: info.nar_size,
         references,
         deriver,
@@ -255,16 +259,14 @@ pub fn narinfo_from_path_info(info: &PathInfo) -> NarInfo {
 
 #[cfg(test)]
 mod tests {
-    use ogygia_nixutils::NarHash;
-
     use super::*;
 
     const SAMPLE_NARINFO: &str = r#"StorePath: /nix/store/abc123def456ghi789jkl012mno345pq-hello-2.10
 URL: nar/1234567890abcdef.nar.xz
 Compression: xz
-FileHash: sha256:abcdef1234567890
+FileHash: sha256-S0ymvFDCaeUfZSW1veq0gU12WoV80qZSXcgyllwCzZY=
 FileSize: 12345
-NarHash: sha256:fedcba0987654321
+NarHash: sha256-S0ymvFDCaeUfZSW1veq0gU12WoV80qZSXcgyllwCzZY=
 NarSize: 67890
 References: abc123def456ghi789jkl012mno345pq-glibc-2.35
 Deriver: xyz789abc123def456ghi012jkl345mno-hello-2.10.drv
@@ -300,7 +302,7 @@ Sig: my-cache-1:qrstuvwxyz123456
         );
         assert_eq!(narinfo.compression, Compression::Zstd);
         assert_eq!(
-            narinfo.nar_hash,
+            narinfo.nar_hash.to_sri(),
             "sha256-S0ymvFDCaeUfZSW1veq0gU12WoV80qZSXcgyllwCzZY="
         );
         assert_eq!(narinfo.nar_size, 12345);
@@ -362,9 +364,9 @@ Sig: my-cache-1:qrstuvwxyz123456
             store_path: "/nix/store/abc123-test".to_string(),
             url: "nar/test.nar.zst".to_string(),
             compression: Compression::Zstd,
-            file_hash: "sha256:abc".to_string(),
+            file_hash: NarHash::from_hex(&"ab".repeat(32)).unwrap(),
             file_size: 100,
-            nar_hash: "sha256:def".to_string(),
+            nar_hash: NarHash::from_hex(&"cd".repeat(32)).unwrap(),
             nar_size: 200,
             references: vec![],
             deriver: None,

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -11,7 +11,6 @@ use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
-use ogygia_nixutils::NarHash;
 use ogygia_nixutils::StoreHash;
 use serde::Deserialize;
 use serde::Serialize;
@@ -88,15 +87,8 @@ pub async fn get_narinfo(
     if let Some((mut narinfo, _)) = state.try_peer_narinfo(hash).await {
         // Rewrite the URL to use our format with the NarHash encoded as hex,
         // so the NAR request will be self-describing regardless of the peer's format.
-        let nar_hash = match NarHash::from_sri(&narinfo.nar_hash) {
-            Ok(h) => h,
-            Err(e) => {
-                tracing::warn!("Peer narinfo {} has invalid NarHash: {}", hash, e);
-                return (StatusCode::NOT_FOUND, "Not found").into_response();
-            }
-        };
         let filename = narinfo.url.rsplit('/').next().unwrap_or(&narinfo.url);
-        narinfo.url = format!("nar/{}/{}", nar_hash.to_hex(), filename);
+        narinfo.url = format!("nar/{}/{}", narinfo.nar_hash.to_hex(), filename);
         return (
             StatusCode::OK,
             [("content-type", "text/x-nix-narinfo")],
@@ -157,7 +149,7 @@ async fn try_local_store_narinfo(state: &AppState, hash: &str) -> Option<NarInfo
     // Generate/retrieve the cached NAR to get real FileHash and FileSize
     match state.nar_cache.ensure(hash, &store_path).await {
         Ok(cached) => {
-            narinfo.file_hash = cached.file_hash.clone();
+            narinfo.file_hash = cached.file_hash;
             narinfo.file_size = cached.file_size;
         }
         Err(e) => {
@@ -294,6 +286,7 @@ async fn try_local_store_nar(
     };
 
     let file_size = cached.file_size;
+    let file_hash = cached.file_hash.to_sri();
 
     match range {
         Some((start, end)) => {
@@ -333,7 +326,7 @@ async fn try_local_store_nar(
                     ("content-type", "application/zstd"),
                     ("content-length", content_length.as_str()),
                     ("content-range", content_range.as_str()),
-                    ("x-ogygia-nar-file-hash", cached.file_hash.as_str()),
+                    ("x-ogygia-nar-file-hash", file_hash.as_str()),
                 ],
                 body,
             )
@@ -348,7 +341,7 @@ async fn try_local_store_nar(
                 [
                     ("content-type", "application/zstd"),
                     ("content-length", content_length.as_str()),
-                    ("x-ogygia-nar-file-hash", cached.file_hash.as_str()),
+                    ("x-ogygia-nar-file-hash", file_hash.as_str()),
                 ],
                 body,
             )

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -149,7 +149,7 @@ impl AppState {
                     }
 
                     // Skip peers whose NarHash doesn't match the one in the URL
-                    if NarHash::from_sri(&narinfo.nar_hash).ok() != Some(expected) {
+                    if narinfo.nar_hash != expected {
                         continue;
                     }
 

--- a/src/ogygia-nixutils/src/types.rs
+++ b/src/ogygia-nixutils/src/types.rs
@@ -27,6 +27,11 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 pub struct NarHash([u8; 32]);
 
 impl NarHash {
+    /// Construct from a raw 32-byte SHA-256 digest.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
     /// Parse the Nix database column form `sha256:<hex>`.
     pub fn from_db_str(s: &str) -> Result<Self> {
         Self::from_hex(expect_sha256(s, ':')?)
@@ -185,6 +190,12 @@ mod tests {
     #[test]
     fn nar_hash_from_hex_rejects_wrong_length() {
         assert!(NarHash::from_hex("abcd").is_err());
+    }
+
+    #[test]
+    fn nar_hash_from_bytes_roundtrips() {
+        let hash = NarHash::from_db_str(DB).unwrap();
+        assert_eq!(NarHash::from_bytes(*hash.as_bytes()), hash);
     }
 
     #[test]


### PR DESCRIPTION
`NarInfo`'s `nar_hash`/`file_hash` and `CachedNar`'s `file_hash` were bare `String`s holding SRI-encoded SHA-256 digests, formatted and parsed by hand and left unvalidated; consumers re-parsed them with `NarHash::from_sri` at each point of use.

Made those fields `NarHash`. `NarInfo::parse` validates the `FileHash` and `NarHash` lines through `NarHash::from_sri` once, and the NAR cache builds the compressed-file hash directly from the raw digest via a new `NarHash::from_bytes`, dropping the hand-rolled `sha256-<base64>` formatting. Serialization is unchanged: `NarHash`'s `Display` is the SRI form, so the narinfo output and the `x-ogygia-nar-file-hash` header are byte-identical, and the peer NarHash check and URL rewrite compare by value instead of re-parsing strings.

We only ever parse narinfos generated by ogygia-irisd, which emit SRI, so `from_sri` covers every input we see and the wire format is preserved across versions.

Test plan:
- Added a `NarHash::from_bytes` round-trip unit test.
- Updated the narinfo unit tests to typed hashes; existing parse, serialize round-trip and NAR-serving tests exercise the wire format.
- CI