### PR TITLE
nixutils: type NAR signatures as a parsed Signature

### DIFF
--- a/src/ogygia-irisd/src/nix/narinfo.rs
+++ b/src/ogygia-irisd/src/nix/narinfo.rs
@@ -53,6 +53,7 @@ pub fn narinfo_from_path_info(info: &PathInfo) -> NarInfo {
 #[cfg(test)]
 mod tests {
     use ogygia_nixutils::NarHash;
+    use ogygia_nixutils::Signature;
 
     use super::*;
 
@@ -67,7 +68,11 @@ mod tests {
             deriver: Some(
                 "/nix/store/drv123abc456def789ghi012jkl345mno-hello-2.10.drv".to_string(),
             ),
-            signatures: vec!["cache.nixos.org-1:signature123".to_string()],
+            signatures: vec![
+                "cache.nixos.org-1:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw=="
+                    .parse::<Signature>()
+                    .unwrap(),
+            ],
             ca: None,
         };
 

--- a/src/ogygia-nixutils/src/db.rs
+++ b/src/ogygia-nixutils/src/db.rs
@@ -208,12 +208,13 @@ impl NixDb {
 
         let nar_hash = NarHash::from_db_str(&row.hash)
             .with_context(|| format!("invalid NAR hash for {}", row.path))?;
-        let signatures: Vec<String> = row
+        let signatures = row
             .sigs
             .as_deref()
             .filter(|s| !s.is_empty())
-            .map(|s| s.split(' ').map(String::from).collect())
-            .unwrap_or_default();
+            .map(|s| s.split(' ').map(str::parse).collect())
+            .unwrap_or_else(|| Ok(Vec::new()))
+            .with_context(|| format!("invalid signature for {}", row.path))?;
 
         Ok(Some(PathInfo {
             path: row.path,

--- a/src/ogygia-nixutils/src/lib.rs
+++ b/src/ogygia-nixutils/src/lib.rs
@@ -7,8 +7,9 @@
 //! cheaply-cloneable entry point to the local Nix installation — whose
 //! store-metadata queries are answered directly from `/nix/var/nix/db/db.sqlite`
 //! via an async connection pool opened on first use. Alongside it live the
-//! strongly-typed store hashes ([`StoreHash`], [`NarHash`]), the [`PathInfo`]
-//! metadata record, and [`NarInfo`] narinfo parsing and serialization.
+//! strongly-typed store hashes ([`StoreHash`], [`NarHash`]) and signatures
+//! ([`Signature`]), the [`PathInfo`] metadata record, and [`NarInfo`] narinfo
+//! parsing and serialization.
 //!
 //! The equivalence between [`Nix`]'s queries and the real `nix path-info`
 //! command is verified by the testcontainers-based tests in `db.rs`.
@@ -17,6 +18,7 @@ mod db;
 pub mod narinfo;
 mod nix;
 pub mod path_info;
+mod signature;
 pub mod types;
 
 pub use narinfo::Compression;
@@ -24,5 +26,6 @@ pub use narinfo::NarInfo;
 pub use nix::Nix;
 pub use path_info::PathInfo;
 pub use path_info::parse_path_info_json;
+pub use signature::Signature;
 pub use types::NarHash;
 pub use types::StoreHash;

--- a/src/ogygia-nixutils/src/narinfo.rs
+++ b/src/ogygia-nixutils/src/narinfo.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use anyhow::Result;
 use anyhow::anyhow;
 
+use crate::signature::Signature;
 use crate::types::NarHash;
 
 /// Parsed narinfo file
@@ -31,7 +32,7 @@ pub struct NarInfo {
     /// Deriver store path (optional)
     pub deriver: Option<String>,
     /// Signatures
-    pub signatures: Vec<String>,
+    pub signatures: Vec<Signature>,
     /// Content-addressed info (optional)
     pub ca: Option<String>,
 }
@@ -50,19 +51,17 @@ pub enum Compression {
 impl NarInfo {
     /// Check if this narinfo has at least one signature from a trusted key.
     ///
-    /// Trusted keys are in format "name:base64-public-key".
-    /// Signatures are in format "name:base64-signature".
-    /// Returns true if any signature's name prefix matches a trusted key's name prefix.
+    /// Trusted keys are in format "name:base64-public-key"; a signature is
+    /// trusted if its key name matches that of any trusted key.
     pub fn has_trusted_signature(&self, trusted_keys: &[String]) -> bool {
         let trusted_names: Vec<&str> = trusted_keys
             .iter()
             .filter_map(|key| key.split_once(':').map(|(name, _)| name))
             .collect();
 
-        self.signatures.iter().any(|sig| {
-            sig.split_once(':')
-                .is_some_and(|(name, _)| trusted_names.contains(&name))
-        })
+        self.signatures
+            .iter()
+            .any(|sig| trusted_names.contains(&sig.name()))
     }
 
     /// Check if this narinfo has a meaningful content-addressed (CA) field.
@@ -117,7 +116,7 @@ impl FromStr for NarInfo {
                 let value = value.trim();
 
                 if key == "Sig" {
-                    signatures.push(value.to_string());
+                    signatures.push(value.parse()?);
                 } else {
                     fields.insert(key, value);
                 }
@@ -234,8 +233,8 @@ NarHash: sha256-S0ymvFDCaeUfZSW1veq0gU12WoV80qZSXcgyllwCzZY=
 NarSize: 67890
 References: abc123def456ghi789jkl012mno345pq-glibc-2.35
 Deriver: xyz789abc123def456ghi012jkl345mno-hello-2.10.drv
-Sig: cache.nixos.org-1:abcdefghijklmnop
-Sig: my-cache-1:qrstuvwxyz123456
+Sig: cache.nixos.org-1:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==
+Sig: my-cache-1:AAcOFRwjKjE4P0ZNVFtiaXB3foWMk5qhqK+2vcTL0tng5+71/AMKERgfJi00O0JJUFdeZWxzeoGIj5adpKuyuQ==
 "#;
 
     #[test]
@@ -277,6 +276,13 @@ Sig: my-cache-1:qrstuvwxyz123456
         assert!(!info.has_trusted_signature(&untrusted));
 
         assert!(!info.has_trusted_signature(&[]));
+    }
+
+    /// A valid signature under `name` (the body is arbitrary 64-byte content).
+    fn sig(name: &str) -> Signature {
+        format!("{name}:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==")
+            .parse()
+            .unwrap()
     }
 
     /// Helper to create a base NarInfo for testing
@@ -322,7 +328,7 @@ Sig: my-cache-1:qrstuvwxyz123456
         // CA path with trusted signature → is_trusted returns true
         let info = NarInfo {
             ca: Some("fixed:sha256:abc".to_string()),
-            signatures: vec!["cache.nixos.org-1:sig".to_string()],
+            signatures: vec![sig("cache.nixos.org-1")],
             ..base_narinfo()
         };
         let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];
@@ -333,7 +339,7 @@ Sig: my-cache-1:qrstuvwxyz123456
     fn test_is_trusted_non_ca_with_trusted_sig() {
         // Non-CA path with trusted signature → is_trusted returns true
         let info = NarInfo {
-            signatures: vec!["cache.nixos.org-1:sig".to_string()],
+            signatures: vec![sig("cache.nixos.org-1")],
             ..base_narinfo()
         };
         let trusted_keys = vec!["cache.nixos.org-1:publickey".to_string()];

--- a/src/ogygia-nixutils/src/path_info.rs
+++ b/src/ogygia-nixutils/src/path_info.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use anyhow::Result;
 use serde::Deserialize;
 
+use crate::signature::Signature;
 use crate::types::NarHash;
 
 /// Information about a store path.
@@ -29,8 +30,8 @@ pub struct PathInfo {
     pub references: Vec<String>,
     /// Deriver path, if known.
     pub deriver: Option<String>,
-    /// Signatures over the NAR (`<key-name>:<base64>`).
-    pub signatures: Vec<String>,
+    /// Signatures over the NAR.
+    pub signatures: Vec<Signature>,
     /// Content-addressing descriptor (e.g. `fixed:sha256:…`), if content-addressed.
     pub ca: Option<String>,
 }
@@ -78,13 +79,19 @@ pub fn parse_path_info_json(json: &str) -> Result<Vec<PathInfo>> {
         let Some(info) = info else { continue };
         let nar_hash = NarHash::from_sri(&info.nar_hash)
             .with_context(|| format!("invalid NarHash for {path}"))?;
+        let signatures = info
+            .signatures
+            .iter()
+            .map(|s| s.parse())
+            .collect::<Result<Vec<Signature>>>()
+            .with_context(|| format!("invalid signature for {path}"))?;
         result.push(PathInfo {
             path,
             nar_hash,
             nar_size: info.nar_size,
             references: info.references,
             deriver: info.deriver,
-            signatures: info.signatures,
+            signatures,
             ca: info.ca,
         });
     }
@@ -105,7 +112,7 @@ mod tests {
                     "/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-glibc-2.35"
                 ],
                 "deriver": "/nix/store/cccccccccccccccccccccccccccccccc-hello-2.10.drv",
-                "signatures": ["cache.nixos.org-1:sig"],
+                "signatures": ["cache.nixos.org-1:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw=="],
                 "ca": null
             }
         }"#;
@@ -127,7 +134,8 @@ mod tests {
             info.deriver.as_deref(),
             Some("/nix/store/cccccccccccccccccccccccccccccccc-hello-2.10.drv")
         );
-        assert_eq!(info.signatures, vec!["cache.nixos.org-1:sig"]);
+        assert_eq!(info.signatures.len(), 1);
+        assert_eq!(info.signatures[0].name(), "cache.nixos.org-1");
         assert_eq!(info.ca, None);
     }
 

--- a/src/ogygia-nixutils/src/signature.rs
+++ b/src/ogygia-nixutils/src/signature.rs
@@ -1,0 +1,117 @@
+//! A signature over a store path's NAR.
+//!
+//! Nix writes signatures as `<key-name>:<base64>`, where the base64 payload is
+//! a 64-byte Ed25519 signature. Previously these were passed around as bare
+//! strings, so every consumer that needed the key name re-ran the same
+//! `split_once(':')`. [`Signature`] parses the form once, holds the name and the
+//! raw signature bytes, and exposes the name directly — mirroring how
+//! [`NarHash`](crate::NarHash) turns a hash's encodings into rendering methods.
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+
+/// Length of an Ed25519 signature in bytes.
+const SIG_LEN: usize = 64;
+
+/// A signature over a store path's NAR, in Nix's `<key-name>:<base64>` form.
+///
+/// The body is the raw 64-byte Ed25519 signature; base64 is just its textual
+/// encoding, decoded on parsing ([`FromStr`](std::str::FromStr)) and re-rendered
+/// on [`Display`](std::fmt::Display). Holding the decoded bytes means an invalid or
+/// wrong-length signature is rejected at its ingestion point rather than
+/// surviving as an opaque string, and the key name — the only part callers match
+/// against trusted or signing keys — is a direct accessor.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Signature {
+    name: String,
+    body: [u8; SIG_LEN],
+}
+
+impl Signature {
+    /// The signing key's name (the part before the `:`).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The raw 64-byte Ed25519 signature.
+    pub fn body(&self) -> &[u8; SIG_LEN] {
+        &self.body
+    }
+}
+
+impl std::str::FromStr for Signature {
+    type Err = anyhow::Error;
+
+    /// Parse the `<key-name>:<base64>` form, decoding and length-checking the
+    /// Ed25519 signature body.
+    fn from_str(s: &str) -> Result<Self> {
+        let (name, body) = s
+            .split_once(':')
+            .with_context(|| format!("malformed signature, expected `<name>:<base64>`: {s}"))?;
+        let body: [u8; SIG_LEN] = BASE64
+            .decode(body)
+            .with_context(|| format!("invalid base64 in signature: {s}"))?
+            .try_into()
+            .map_err(|v: Vec<u8>| {
+                anyhow!("signature is {} bytes, expected {SIG_LEN}: {s}", v.len())
+            })?;
+        Ok(Self {
+            name: name.to_owned(),
+            body,
+        })
+    }
+}
+
+impl std::fmt::Display for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.name, BASE64.encode(self.body))
+    }
+}
+
+impl std::fmt::Debug for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Signature({self})")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `name:base64` for 64 arbitrary bytes — a well-formed signature.
+    fn sample() -> String {
+        format!("my-cache-1:{}", BASE64.encode([7u8; SIG_LEN]))
+    }
+
+    #[test]
+    fn parses_name_and_body() {
+        let sig: Signature = sample().parse().unwrap();
+        assert_eq!(sig.name(), "my-cache-1");
+        assert_eq!(sig.body(), &[7u8; SIG_LEN]);
+    }
+
+    #[test]
+    fn display_round_trips() {
+        let text = sample();
+        assert_eq!(text.parse::<Signature>().unwrap().to_string(), text);
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        assert!("no-colon-here".parse::<Signature>().is_err());
+    }
+
+    #[test]
+    fn rejects_bad_base64() {
+        assert!("name:not valid base64!!".parse::<Signature>().is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        // Valid base64 for 3 bytes, not 64.
+        assert!("name:YWJj".parse::<Signature>().is_err());
+    }
+}

--- a/src/ogygia/src/iris/nix.rs
+++ b/src/ogygia/src/iris/nix.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use ogygia_nixutils::Signature;
 use serde::Deserialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
@@ -49,8 +50,8 @@ fn nix_bin() -> &'static str {
 pub struct PathInfo {
     /// Full store path
     pub path: String,
-    /// Signatures on this path (format: "key-name:base64-signature")
-    pub signatures: Vec<String>,
+    /// Signatures on this path.
+    pub signatures: Vec<Signature>,
 }
 
 /// Raw JSON structure from `nix path-info --json` (path is the map key)
@@ -197,11 +198,16 @@ pub async fn query_ultimate_paths(paths: &[String]) -> Result<Vec<PathInfo>> {
     let ultimate_paths: Vec<PathInfo> = infos
         .into_iter()
         .filter(|(_, raw)| raw.ultimate)
-        .map(|(path, raw)| PathInfo {
-            path,
-            signatures: raw.signatures,
+        .map(|(path, raw)| {
+            let signatures = raw
+                .signatures
+                .iter()
+                .map(|s| s.parse())
+                .collect::<Result<Vec<Signature>>>()
+                .with_context(|| format!("invalid signature for {path}"))?;
+            Ok(PathInfo { path, signatures })
         })
-        .collect();
+        .collect::<Result<Vec<PathInfo>>>()?;
 
     Ok(ultimate_paths)
 }

--- a/src/ogygia/src/iris/push.rs
+++ b/src/ogygia/src/iris/push.rs
@@ -91,12 +91,11 @@ async fn async_run(args: &PushArgs) -> Result<()> {
 
     // Sign paths using nix store sign
     let key_name = parse_key_name(&args.signing_key)?;
-    let key_prefix = format!("{}:", key_name);
 
     // Filter out paths that already have our signature
     let unsigned: Vec<_> = ultimate_paths
         .iter()
-        .filter(|p| !p.signatures.iter().any(|s| s.starts_with(&key_prefix)))
+        .filter(|p| !p.signatures.iter().any(|s| s.name() == key_name))
         .collect();
 
     if unsigned.is_empty() {


### PR DESCRIPTION
Store-path signatures were passed around as bare `Vec<String>` in Nix's `<key-name>:<base64>` form, so every consumer that needed the key name re-ran the same `split_once(':')`, and a malformed signature survived as an opaque string all the way to serialization.

This adds a `Signature` type to ogygia-nixutils that parses the form once, holding the key name alongside the decoded 64-byte Ed25519 body, with `FromStr`/`Display` handling base64 the same way `NarHash` handles its encodings. The `signatures` fields of `PathInfo` and `NarInfo` (and the ogygia push path's local `PathInfo`) become `Vec<Signature>`, and the ad-hoc name splits in `has_trusted_signature` and the push dedup filter become `Signature::name()` comparisons.

Parsing at each ingestion point (the Nix DB row, narinfo files, and `nix path-info --json`) now rejects an invalid or wrong-length signature where it enters the system, and callers query the key name directly instead of re-splitting a string.

Test plan:
- New unit tests for Signature covering name/body parsing, Display round-trip, and rejection of a missing colon, bad base64, and wrong length.
- Updated the existing narinfo/path_info/irisd fixtures to real 64-byte signatures; `cargo test --workspace` passes, including the testcontainers `nix path-info` equivalence test, which exercises real Nix signatures through the database path.