### PR TITLE
nixutils: detect ultimate paths through the Nix handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "which",
 ]
 
 [[package]]

--- a/src/ogygia-nixutils/src/cli.rs
+++ b/src/ogygia-nixutils/src/cli.rs
@@ -1,5 +1,6 @@
 //! Shelling out to the Nix CLIs.
 
+use std::collections::HashMap;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::process::Stdio;
@@ -12,6 +13,7 @@ use async_stream::try_stream;
 use futures::Stream;
 use futures::StreamExt;
 use futures::pin_mut;
+use serde::Deserialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
@@ -54,6 +56,26 @@ impl Default for NixCli {
 }
 
 impl NixCli {
+    /// Whether `store_path` was built locally rather than substituted from a
+    /// binary cache — Nix's `ultimate` flag, read from `nix path-info --json`.
+    pub async fn is_ultimate(&self, store_path: &str) -> Result<bool> {
+        let output = Command::new(&*self.bin)
+            .args(["path-info", "--json"])
+            .arg(store_path)
+            .output()
+            .await
+            .context("failed to run nix path-info --json")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!("nix path-info failed: {}", stderr.trim()));
+        }
+
+        let stdout =
+            std::str::from_utf8(&output.stdout).context("invalid UTF-8 in nix path-info output")?;
+        ultimate_from_path_info_json(stdout, store_path)
+    }
+
     /// Sign the store paths in `paths` with the key in `key_file`.
     pub async fn sign_paths<P>(&self, key_file: &Path, paths: impl Stream<Item = P>) -> Result<()>
     where
@@ -135,5 +157,133 @@ impl NixCli {
                 Err(anyhow!("nix path-info -r exited with {status}"))?;
             }
         }
+    }
+}
+
+/// Read the `ultimate` flag for `store_path` from `nix path-info --json` output.
+///
+/// The output is a map keyed by store path, where the queried path's entry
+/// carries a boolean `ultimate` (a path Nix doesn't know is reported as a `null`
+/// entry). Split out from [`NixCli::is_ultimate`] so the parse can be exercised
+/// against real `nix path-info --json` output without spawning `nix`.
+fn ultimate_from_path_info_json(json: &str, store_path: &str) -> Result<bool> {
+    #[derive(Deserialize)]
+    struct Entry {
+        #[serde(default)]
+        ultimate: bool,
+    }
+
+    let map: HashMap<String, Option<Entry>> =
+        serde_json::from_str(json).context("failed to parse nix path-info JSON")?;
+    let entry = map
+        .get(store_path)
+        .with_context(|| format!("nix path-info returned no entry for {store_path}"))?
+        .as_ref()
+        .with_context(|| format!("{store_path} is not a valid store path"))?;
+    Ok(entry.ultimate)
+}
+
+#[cfg(test)]
+mod tests {
+    use testcontainers::GenericImage;
+    use testcontainers::ImageExt;
+    use testcontainers::core::CmdWaitFor;
+    use testcontainers::core::ExecCommand;
+    use testcontainers::core::Mount;
+    use testcontainers::core::WaitFor;
+    use testcontainers::runners::AsyncRunner;
+
+    use super::*;
+
+    /// Shell script run inside the container to produce one locally-built path
+    /// (Nix marks build outputs `ultimate`) and one substituted path (the base
+    /// image's `bash`, imported into the store, so `ultimate` is unset). It
+    /// writes each path and the golden `nix path-info --json` covering both into
+    /// the bind-mounted `/work` directory.
+    const SETUP_SCRIPT: &str = r#"
+set -eu
+export NIX_CONFIG='substituters =
+experimental-features = nix-command'
+
+SH=$(command -v bash)
+# Resolve the profile symlink to the real store path, then take the store path
+# containing bash: a substituted, non-ultimate path.
+REAL=$(readlink -f "$SH")
+NONULTIMATE=/nix/store/$(printf '%s' "${REAL#/nix/store/}" | cut -d/ -f1)
+
+cat > /tmp/leaf.nix <<'NIXEOF'
+{ sh }:
+derivation {
+  name = "ultimate-leaf";
+  system = builtins.currentSystem;
+  builder = sh;
+  args = [ "-c" "echo built > $out" ];
+}
+NIXEOF
+
+# A locally-built output: Nix sets its ultimate flag.
+ULTIMATE=$(nix-build --no-out-link --argstr sh "$SH" /tmp/leaf.nix)
+
+printf '%s\n' "$ULTIMATE" > /work/ultimate.txt
+printf '%s\n' "$NONULTIMATE" > /work/nonultimate.txt
+nix path-info --json "$ULTIMATE" "$NONULTIMATE" > /work/golden.json
+chmod -R a+rw /work
+"#;
+
+    /// Confirm that `is_ultimate`'s parse reads Nix's `ultimate` flag correctly
+    /// from real, version-pinned `nix path-info --json` output. Ground truth is
+    /// how each path was created: a locally-built derivation is ultimate, a
+    /// substituted path is not — independent of the flag we are reading.
+    ///
+    /// Requires a Docker daemon.
+    #[tokio::test]
+    async fn is_ultimate_matches_nix_path_info() {
+        let work = tempfile::tempdir().unwrap();
+
+        let container = GenericImage::new("nixos/nix", "2.34.7")
+            .with_wait_for(WaitFor::message_on_stdout("container-ready"))
+            .with_cmd(["sh", "-c", "echo container-ready && sleep infinity"])
+            .with_mount(Mount::bind_mount(
+                work.path().to_str().unwrap().to_string(),
+                "/work",
+            ))
+            .start()
+            .await
+            .expect("start nix container");
+
+        let mut setup = container
+            .exec(
+                ExecCommand::new(["sh", "-c", SETUP_SCRIPT])
+                    .with_cmd_ready_condition(CmdWaitFor::exit()),
+            )
+            .await
+            .expect("exec setup script");
+        let exit = setup.exit_code().await.expect("setup exit code");
+        let _ = setup.stdout_to_vec().await;
+        let setup_stderr =
+            String::from_utf8_lossy(&setup.stderr_to_vec().await.unwrap()).to_string();
+        if exit != Some(0) {
+            panic!("setup script failed (exit {exit:?}):\n{setup_stderr}");
+        }
+
+        let ultimate = std::fs::read_to_string(work.path().join("ultimate.txt"))
+            .expect("read ultimate.txt")
+            .trim()
+            .to_string();
+        let nonultimate = std::fs::read_to_string(work.path().join("nonultimate.txt"))
+            .expect("read nonultimate.txt")
+            .trim()
+            .to_string();
+        let golden =
+            std::fs::read_to_string(work.path().join("golden.json")).expect("read golden.json");
+
+        assert!(
+            ultimate_from_path_info_json(&golden, &ultimate).expect("parse ultimate path"),
+            "locally-built path should be ultimate: {ultimate}",
+        );
+        assert!(
+            !ultimate_from_path_info_json(&golden, &nonultimate).expect("parse non-ultimate path"),
+            "substituted path should not be ultimate: {nonultimate}",
+        );
     }
 }

