### PR TITLE
nixutils: sign store paths through the Nix handle

### DIFF
--- a/src/ogygia-nixutils/src/cli.rs
+++ b/src/ogygia-nixutils/src/cli.rs
@@ -1,5 +1,6 @@
 //! Shelling out to the Nix CLIs.
 
+use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -9,7 +10,10 @@ use anyhow::Result;
 use anyhow::anyhow;
 use async_stream::try_stream;
 use futures::Stream;
+use futures::StreamExt;
+use futures::pin_mut;
 use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::process::Command;
 
@@ -50,6 +54,43 @@ impl Default for NixCli {
 }
 
 impl NixCli {
+    /// Sign the store paths in `paths` with the key in `key_file`.
+    pub async fn sign_paths<P>(&self, key_file: &Path, paths: impl Stream<Item = P>) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let mut child = Command::new(&*self.bin)
+            .args(["store", "sign", "--key-file"])
+            .arg(key_file)
+            .arg("--stdin")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .context("failed to spawn nix store sign")?;
+
+        let mut stdin = child.stdin.take().expect("child spawned with piped stdin");
+
+        pin_mut!(paths);
+        while let Some(path) = paths.next().await {
+            stdin
+                .write_all(path.as_ref().as_os_str().as_bytes())
+                .await
+                .context("writing paths to nix store sign")?;
+            stdin.write_all(b"\n").await?;
+        }
+        // Close stdin so the child sees EOF and stops reading.
+        drop(stdin);
+
+        let status = child.wait().await.context("waiting for nix store sign")?;
+        if !status.success() {
+            return Err(anyhow!("nix store sign exited with {status}"));
+        }
+
+        Ok(())
+    }
+
     /// Stream the closure of `paths` via `nix path-info -r`, one store path per
     /// item. Runs lazily on first poll; a spawn failure or non-zero exit surfaces
     /// as an `Err` item.

--- a/src/ogygia-nixutils/src/nix.rs
+++ b/src/ogygia-nixutils/src/nix.rs
@@ -11,6 +11,7 @@
 //! handle. A caller that only exercises operations which don't need the database
 //! never opens it — and never has to declare up front whether it will.
 
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -77,6 +78,16 @@ impl Nix {
     /// Check whether a store path is serveable (signed or content-addressed).
     pub async fn is_path_serveable(&self, store_path: &str) -> Result<bool> {
         self.db().await?.is_path_serveable(store_path).await
+    }
+
+    /// Sign the store paths in `paths` with the key in `key_file`. Paths that
+    /// already carry the key's signature are re-signed harmlessly; filter them
+    /// out beforehand to avoid the work.
+    pub async fn sign_paths<P>(&self, key_file: &Path, paths: impl Stream<Item = P>) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        self.cli().sign_paths(key_file, paths).await
     }
 
     /// Stream the closure of `paths` — every store path in their transitive

--- a/src/ogygia/src/iris/nix.rs
+++ b/src/ogygia/src/iris/nix.rs
@@ -87,55 +87,6 @@ pub async fn read_store_paths_from_stdin() -> Result<Vec<String>> {
     Ok(paths)
 }
 
-/// Result of signing store paths.
-#[derive(Debug)]
-pub struct SignResult {
-    /// Number of paths successfully signed
-    pub signed: usize,
-    /// Number of paths that failed to sign
-    pub failed: usize,
-}
-
-/// Sign store paths using `nix store sign --key-file`.
-///
-/// Accepts any iterator of path-like items and signs them in batches
-/// to avoid command line length limits.
-pub async fn sign_store_paths<I, P>(key_file: &Path, paths: I) -> Result<SignResult>
-where
-    I: IntoIterator<Item = P>,
-    P: AsRef<Path>,
-{
-    const BATCH_SIZE: usize = 100;
-
-    let mut signed = 0;
-    let mut failed = 0;
-
-    // Process paths in batches to avoid command line limits
-    let mut iter = paths.into_iter().peekable();
-    while iter.peek().is_some() {
-        let batch: Vec<_> = iter.by_ref().take(BATCH_SIZE).collect();
-
-        let mut cmd = Command::new(nix_bin());
-        cmd.args(["store", "sign", "--key-file"]);
-        cmd.arg(key_file);
-        for p in &batch {
-            cmd.arg(p.as_ref());
-        }
-
-        let output = cmd.output().await.context("Failed to run nix store sign")?;
-
-        if output.status.success() {
-            signed += batch.len();
-        } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!("nix store sign failed for batch: {}", stderr.trim());
-            failed += batch.len();
-        }
-    }
-
-    Ok(SignResult { signed, failed })
-}
-
 /// Query path info for multiple paths and filter to only ultimate (locally-built) paths.
 ///
 /// Returns PathInfo for paths where `ultimate: true`, meaning they were built

