### PR TITLE
nixutils: expose store access as a lazily-connected Nix handle

### DIFF
--- a/src/ogygia-irisd/src/main.rs
+++ b/src/ogygia-irisd/src/main.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Parser;
-use ogygia_nixutils::NixDb;
+use ogygia_nixutils::Nix;
 use tokio::signal;
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
@@ -91,10 +91,10 @@ async fn main() -> Result<()> {
         tracing::info!("NAR cache: recovered {} entries from disk", recovered);
     }
 
-    // Open the Nix database (read-only). A single connection pool is shared,
-    // cheaply cloned, across the HTTP server, scanner, and watcher.
-    let nix_db = NixDb::open().await.context("Failed to open Nix database")?;
-    tracing::info!("Opened Nix database");
+    // Handle to the local Nix installation, cheaply cloned across the HTTP
+    // server, scanner, and watcher. The read-only database is opened lazily on
+    // first use and its connection pool shared across every clone.
+    let nix = Nix::default();
 
     // Cancellation token for coordinated shutdown
     let token = CancellationToken::new();
@@ -122,13 +122,13 @@ async fn main() -> Result<()> {
         Arc::clone(&peer_blooms),
         http_client,
         nar_cache,
-        nix_db.clone(),
+        nix.clone(),
         token.clone(),
     )));
 
     {
         let scanner =
-            store::scanner::StoreScanner::new(Arc::clone(&local_bloom), nix_db.clone(), rebuild_rx);
+            store::scanner::StoreScanner::new(Arc::clone(&local_bloom), nix.clone(), rebuild_rx);
         let local_bloom = Arc::clone(&local_bloom);
 
         tasks.push(tokio::spawn(async move {
@@ -142,10 +142,10 @@ async fn main() -> Result<()> {
     // Store watcher (optional, runs until cancelled)
     if !cli.no_watch {
         let bloom = Arc::clone(&local_bloom);
-        let nix_db = nix_db.clone();
+        let nix = nix.clone();
         let token = token.clone();
         tasks.push(tokio::spawn(async move {
-            let watcher = Arc::new(store::watcher::StoreWatcher::new(bloom, nix_db, rebuild_tx));
+            let watcher = Arc::new(store::watcher::StoreWatcher::new(bloom, nix, rebuild_tx));
             watcher.start(token).await
         }));
     }

--- a/src/ogygia-irisd/src/server/handlers.rs
+++ b/src/ogygia-irisd/src/server/handlers.rs
@@ -132,7 +132,7 @@ pub async fn get_local_narinfo(
 /// FileHash and FileSize (needed for integrity validation and range requests).
 async fn try_local_store_narinfo(state: &AppState, hash: &str) -> Option<NarInfo> {
     let store_hash = hash.parse::<StoreHash>().ok()?;
-    let path_info = match state.nix_db.find_path_info(&store_hash).await {
+    let path_info = match state.nix.find_path_info(&store_hash).await {
         Ok(Some(info)) => info,
         Ok(None) => return None,
         Err(e) => {
@@ -250,7 +250,7 @@ async fn try_local_store_nar(
         Ok(h) => h,
         Err(_) => return (StatusCode::NOT_FOUND, "Not found").into_response(),
     };
-    let path_info = match state.nix_db.find_path_info(&store_hash).await {
+    let path_info = match state.nix.find_path_info(&store_hash).await {
         Ok(Some(info)) => info,
         Ok(None) => return (StatusCode::NOT_FOUND, "Not found").into_response(),
         Err(e) => {
@@ -377,7 +377,7 @@ pub async fn get_providers(
     // Check local store
     let local = match hash.parse::<StoreHash>() {
         Ok(store_hash) => state
-            .nix_db
+            .nix
             .find_store_path(&store_hash)
             .await
             .ok()
@@ -465,7 +465,7 @@ pub async fn rescan(
         };
 
         // Query the Nix database and verify serveability
-        let serveable = match state.nix_db.is_path_serveable(&path_str).await {
+        let serveable = match state.nix.is_path_serveable(&path_str).await {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(
@@ -606,7 +606,7 @@ mod tests {
                 )),
                 http_client: reqwest::Client::new(),
                 nar_cache,
-                nix_db: ogygia_nixutils::NixDb::open_in_memory().await.unwrap(),
+                nix: ogygia_nixutils::Nix::in_memory().await.unwrap(),
             })
         }
 

--- a/src/ogygia-irisd/src/server/mod.rs
+++ b/src/ogygia-irisd/src/server/mod.rs
@@ -7,7 +7,7 @@ mod state;
 use std::sync::Arc;
 
 use anyhow::Result;
-use ogygia_nixutils::NixDb;
+use ogygia_nixutils::Nix;
 pub use routes::create_router;
 pub use state::AppState;
 use tokio_util::sync::CancellationToken;
@@ -28,7 +28,7 @@ pub async fn start(
     peer_blooms: Arc<PeerBlooms>,
     http_client: reqwest::Client,
     nar_cache: Arc<NarCache>,
-    nix_db: NixDb,
+    nix: Nix,
     token: CancellationToken,
 ) -> Result<()> {
     let state = Arc::new(AppState {
@@ -37,7 +37,7 @@ pub async fn start(
         peer_blooms,
         http_client,
         nar_cache,
-        nix_db,
+        nix,
     });
 
     let app = create_router(state).layer(

--- a/src/ogygia-irisd/src/server/state.rs
+++ b/src/ogygia-irisd/src/server/state.rs
@@ -12,7 +12,7 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use ogygia_nixutils::NarHash;
 use ogygia_nixutils::NarInfo;
-use ogygia_nixutils::NixDb;
+use ogygia_nixutils::Nix;
 
 use crate::bloom::local::LocalBloom;
 use crate::bloom::peers::PeerBlooms;
@@ -26,7 +26,7 @@ pub struct AppState {
     pub peer_blooms: Arc<PeerBlooms>,
     pub http_client: reqwest::Client,
     pub nar_cache: Arc<NarCache>,
-    pub nix_db: NixDb,
+    pub nix: Nix,
 }
 
 impl AppState {

--- a/src/ogygia-irisd/src/store/scanner.rs
+++ b/src/ogygia-irisd/src/store/scanner.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use ogygia_nixutils::NixDb;
+use ogygia_nixutils::Nix;
 use tokio::sync::mpsc;
 
 use crate::bloom::local::LocalBloom;
@@ -16,16 +16,16 @@ use crate::bloom::local::LocalBloom;
 /// Store scanner for indexing existing paths
 pub struct StoreScanner {
     bloom: Arc<LocalBloom>,
-    nix_db: NixDb,
+    nix: Nix,
     rebuild_rx: mpsc::Receiver<()>,
 }
 
 impl StoreScanner {
     /// Create a new store scanner with a channel for rebuild requests.
-    pub fn new(bloom: Arc<LocalBloom>, nix_db: NixDb, rebuild_rx: mpsc::Receiver<()>) -> Self {
+    pub fn new(bloom: Arc<LocalBloom>, nix: Nix, rebuild_rx: mpsc::Receiver<()>) -> Self {
         Self {
             bloom,
-            nix_db,
+            nix,
             rebuild_rx,
         }
     }
@@ -62,7 +62,7 @@ impl StoreScanner {
     pub async fn scan(&self, label: &str) -> Result<ScanStats> {
         tracing::info!("{}: starting...", label);
 
-        let hashes = self.nix_db.serveable_hashes().await?;
+        let hashes = self.nix.serveable_hashes().await?;
 
         let indexed = hashes.len();
         for hash in &hashes {

--- a/src/ogygia-irisd/src/store/watcher.rs
+++ b/src/ogygia-irisd/src/store/watcher.rs
@@ -13,7 +13,7 @@ use notify::EventKind;
 use notify::RecommendedWatcher;
 use notify::RecursiveMode;
 use notify::Watcher;
-use ogygia_nixutils::NixDb;
+use ogygia_nixutils::Nix;
 use ogygia_nixutils::StoreHash;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -23,16 +23,16 @@ use crate::bloom::local::LocalBloom;
 /// Store watcher that monitors /nix/store for path changes
 pub struct StoreWatcher {
     bloom: Arc<LocalBloom>,
-    nix_db: NixDb,
+    nix: Nix,
     rebuild_tx: mpsc::Sender<()>,
 }
 
 impl StoreWatcher {
     /// Create a new store watcher with a channel for requesting rebuilds.
-    pub fn new(bloom: Arc<LocalBloom>, nix_db: NixDb, rebuild_tx: mpsc::Sender<()>) -> Self {
+    pub fn new(bloom: Arc<LocalBloom>, nix: Nix, rebuild_tx: mpsc::Sender<()>) -> Self {
         Self {
             bloom,
-            nix_db,
+            nix,
             rebuild_tx,
         }
     }
@@ -106,7 +106,7 @@ impl StoreWatcher {
             return;
         };
 
-        let serveable = match self.nix_db.is_path_serveable(store_path).await {
+        let serveable = match self.nix.is_path_serveable(store_path).await {
             Ok(s) => s,
             Err(e) => {
                 tracing::debug!("Failed to query path info for {}: {}", store_path, e);

--- a/src/ogygia-nixutils/Cargo.toml
+++ b/src/ogygia-nixutils/Cargo.toml
@@ -13,6 +13,7 @@ hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/ogygia-nixutils/src/db.rs
+++ b/src/ogygia-nixutils/src/db.rs
@@ -42,10 +42,11 @@ const IN_MEMORY_SCHEMA: &str = "\
 
 /// Read-only handle to the Nix store database.
 ///
-/// Cloning is cheap and shares the underlying connection pool, so components
-/// (HTTP server, scanner, watcher) can each hold a `NixDb` while drawing from
-/// one pool of read-only connections. The pool can later grow, shrink, or gain
-/// smarter recycling without any caller changing how it queries.
+/// The backend behind [`Nix`](crate::Nix)'s store-metadata queries. Cloning is
+/// cheap and shares the underlying connection pool, so the components holding a
+/// `Nix` all draw from one pool of read-only connections. The pool can later
+/// grow, shrink, or gain smarter recycling without any caller changing how it
+/// queries.
 #[derive(Clone)]
 pub struct NixDb {
     pool: Pool,

--- a/src/ogygia-nixutils/src/lib.rs
+++ b/src/ogygia-nixutils/src/lib.rs
@@ -3,24 +3,25 @@
 //!
 //! `ogygia-irisd` needs fast, index-backed lookups of store-path metadata
 //! (the data behind `nix path-info`). Shelling out to `nix path-info --json`
-//! per request is slow; this crate provides a [`NixDb`] client — a
-//! cheaply-cloneable handle over an async connection pool to
-//! `/nix/var/nix/db/db.sqlite` — that answers the same questions directly.
-//! Alongside it live the strongly-typed store hashes ([`StoreHash`],
-//! [`NarHash`]), the [`PathInfo`] metadata record, and [`NarInfo`] narinfo
-//! parsing and serialization.
+//! per request is slow; this crate provides a [`Nix`] handle — a
+//! cheaply-cloneable entry point to the local Nix installation — whose
+//! store-metadata queries are answered directly from `/nix/var/nix/db/db.sqlite`
+//! via an async connection pool opened on first use. Alongside it live the
+//! strongly-typed store hashes ([`StoreHash`], [`NarHash`]), the [`PathInfo`]
+//! metadata record, and [`NarInfo`] narinfo parsing and serialization.
 //!
-//! The equivalence between [`NixDb`] and the real `nix path-info` command is
-//! verified by the testcontainers-based tests in `db.rs`.
+//! The equivalence between [`Nix`]'s queries and the real `nix path-info`
+//! command is verified by the testcontainers-based tests in `db.rs`.
 
-pub mod db;
+mod db;
 pub mod narinfo;
+mod nix;
 pub mod path_info;
 pub mod types;
 
-pub use db::NixDb;
 pub use narinfo::Compression;
 pub use narinfo::NarInfo;
+pub use nix::Nix;
 pub use path_info::PathInfo;
 pub use path_info::parse_path_info_json;
 pub use types::NarHash;

--- a/src/ogygia-nixutils/src/nix.rs
+++ b/src/ogygia-nixutils/src/nix.rs
@@ -1,0 +1,80 @@
+//! A handle to the local Nix installation.
+//!
+//! [`Nix`] is the entry point for asking questions about the local store. It is
+//! deliberately named for the domain, not the backend: today its store-metadata
+//! queries are answered by the Nix SQLite database ([`NixDb`]), but a caller
+//! writes `nix.find_path_info(..)` regardless of how that answer is produced, so
+//! individual operations can move between backends (a direct query, shelling out
+//! to a `nix` command, a Rust reimplementation) without touching call sites.
+//!
+//! Backends are opened lazily on first use and cached for the life of the
+//! handle. A caller that only exercises operations which don't need the database
+//! never opens it — and never has to declare up front whether it will.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::OnceCell;
+
+use crate::db::NixDb;
+use crate::path_info::PathInfo;
+use crate::types::StoreHash;
+
+/// A handle to the local Nix installation.
+///
+/// Cloning is cheap and all clones share one lazily-opened database: the first
+/// database-backed call anywhere opens the connection pool, and every clone sees
+/// it thereafter. The pool then stays open for the life of the handle rather
+/// than being torn down between calls, so repeated lookups reuse connections.
+#[derive(Clone)]
+pub struct Nix {
+    /// Shared so that cloning before the first query can't open several pools;
+    /// the `Arc` makes "open once" hold across every clone, not once per clone.
+    db: Arc<OnceCell<NixDb>>,
+}
+
+impl Nix {
+    /// A handle backed by an empty in-memory database, for tests that need a
+    /// [`Nix`] but no real store data: every lookup returns "not found".
+    pub async fn in_memory() -> Result<Self> {
+        let db = NixDb::open_in_memory().await?;
+        Ok(Self {
+            db: Arc::new(OnceCell::new_with(Some(db))),
+        })
+    }
+
+    /// The store database, opened on first use and cached for the process.
+    async fn db(&self) -> Result<&NixDb> {
+        self.db.get_or_try_init(NixDb::open).await
+    }
+
+    /// Find a store path by its store-path hash.
+    pub async fn find_store_path(&self, hash: &StoreHash) -> Result<Option<PathBuf>> {
+        self.db().await?.find_store_path(hash).await
+    }
+
+    /// Look up full path information by store-path hash.
+    pub async fn find_path_info(&self, hash: &StoreHash) -> Result<Option<PathInfo>> {
+        self.db().await?.find_path_info(hash).await
+    }
+
+    /// Return the 32-character store hashes of all serveable paths.
+    pub async fn serveable_hashes(&self) -> Result<Vec<StoreHash>> {
+        self.db().await?.serveable_hashes().await
+    }
+
+    /// Check whether a store path is serveable (signed or content-addressed).
+    pub async fn is_path_serveable(&self, store_path: &str) -> Result<bool> {
+        self.db().await?.is_path_serveable(store_path).await
+    }
+}
+
+impl Default for Nix {
+    /// A handle to the Nix installation at its default location.
+    fn default() -> Self {
+        Self {
+            db: Arc::new(OnceCell::new()),
+        }
+    }
+}

--- a/src/ogygia-nixutils/src/path_info.rs
+++ b/src/ogygia-nixutils/src/path_info.rs
@@ -11,12 +11,12 @@ use crate::types::NarHash;
 /// Information about a store path.
 ///
 /// These are exactly the fields reported by `nix path-info --json` that
-/// `ogygia-irisd` needs to build a narinfo. [`NixDb::find_path_info`] produces
+/// `ogygia-irisd` needs to build a narinfo. [`Nix::find_path_info`] produces
 /// the same value directly from the Nix database;
 /// [`parse_path_info_json`] produces it from the command's output. The two are
 /// asserted equal by the equivalence tests.
 ///
-/// [`NixDb::find_path_info`]: crate::db::NixDb::find_path_info
+/// [`Nix::find_path_info`]: crate::Nix::find_path_info
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PathInfo {
     /// Full store path.


### PR DESCRIPTION
The crate's public entry point was `NixDb`, which names the SQLite backend rather than the domain. That leaks an implementation detail: operations that don't need the database (such as future NAR dumping via `nix-store --dump`) would still be reached through a database handle, and every caller had to open the database up front even when it might never run a query.

This introduces `struct Nix`, a cheaply-cloneable handle to the local Nix installation, and demotes `NixDb` to a private backend behind it. The database lives in a shared `Arc<OnceCell<NixDb>>` opened on first use via `get_or_try_init`, so all clones share one lazily-opened pool that then stays alive for the process. The `irisd` server, scanner, and watcher now hold a `Nix` and call the same query methods, which delegate through the cell.

Naming the interface for the domain rather than the backend lets individual operations move between backends without touching call sites, and lazy connection means a caller that never touches the database never opens it and never has to declare that in advance.

Test plan:
- CI