### PR TITLE
nixutils: unify store-path hash extraction via from_store_path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "clap",
  "etcd-client",
  "hostname",
+ "ogygia-nixutils",
  "reqwest",
  "serde",
  "serde_json",

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,18 @@
             ];
           };
 
+          # ogygia's default `irisd` feature depends on the ogygia-nixutils
+          # path crate, so both crates' sources must be present when building it.
+          ogygiaSrc = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./Cargo.toml
+              ./Cargo.lock
+              (craneLib.fileset.commonCargoSources ./src/ogygia)
+              (craneLib.fileset.commonCargoSources ./src/ogygia-nixutils)
+            ];
+          };
+
           commonArgs = {
             inherit src;
             strictDeps = true;
@@ -118,7 +130,7 @@
           ogygia = craneLib.buildPackage (individualCrateArgs // {
             pname = "ogygia";
             cargoExtraArgs = "-p ogygia";
-            src = fileSetForCrate ./src/ogygia;
+            src = ogygiaSrc;
           });
 
           # ogygia-nixutils is a library crate with no deployable artifact; it

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -454,12 +454,15 @@ pub async fn rescan(
     for path in &request.paths {
         let path_str = path.to_string_lossy();
 
-        // Validate path format
-        if !path_str.starts_with("/nix/store/") {
-            tracing::warn!("rescan: invalid path format: {}", path_str);
-            errors += 1;
-            continue;
-        }
+        // Extract and validate the store-path hash (also validates the format).
+        let hash = match StoreHash::from_store_path(&path_str) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!("rescan: invalid path {}: {}", path_str, e);
+                errors += 1;
+                continue;
+            }
+        };
 
         // Query the Nix database and verify serveability
         let serveable = match state.nix_db.is_path_serveable(&path_str).await {
@@ -483,20 +486,6 @@ pub async fn rescan(
             errors += 1;
             continue;
         }
-
-        // Extract and validate the store-path hash.
-        let hash = match path_str
-            .strip_prefix("/nix/store/")
-            .and_then(|s| s.get(..32))
-            .and_then(|h| h.parse::<StoreHash>().ok())
-        {
-            Some(h) => h,
-            None => {
-                tracing::warn!("rescan: invalid hash in path: {}", path_str);
-                errors += 1;
-                continue;
-            }
-        };
 
         state.local_bloom.insert(hash.as_str());
         rescanned += 1;

--- a/src/ogygia-irisd/src/store/watcher.rs
+++ b/src/ogygia-irisd/src/store/watcher.rs
@@ -102,11 +102,7 @@ impl StoreWatcher {
     ///
     /// Only indexes the path if it is serveable (signed or content-addressed).
     async fn process_create(&self, store_path: &str) {
-        let Some(hash) = store_path
-            .strip_prefix("/nix/store/")
-            .and_then(|s| s.get(..32))
-            .and_then(|h| h.parse::<StoreHash>().ok())
-        else {
+        let Ok(hash) = StoreHash::from_store_path(store_path) else {
             return;
         };
 

--- a/src/ogygia-nixutils/src/types.rs
+++ b/src/ogygia-nixutils/src/types.rs
@@ -114,6 +114,22 @@ impl StoreHash {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Extract the store-path hash from a full `/nix/store/<hash>-<name>` path.
+    ///
+    /// The hash is the 32 nixbase32 characters immediately after the
+    /// `/nix/store/` prefix. This is the one validated way to turn a store path
+    /// into a [`StoreHash`], replacing the ad-hoc `strip_prefix`/slice/parse
+    /// dance repeated across call sites.
+    pub fn from_store_path(path: &str) -> Result<Self> {
+        let rest = path
+            .strip_prefix("/nix/store/")
+            .with_context(|| format!("not a /nix/store path: {path}"))?;
+        let hash = rest
+            .get(..Self::LEN)
+            .with_context(|| format!("store path too short to contain a hash: {path}"))?;
+        hash.parse()
+    }
 }
 
 impl std::str::FromStr for StoreHash {
@@ -218,6 +234,26 @@ mod tests {
                 .parse::<StoreHash>()
                 .is_err()
         ); // 33
+    }
+
+    #[test]
+    fn store_hash_from_store_path_extracts_hash() {
+        let hash =
+            StoreHash::from_store_path("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-hello-2.10")
+                .unwrap();
+        assert_eq!(hash.as_str(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
+
+    #[test]
+    fn store_hash_from_store_path_rejects_bad_input() {
+        // Missing prefix.
+        assert!(StoreHash::from_store_path("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x").is_err());
+        // Too short to hold a 32-character hash.
+        assert!(StoreHash::from_store_path("/nix/store/aaa").is_err());
+        // Right length, but the hash contains a non-nixbase32 character.
+        assert!(
+            StoreHash::from_store_path("/nix/store/eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-x").is_err()
+        );
     }
 
     #[test]

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -10,6 +10,7 @@ irisd = [
     "dep:reqwest",
     "dep:serde_json",
     "dep:which",
+    "dep:ogygia-nixutils",
 ]
 
 [dependencies]
@@ -27,3 +28,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde_json = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
+ogygia-nixutils = { path = "../ogygia-nixutils", optional = true }

--- a/src/ogygia/src/iris/providers.rs
+++ b/src/ogygia/src/iris/providers.rs
@@ -5,9 +5,9 @@
 
 use anyhow::Context;
 use anyhow::Result;
-use anyhow::anyhow;
 use clap::Args;
 use clap::ValueEnum;
+use ogygia_nixutils::StoreHash;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -67,8 +67,8 @@ pub fn run(args: &ProvidersArgs) -> Result<()> {
 
 async fn run_async(args: &ProvidersArgs) -> Result<()> {
     let store_path_hash = parse_hash_or_store_path(&args.input)
-        .ok_or_else(|| {
-            anyhow!(
+        .with_context(|| {
+            format!(
                 "Invalid input '{}': expected 32-character hash or /nix/store/... path",
                 args.input
             )
@@ -154,15 +154,11 @@ fn print_json(result: &ProvidersResponse) -> Result<()> {
     Ok(())
 }
 
-/// Parse input that is either a 32-character hash or a full store path.
-fn parse_hash_or_store_path(input: &str) -> Option<&str> {
+/// Parse input that is either a 32-character store-path hash or a full store path.
+fn parse_hash_or_store_path(input: &str) -> Result<StoreHash> {
     if input.starts_with("/nix/store/") {
-        input
-            .strip_prefix("/nix/store/")
-            .map(|s| &s[..32.min(s.len())])
-    } else if input.len() == 32 && input.chars().all(|c| c.is_ascii_alphanumeric()) {
-        Some(input)
+        StoreHash::from_store_path(input)
     } else {
-        None
+        input.parse()
     }
 }


### PR DESCRIPTION
Extracting the 32-character hash from a /nix/store/<hash>-<name> path was reimplemented in irisd's rescan handler, the store watcher, and the `ogygia iris providers` CLI. Each hand-rolled the strip-prefix/slice/parse dance, and the CLI copy diverged: it validated with is_ascii_alphanumeric rather than the nixbase32 alphabet and silently truncated short input.

This adds StoreHash::from_store_path as the one validated way to turn a store path into a StoreHash, and routes every call site through it. The ogygia crate gains an optional ogygia-nixutils dependency (behind its default irisd feature) with the matching source wired into the nix build.

Consolidating on the type's own constructor gives a single, tested implementation with consistent nixbase32 validation everywhere.

Test plan:
- New unit tests cover from_store_path extracting a hash and rejecting a missing prefix, too-short input, and non-nixbase32 characters.
- Existing NixDb testcontainers equivalence test and `nix flake check` pass.