### PR TITLE
nixutils: stream the store-path closure from the Nix handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "anyhow",
  "clap",
  "etcd-client",
+ "futures",
  "hostname",
  "ogygia-nixutils",
  "reqwest",
@@ -1981,8 +1982,10 @@ name = "ogygia-nixutils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "base64",
  "deadpool-sqlite",
+ "futures",
  "hex",
  "rstest",
  "rusqlite",
@@ -1992,6 +1995,8 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "tokio",
+ "tracing",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ enum-map = "2.7"
 # Utilities
 bytes = "1"
 futures = "0.3"
+async-stream = "0.3"
 thiserror = "2"
 
 # Filesystem watching

--- a/src/ogygia-nixutils/Cargo.toml
+++ b/src/ogygia-nixutils/Cargo.toml
@@ -13,7 +13,11 @@ hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "process", "io-util"] }
+futures = { workspace = true }
+async-stream = { workspace = true }
+which = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/src/ogygia-nixutils/src/cli.rs
+++ b/src/ogygia-nixutils/src/cli.rs
@@ -1,0 +1,98 @@
+//! Shelling out to the Nix CLIs.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use async_stream::try_stream;
+use futures::Stream;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::process::Command;
+
+/// Fallback locations for the `nix` binary when it isn't on `PATH`.
+const NIX_FALLBACKS: &[&str] = &[
+    "/run/current-system/sw/bin/nix",
+    "/nix/var/nix/profiles/default/bin/nix",
+];
+
+pub struct NixCli {
+    /// `Arc` so it can be cloned into a command's `'static` stream without
+    /// reallocating.
+    bin: Arc<Path>,
+}
+
+impl Default for NixCli {
+    /// Locate the `nix` binary: `PATH` first, then known fallback locations.
+    fn default() -> Self {
+        if which::which("nix").is_ok() {
+            tracing::info!("using nix from PATH");
+            return Self {
+                bin: Arc::from(Path::new("nix")),
+            };
+        }
+        for path in NIX_FALLBACKS {
+            if Path::new(path).exists() {
+                tracing::info!("using nix fallback: {path}");
+                return Self {
+                    bin: Arc::from(Path::new(path)),
+                };
+            }
+        }
+        tracing::warn!("nix not found on PATH or in fallback locations, assuming `nix`");
+        Self {
+            bin: Arc::from(Path::new("nix")),
+        }
+    }
+}
+
+impl NixCli {
+    /// Stream the closure of `paths` via `nix path-info -r`, one store path per
+    /// item. Runs lazily on first poll; a spawn failure or non-zero exit surfaces
+    /// as an `Err` item.
+    pub fn compute_closure(
+        &self,
+        paths: Vec<String>,
+    ) -> impl Stream<Item = Result<String>> + Send + 'static {
+        let bin = self.bin.clone();
+        try_stream! {
+            if paths.is_empty() {
+                return;
+            }
+
+            let mut child = Command::new(&*bin)
+                .args(["path-info", "-r"])
+                .args(&paths)
+                .stdout(Stdio::piped())
+                // stderr inherited so a full stderr pipe can't block the child
+                // while we drain only stdout.
+                .kill_on_drop(true)
+                .spawn()
+                .context("failed to spawn nix path-info -r")?;
+
+            let stdout = child
+                .stdout
+                .take()
+                .expect("child spawned with piped stdout");
+
+            let mut lines = BufReader::new(stdout).lines();
+            while let Some(line) = lines
+                .next_line()
+                .await
+                .context("reading nix path-info output")?
+            {
+                if !line.is_empty() {
+                    yield line;
+                }
+            }
+
+            let status = child.wait().await.context("waiting for nix path-info")?;
+            if !status.success() {
+                Err(anyhow!("nix path-info -r exited with {status}"))?;
+            }
+        }
+    }
+}

--- a/src/ogygia-nixutils/src/lib.rs
+++ b/src/ogygia-nixutils/src/lib.rs
@@ -14,6 +14,7 @@
 //! The equivalence between [`Nix`]'s queries and the real `nix path-info`
 //! command is verified by the testcontainers-based tests in `db.rs`.
 