--- a/src/ogygia-nixutils/src/nix.rs
+++ b/src/ogygia-nixutils/src/nix.rs
@@ -80,6 +80,12 @@ impl Nix {
         self.db().await?.is_path_serveable(store_path).await
     }
 
+    /// Whether `store_path` was built locally rather than substituted from a
+    /// binary cache (Nix's `ultimate` flag).
+    pub async fn is_ultimate(&self, store_path: &str) -> Result<bool> {
+        self.cli().is_ultimate(store_path).await
+    }
+
     /// Sign the store paths in `paths` with the key in `key_file`. Paths that
     /// already carry the key's signature are re-signed harmlessly; filter them
     /// out beforehand to avoid the work.

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -9,7 +9,6 @@ default = ["irisd"]
 irisd = [
     "dep:reqwest",
     "dep:serde_json",
-    "dep:which",
     "dep:futures",
     "dep:ogygia-nixutils",
 ]
@@ -28,6 +27,5 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # Optional deps for irisd feature
 reqwest = { workspace = true, features = ["json"], optional = true }
 serde_json = { workspace = true, optional = true }
-which = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 ogygia-nixutils = { path = "../ogygia-nixutils", optional = true }

--- a/src/ogygia/src/iris/nix.rs
+++ b/src/ogygia/src/iris/nix.rs
@@ -1,67 +1,15 @@
-//! Nix store queries.
+//! Nix helpers for the iris subcommand.
 //!
-//! Provides functions to query information about Nix store paths
-//! using the `nix path-info` command.
+//! Reading store paths from stdin and parsing the signing key file; store-path
+//! metadata queries live in [`ogygia_nixutils`].
 
-use std::collections::HashMap;
 use std::path::Path;