--- a/src/ogygia/src/iris/push.rs
+++ b/src/ogygia/src/iris/push.rs
@@ -10,13 +10,13 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
 use futures::TryStreamExt;
+use futures::stream;
 use ogygia_nixutils::Nix;
 
 use super::client::IrisdClient;
 use super::nix::parse_key_name;
 use super::nix::query_ultimate_paths;
 use super::nix::read_store_paths_from_stdin;
-use super::nix::sign_store_paths;
 
 /// Arguments for the push command
 #[derive(Args)]
@@ -56,6 +56,8 @@ async fn async_run(args: &PushArgs) -> Result<()> {
 
     tracing::info!("Connecting to irisd at {}", args.irisd_url);
 
+    let nix = Nix::default();
+
     // Read store paths from stdin
     let input_paths = read_store_paths_from_stdin().await?;
 
@@ -70,10 +72,7 @@ async fn async_run(args: &PushArgs) -> Result<()> {
         input_paths
     } else {
         tracing::info!("Computing closure for {} paths...", input_paths.len());
-        let closure: Vec<String> = Nix::default()
-            .compute_closure(input_paths)
-            .try_collect()
-            .await?;
+        let closure: Vec<String> = nix.compute_closure(input_paths).try_collect().await?;
         tracing::info!("Closure contains {} store paths", closure.len());
         closure
     };
@@ -117,17 +116,12 @@ async fn async_run(args: &PushArgs) -> Result<()> {
         ultimate_paths.len() - unsigned.len(),
         key_name
     );
-    let sign_result = sign_store_paths(&args.signing_key, unsigned.iter().map(|p| &p.path)).await?;
-
-    if sign_result.failed > 0 {
-        tracing::warn!(
-            "Signing: {} succeeded, {} failed",
-            sign_result.signed,
-            sign_result.failed
-        );
-    } else {
-        tracing::info!("Signed {} paths", sign_result.signed);
-    }
+    nix.sign_paths(
+        &args.signing_key,
+        stream::iter(unsigned.iter().map(|p| &p.path)),
+    )
+    .await?;
+    tracing::info!("Signed {} paths", unsigned.len());
 
     let paths_to_rescan: Vec<_> = unsigned.into_iter().map(|p| &p.path).collect();
 


### PR DESCRIPTION
Signing locally-built paths still shelled out to `nix store sign` from
ogygia's `iris::nix` module, which carried its own copy of the nix-binary
resolver that the nixutils crate already owns for its other store
operations.

This moves the call onto `NixCli` and exposes it as `Nix::sign_paths`,
feeding a stream of paths to `nix store sign --stdin`. Using stdin sidesteps
command-line length limits, so one process signs the whole stream however
long it is and nothing is collected in memory. The push command adapts its
filtered path list into a stream, and the duplicated implementation in
`iris::nix` is deleted.

The stream interface is shaped for the upcoming iris pipeline, which will tie
the closure computation through an ultimate-path filter directly into signing
with nothing collected in between. Making the stream infallible is the
caller's responsibility, keeping this function a plain sink.

Test plan:
- CI
- `cargo test -p ogygia-nixutils -p ogygia` (incl. the testcontainers
  path-info equivalence test)
- `cargo clippy -p ogygia-nixutils -p ogygia` clean