+mod cli;
 mod db;
 pub mod narinfo;
 mod nix;

--- a/src/ogygia-nixutils/src/nix.rs
+++ b/src/ogygia-nixutils/src/nix.rs
@@ -13,25 +13,28 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use anyhow::Result;
+use futures::Stream;
 use tokio::sync::OnceCell;
 
+use crate::cli::NixCli;
 use crate::db::NixDb;
 use crate::path_info::PathInfo;
 use crate::types::StoreHash;
 
-/// A handle to the local Nix installation.
+/// A handle to the local Nix installation: the entry point for querying the
+/// store and running store operations.
 ///
-/// Cloning is cheap and all clones share one lazily-opened database: the first
-/// database-backed call anywhere opens the connection pool, and every clone sees
-/// it thereafter. The pool then stays open for the life of the handle rather
-/// than being torn down between calls, so repeated lookups reuse connections.
+/// Cheap to clone, and clones share one lazily-initialized backend, so pass it
+/// around freely rather than threading a reference.
 #[derive(Clone)]
 pub struct Nix {
     /// Shared so that cloning before the first query can't open several pools;
     /// the `Arc` makes "open once" hold across every clone, not once per clone.
     db: Arc<OnceCell<NixDb>>,
+    cli: Arc<OnceLock<NixCli>>,
 }
 
 impl Nix {
@@ -41,12 +44,19 @@ impl Nix {
         let db = NixDb::open_in_memory().await?;
         Ok(Self {
             db: Arc::new(OnceCell::new_with(Some(db))),
+            cli: Arc::new(OnceLock::new()),
         })
     }
 
     /// The store database, opened on first use and cached for the process.
     async fn db(&self) -> Result<&NixDb> {
         self.db.get_or_try_init(NixDb::open).await
+    }
+
+    /// The `nix` CLI backend, built on first use and cached for the life of the
+    /// handle.
+    fn cli(&self) -> &NixCli {
+        self.cli.get_or_init(NixCli::default)
     }
 
     /// Find a store path by its store-path hash.
@@ -68,6 +78,15 @@ impl Nix {
     pub async fn is_path_serveable(&self, store_path: &str) -> Result<bool> {
         self.db().await?.is_path_serveable(store_path).await
     }
+
+    /// Stream the closure of `paths` — every store path in their transitive
+    /// reference set, including the inputs themselves.
+    pub fn compute_closure(
+        &self,
+        paths: Vec<String>,
+    ) -> impl Stream<Item = Result<String>> + Send + 'static {
+        self.cli().compute_closure(paths)
+    }
 }
 
 impl Default for Nix {
@@ -75,6 +94,7 @@ impl Default for Nix {
     fn default() -> Self {
         Self {
             db: Arc::new(OnceCell::new()),
+            cli: Arc::new(OnceLock::new()),
         }
     }
 }

--- a/src/ogygia-nixutils/src/signature.rs
+++ b/src/ogygia-nixutils/src/signature.rs
@@ -1,11 +1,4 @@
-//! A signature over a store path's NAR.
-//!
-//! Nix writes signatures as `<key-name>:<base64>`, where the base64 payload is
-//! a 64-byte Ed25519 signature. Previously these were passed around as bare
-//! strings, so every consumer that needed the key name re-ran the same
-//! `split_once(':')`. [`Signature`] parses the form once, holds the name and the
-//! raw signature bytes, and exposes the name directly — mirroring how
-//! [`NarHash`](crate::NarHash) turns a hash's encodings into rendering methods.
+//! Parsing and serialization of Nix store-path signatures.
 
 use anyhow::Context;
 use anyhow::Result;
@@ -18,12 +11,9 @@ const SIG_LEN: usize = 64;
 
 /// A signature over a store path's NAR, in Nix's `<key-name>:<base64>` form.
 ///
-/// The body is the raw 64-byte Ed25519 signature; base64 is just its textual
-/// encoding, decoded on parsing ([`FromStr`](std::str::FromStr)) and re-rendered
-/// on [`Display`](std::fmt::Display). Holding the decoded bytes means an invalid or
-/// wrong-length signature is rejected at its ingestion point rather than
-/// surviving as an opaque string, and the key name — the only part callers match
-/// against trusted or signing keys — is a direct accessor.
+/// Parse with [`FromStr`](std::str::FromStr) (which validates the base64 and its
+/// length) and render back with [`Display`](std::fmt::Display); match it against
+/// a key by its [`name`](Self::name).
 #[derive(Clone, PartialEq, Eq)]
 pub struct Signature {
     name: String,

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -10,6 +10,7 @@ irisd = [
     "dep:reqwest",
     "dep:serde_json",
     "dep:which",
+    "dep:futures",
     "dep:ogygia-nixutils",
 ]
 
@@ -28,4 +29,5 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde_json = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 ogygia-nixutils = { path = "../ogygia-nixutils", optional = true }

--- a/src/ogygia/src/iris/nix.rs
+++ b/src/ogygia/src/iris/nix.rs
@@ -63,37 +63,6 @@ struct RawPathInfo {
     signatures: Vec<String>,
 }
 
-/// Compute the closure of store paths using `nix path-info -r`.
-///
-/// Returns all paths in the closure, including the input paths.
-pub async fn compute_closure(paths: &[String]) -> Result<Vec<String>> {
-    if paths.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let output = Command::new(nix_bin())
-        .args(["path-info", "-r"])
-        .args(paths)
-        .output()
-        .await
-        .context("Failed to run nix path-info -r")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow!("nix path-info -r failed: {}", stderr.trim()));
-    }
-
-    let stdout = String::from_utf8(output.stdout).context("Invalid UTF-8 in nix output")?;
-
-    let closure: Vec<String> = stdout
-        .lines()
-        .filter(|line| !line.is_empty())
-        .map(|s| s.to_string())
-        .collect();
-
-    Ok(closure)
-}
-
 /// Read store paths from stdin, one per line.
 ///
 /// Skips empty lines and lines that don't start with /nix/store/.