-use std::sync::OnceLock;
 
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use ogygia_nixutils::Signature;
-use serde::Deserialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
-use tokio::process::Command;
-
-/// Fallback paths for nix binary when not in PATH.
-const NIX_FALLBACKS: &[&str] = &[
-    "/run/current-system/sw/bin/nix",
-    "/nix/var/nix/profiles/default/bin/nix",
-];
-
-static NIX_BIN: OnceLock<&'static str> = OnceLock::new();
-
-/// Find the nix binary, checking PATH first then falling back to known locations.
-fn nix_bin() -> &'static str {
-    NIX_BIN.get_or_init(|| {
-        // Check PATH first
-        if which::which("nix").is_ok() {
-            tracing::info!("using nix from PATH");
-            return "nix";
-        }
-        // Try fallback paths
-        for path in NIX_FALLBACKS {
-            if std::path::Path::new(path).exists() {
-                tracing::info!("using nix fallback: {}", path);
-                return path;
-            }
-        }
-        // Last resort, hope it's in PATH
-        tracing::warn!("nix not found in PATH or fallback locations, hoping for the best");
-        "nix"
-    })
-}
-
-/// Information about a Nix store path from `nix path-info --json`
-#[derive(Debug)]
-pub struct PathInfo {
-    /// Full store path
-    pub path: String,
-    /// Signatures on this path.
-    pub signatures: Vec<Signature>,
-}
-
-/// Raw JSON structure from `nix path-info --json` (path is the map key)
-#[derive(Deserialize)]
-struct RawPathInfo {
-    #[serde(default)]
-    ultimate: bool,
-    #[serde(default)]
-    signatures: Vec<String>,
-}
 
 /// Read store paths from stdin, one per line.
 ///
@@ -85,51 +33,6 @@ pub async fn read_store_paths_from_stdin() -> Result<Vec<String>> {
     }
 
     Ok(paths)
-}
-
-/// Query path info for multiple paths and filter to only ultimate (locally-built) paths.
-///
-/// Returns PathInfo for paths where `ultimate: true`, meaning they were built
-/// locally rather than substituted from a cache.
-pub async fn query_ultimate_paths(paths: &[String]) -> Result<Vec<PathInfo>> {
-    if paths.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Query all paths in batch
-    let mut cmd = Command::new(nix_bin());
-    cmd.args(["path-info", "--json"]);
-    cmd.args(paths);
-
-    let output = cmd.output().await.context("Failed to run nix path-info")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow!("nix path-info failed: {}", stderr.trim()));
-    }
-
-    let stdout = String::from_utf8(output.stdout).context("Invalid UTF-8 in nix output")?;
-
-    // Parse the JSON map
-    let infos: HashMap<String, RawPathInfo> =
-        serde_json::from_str(&stdout).context("Failed to parse nix path-info JSON")?;
-
-    // Filter to only ultimate paths
-    let ultimate_paths: Vec<PathInfo> = infos
-        .into_iter()
-        .filter(|(_, raw)| raw.ultimate)
-        .map(|(path, raw)| {
-            let signatures = raw
-                .signatures
-                .iter()
-                .map(|s| s.parse())
-                .collect::<Result<Vec<Signature>>>()
-                .with_context(|| format!("invalid signature for {path}"))?;
-            Ok(PathInfo { path, signatures })
-        })
-        .collect::<Result<Vec<PathInfo>>>()?;
-
-    Ok(ultimate_paths)
 }
 
 /// Parse key name from a Nix signing key file.

--- a/src/ogygia/src/iris/push.rs
+++ b/src/ogygia/src/iris/push.rs
@@ -9,13 +9,14 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
+use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::stream;
 use ogygia_nixutils::Nix;
+use ogygia_nixutils::StoreHash;
 
 use super::client::IrisdClient;
 use super::nix::parse_key_name;
-use super::nix::query_ultimate_paths;
 use super::nix::read_store_paths_from_stdin;
 
 /// Arguments for the push command