--- a/src/ogygia/src/iris/push.rs
+++ b/src/ogygia/src/iris/push.rs
@@ -9,9 +9,10 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
+use futures::TryStreamExt;
+use ogygia_nixutils::Nix;
 
 use super::client::IrisdClient;
-use super::nix::compute_closure;
 use super::nix::parse_key_name;
 use super::nix::query_ultimate_paths;
 use super::nix::read_store_paths_from_stdin;
@@ -69,7 +70,10 @@ async fn async_run(args: &PushArgs) -> Result<()> {
         input_paths
     } else {
         tracing::info!("Computing closure for {} paths...", input_paths.len());
-        let closure = compute_closure(&input_paths).await?;
+        let closure: Vec<String> = Nix::default()
+            .compute_closure(input_paths)
+            .try_collect()
+            .await?;
         tracing::info!("Closure contains {} store paths", closure.len());
         closure
     };


### PR DESCRIPTION
Closure computation lived in ogygia's `iris::nix` as a free function that shelled out to `nix path-info -r` and buffered the entire result into a `Vec<String>` before returning, so a large closure was held in memory twice and callers couldn't act on paths as they were discovered.

This moves the operation onto the shared `Nix` handle as `compute_closure`, returning `impl Stream<Item = Result<String>>` whose items are store paths yielded as `nix` emits them. A new `cli` backend module in ogygia-nixutils houses the `nix` binary discovery (relocated from ogygia) and an `async-stream` generator that launches the command on first poll, streams stdout lines, and surfaces a spawn failure or non-zero exit as a stream error; stderr stays inherited so its pipe cannot block the child while only stdout is drained. Because the stream is lazy, the planned database-backed form — a recursive query over the `Refs` table — can acquire its connection on first poll and keep this exact signature. The push command collects the stream for now, since its downstream signing and path-info steps remain batch operations.

Streaming store paths, rather than buffering a vector of stdout lines, is a contract the future `Refs` traversal satisfies unchanged, and lets a later per-path push pipeline consume the closure incrementally.

Test plan:
- `nix flake check` (clippy, rustdoc, treefmt, deny/audit, and the `ogygia-irisd-push` NixOS VM test, which runs `ogygia iris push` and so exercises closure computation end to end against a real Nix store).