@@ -66,72 +67,54 @@ async fn async_run(args: &PushArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Compute closure unless --no-closure is specified
-    let store_paths = if args.no_closure {
-        tracing::info!("Processing {} store paths...", input_paths.len());
-        input_paths
-    } else {
-        tracing::info!("Computing closure for {} paths...", input_paths.len());
-        let closure: Vec<String> = nix.compute_closure(input_paths).try_collect().await?;
-        tracing::info!("Closure contains {} store paths", closure.len());
-        closure
-    };
-
-    // Query path info and filter to ultimate (locally-built) paths
-    tracing::info!("Querying path info for {} paths...", store_paths.len());
-    let ultimate_paths = query_ultimate_paths(&store_paths).await?;
-
-    if ultimate_paths.is_empty() {
-        tracing::warn!("No ultimate (locally-built) paths found to push");
-        return Ok(());
-    }
-
-    tracing::info!(
-        "Found {} ultimate paths out of {} total",
-        ultimate_paths.len(),
-        store_paths.len()
-    );
-
-    // Sign paths using nix store sign
     let key_name = parse_key_name(&args.signing_key)?;
 
-    // Filter out paths that already have our signature
-    let unsigned: Vec<_> = ultimate_paths
-        .iter()
-        .filter(|p| !p.signatures.iter().any(|s| s.name() == key_name))
-        .collect();
+    // The store paths to consider, as a stream: the closure of the inputs, or
+    // the inputs themselves with --no-closure.
+    let store_paths = if args.no_closure {
+        tracing::info!("Processing {} store paths...", input_paths.len());
+        stream::iter(input_paths)
+            .map(Ok::<_, anyhow::Error>)
+            .boxed()
+    } else {
+        tracing::info!("Computing closure of {} paths...", input_paths.len());
+        nix.compute_closure(input_paths).boxed()
+    };
 
-    if unsigned.is_empty() {
-        tracing::info!(
-            "All {} paths already signed with {}",
-            ultimate_paths.len(),
-            key_name
-        );
+    // Keep only ultimate (locally-built) paths that don't already carry our
+    // signature; both checks query the local Nix installation per path.
+    let to_sign: Vec<String> = {
+        let nix = &nix;
+        let key = key_name.as_str();
+        store_paths
+            .try_filter_map(move |path| async move {
+                if !nix.is_ultimate(&path).await? {
+                    return Ok(None);
+                }
+                let hash = StoreHash::from_store_path(&path)?;
+                let already_signed = nix
+                    .find_path_info(&hash)
+                    .await?
+                    .is_some_and(|info| info.signatures.iter().any(|s| s.name() == key));
+                Ok((!already_signed).then_some(path))
+            })
+            .try_collect()
+            .await?
+    };
+
+    if to_sign.is_empty() {
+        tracing::info!("No unsigned ultimate paths to push");
         return Ok(());
     }
 
-    tracing::info!(
-        "Signing {} paths ({} already signed with {})...",
-        unsigned.len(),
-        ultimate_paths.len() - unsigned.len(),
-        key_name
-    );
-    nix.sign_paths(
-        &args.signing_key,
-        stream::iter(unsigned.iter().map(|p| &p.path)),
-    )
-    .await?;
-    tracing::info!("Signed {} paths", unsigned.len());
-
-    let paths_to_rescan: Vec<_> = unsigned.into_iter().map(|p| &p.path).collect();
+    tracing::info!("Signing {} paths with {}...", to_sign.len(), key_name);
+    nix.sign_paths(&args.signing_key, stream::iter(&to_sign))
+        .await?;
 
     // Notify irisd to rescan the newly signed paths
-    tracing::info!(
-        "Notifying irisd to rescan {} paths...",
-        paths_to_rescan.len()
-    );
+    tracing::info!("Notifying irisd to rescan {} paths...", to_sign.len());
     let rescan_result = client
-        .rescan(paths_to_rescan)
+        .rescan(&to_sign)
         .await
         .context("Failed to rescan paths")?;
 


### PR DESCRIPTION
The iris push command shelled out to `nix path-info --json` directly to
find locally-built (ultimate) store paths, duplicating the nix-binary
discovery and JSON parsing that belong with the rest of the store-access
code in ogygia-nixutils.

This adds an `is_ultimate` query to the `Nix` handle, backed for now by
`nix path-info --json`, and rewrites iris push around it: it filters the
streamed closure with `Nix::is_ultimate`, collecting only the ultimate
paths not already signed with our key (their signatures read through the
handle's `find_path_info`), then signs and rescans that set. The now-dead
nix binary lookup, `PathInfo`, and `query_ultimate_paths` are removed from
iris, along with its now-unused `which` dependency.

This keeps a single, tested definition of how the local Nix installation
is queried, locking in the interface so the backend can later move to a
direct database read without touching the call site.

Test plan:
- Added a testcontainer test that builds a derivation locally (ultimate by
  construction) alongside a substituted path (not ultimate) and asserts the
  `ultimate` flag is parsed correctly out of real, version-pinned
  `nix path-info --json` output. Ground truth is how each path was created,
  independent of the flag under test.
- Ran `cargo test -p ogygia-nixutils`, `cargo clippy --all-targets`, `cargo fmt`.
- CI