### PR TITLE
nixutils: answer is_ultimate from the Nix database

### DIFF
--- a/src/ogygia-nixutils/src/cli.rs
+++ b/src/ogygia-nixutils/src/cli.rs
@@ -1,6 +1,5 @@
 //! Shelling out to the Nix CLIs.
 
-use std::collections::HashMap;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::process::Stdio;
@@ -13,7 +12,6 @@ use async_stream::try_stream;
 use futures::Stream;
 use futures::StreamExt;
 use futures::pin_mut;
-use serde::Deserialize;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
@@ -56,26 +54,6 @@ impl Default for NixCli {
 }
 
 impl NixCli {
-    /// Whether `store_path` was built locally rather than substituted from a
-    /// binary cache — Nix's `ultimate` flag, read from `nix path-info --json`.
-    pub async fn is_ultimate(&self, store_path: &str) -> Result<bool> {
-        let output = Command::new(&*self.bin)
-            .args(["path-info", "--json"])
-            .arg(store_path)
-            .output()
-            .await
-            .context("failed to run nix path-info --json")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow!("nix path-info failed: {}", stderr.trim()));
-        }
-
-        let stdout =
-            std::str::from_utf8(&output.stdout).context("invalid UTF-8 in nix path-info output")?;
-        ultimate_from_path_info_json(stdout, store_path)
-    }
-
     /// Sign the store paths in `paths` with the key in `key_file`.
     pub async fn sign_paths<P>(&self, key_file: &Path, paths: impl Stream<Item = P>) -> Result<()>
     where
@@ -157,133 +135,5 @@ impl NixCli {
                 Err(anyhow!("nix path-info -r exited with {status}"))?;
             }
         }
-    }
-}
-
-/// Read the `ultimate` flag for `store_path` from `nix path-info --json` output.
-///
-/// The output is a map keyed by store path, where the queried path's entry
-/// carries a boolean `ultimate` (a path Nix doesn't know is reported as a `null`
-/// entry). Split out from [`NixCli::is_ultimate`] so the parse can be exercised
-/// against real `nix path-info --json` output without spawning `nix`.
-fn ultimate_from_path_info_json(json: &str, store_path: &str) -> Result<bool> {
-    #[derive(Deserialize)]
-    struct Entry {
-        #[serde(default)]
-        ultimate: bool,
-    }
-
-    let map: HashMap<String, Option<Entry>> =
-        serde_json::from_str(json).context("failed to parse nix path-info JSON")?;
-    let entry = map
-        .get(store_path)
-        .with_context(|| format!("nix path-info returned no entry for {store_path}"))?
-        .as_ref()
-        .with_context(|| format!("{store_path} is not a valid store path"))?;
-    Ok(entry.ultimate)
-}
-
-#[cfg(test)]
-mod tests {
-    use testcontainers::GenericImage;
-    use testcontainers::ImageExt;
-    use testcontainers::core::CmdWaitFor;
-    use testcontainers::core::ExecCommand;
-    use testcontainers::core::Mount;
-    use testcontainers::core::WaitFor;
-    use testcontainers::runners::AsyncRunner;
-
-    use super::*;
-
-    /// Shell script run inside the container to produce one locally-built path
-    /// (Nix marks build outputs `ultimate`) and one substituted path (the base
-    /// image's `bash`, imported into the store, so `ultimate` is unset). It
-    /// writes each path and the golden `nix path-info --json` covering both into
-    /// the bind-mounted `/work` directory.
-    const SETUP_SCRIPT: &str = r#"
-set -eu
-export NIX_CONFIG='substituters =
-experimental-features = nix-command'
-
-SH=$(command -v bash)
-# Resolve the profile symlink to the real store path, then take the store path
-# containing bash: a substituted, non-ultimate path.
-REAL=$(readlink -f "$SH")
-NONULTIMATE=/nix/store/$(printf '%s' "${REAL#/nix/store/}" | cut -d/ -f1)
-
-cat > /tmp/leaf.nix <<'NIXEOF'
-{ sh }:
-derivation {
-  name = "ultimate-leaf";
-  system = builtins.currentSystem;
-  builder = sh;
-  args = [ "-c" "echo built > $out" ];
-}
-NIXEOF
-
-# A locally-built output: Nix sets its ultimate flag.
-ULTIMATE=$(nix-build --no-out-link --argstr sh "$SH" /tmp/leaf.nix)
-
-printf '%s\n' "$ULTIMATE" > /work/ultimate.txt
-printf '%s\n' "$NONULTIMATE" > /work/nonultimate.txt
-nix path-info --json "$ULTIMATE" "$NONULTIMATE" > /work/golden.json
-chmod -R a+rw /work
-"#;
-
-    /// Confirm that `is_ultimate`'s parse reads Nix's `ultimate` flag correctly
-    /// from real, version-pinned `nix path-info --json` output. Ground truth is
-    /// how each path was created: a locally-built derivation is ultimate, a
-    /// substituted path is not — independent of the flag we are reading.
-    ///
-    /// Requires a Docker daemon.
-    #[tokio::test]
-    async fn is_ultimate_matches_nix_path_info() {
-        let work = tempfile::tempdir().unwrap();
-
-        let container = GenericImage::new("nixos/nix", "2.34.7")
-            .with_wait_for(WaitFor::message_on_stdout("container-ready"))
-            .with_cmd(["sh", "-c", "echo container-ready && sleep infinity"])
-            .with_mount(Mount::bind_mount(
-                work.path().to_str().unwrap().to_string(),
-                "/work",
-            ))
-            .start()
-            .await
-            .expect("start nix container");
-
-        let mut setup = container
-            .exec(
-                ExecCommand::new(["sh", "-c", SETUP_SCRIPT])
-                    .with_cmd_ready_condition(CmdWaitFor::exit()),
-            )
-            .await
-            .expect("exec setup script");
-        let exit = setup.exit_code().await.expect("setup exit code");
-        let _ = setup.stdout_to_vec().await;
-        let setup_stderr =
-            String::from_utf8_lossy(&setup.stderr_to_vec().await.unwrap()).to_string();
-        if exit != Some(0) {
-            panic!("setup script failed (exit {exit:?}):\n{setup_stderr}");
-        }
-
-        let ultimate = std::fs::read_to_string(work.path().join("ultimate.txt"))
-            .expect("read ultimate.txt")
-            .trim()
-            .to_string();
-        let nonultimate = std::fs::read_to_string(work.path().join("nonultimate.txt"))
-            .expect("read nonultimate.txt")
-            .trim()
-            .to_string();
-        let golden =
-            std::fs::read_to_string(work.path().join("golden.json")).expect("read golden.json");
-
-        assert!(
-            ultimate_from_path_info_json(&golden, &ultimate).expect("parse ultimate path"),
-            "locally-built path should be ultimate: {ultimate}",
-        );
-        assert!(
-            !ultimate_from_path_info_json(&golden, &nonultimate).expect("parse non-ultimate path"),
-            "substituted path should not be ultimate: {nonultimate}",
-        );
     }
 }

--- a/src/ogygia-nixutils/src/db.rs
+++ b/src/ogygia-nixutils/src/db.rs
@@ -34,6 +34,7 @@ const IN_MEMORY_SCHEMA: &str = "\
         path TEXT UNIQUE, \
         hash TEXT, \
         narSize INTEGER, \
+        ultimate INTEGER, \
         sigs TEXT, \
         ca TEXT, \
         deriver TEXT \
@@ -246,6 +247,26 @@ impl NixDb {
         raw.iter().map(|h| h.parse()).collect()
     }
 
+    /// Whether a store path was built locally rather than substituted from a
+    /// binary cache — Nix's `ultimate` flag, read from the `ValidPaths.ultimate`
+    /// column (`null` implies false). Errors if the path is not in the store,
+    /// matching what `nix path-info` reports for an unknown path.
+    pub async fn is_ultimate(&self, store_path: &str) -> Result<bool> {
+        let owned = store_path.to_owned();
+        let ultimate = self
+            .query(move |conn| {
+                let mut stmt =
+                    conn.prepare_cached("SELECT ultimate FROM ValidPaths WHERE path = ?1")?;
+                stmt.query_row([&owned], |row| row.get::<_, Option<i64>>(0))
+                    .optional()
+            })
+            .await?;
+        match ultimate {
+            Some(flag) => Ok(flag.unwrap_or(0) != 0),
+            None => anyhow::bail!("{store_path} is not a valid store path"),
+        }
+    }
+
     /// Check whether a store path is serveable (signed or content-addressed).
     pub async fn is_path_serveable(&self, store_path: &str) -> Result<bool> {
         let store_path = store_path.to_owned();
@@ -298,9 +319,10 @@ mod tests {
     /// Shell script run inside the container to produce a variety of store
     /// paths covering the cases the SQLite queries must get right:
     ///   - a content-addressed path (no refs, no deriver, no sigs)
-    ///   - built derivations with a deriver
+    ///   - built derivations with a deriver (Nix marks these `ultimate`)
     ///   - a path with multiple references (insertion order != lexical order)
     ///     plus a self-reference, signed with two keys
+    ///   - a substituted path (the base image's `bash`), which is not `ultimate`
     ///
     /// It writes the list of paths, the golden `nix path-info --json`, and a
     /// copy of the database into the bind-mounted `/work` directory.
@@ -311,6 +333,10 @@ experimental-features = nix-command'
 
 # A builder shell that definitely exists in this image's store.
 SH=$(command -v bash)
+# The store path containing the builder shell: substituted into the image's
+# store, so Nix leaves its `ultimate` flag unset.
+REAL=$(readlink -f "$SH")
+PB=/nix/store/$(printf '%s' "${REAL#/nix/store/}" | cut -d/ -f1)
 
 cat > /tmp/leaf.nix <<'NIXEOF'
 { sh, name }:
@@ -354,7 +380,7 @@ nix-store --generate-binary-cache-key test-key-2 /tmp/k2.sec /tmp/k2.pub
 nix store sign --key-file /tmp/k1.sec "$PC"
 nix store sign --key-file /tmp/k2.sec "$PC"
 
-printf '%s\n' "$PA" "$L1" "$L2" "$L3" "$PC" > /work/paths.txt
+printf '%s\n' "$PA" "$L1" "$L2" "$L3" "$PC" "$PB" > /work/paths.txt
 nix path-info --json $(cat /work/paths.txt) > /work/golden.json
 cp /nix/var/nix/db/db.sqlite* /work/
 chmod -R a+rw /work
@@ -364,6 +390,7 @@ chmod -R a+rw /work
     /// read-only [`NixDb`] queries agree with `nix path-info --json`:
     ///   - `find_path_info` matches the golden metadata field-for-field
     ///   - `is_path_serveable` matches `PathInfo::is_serveable` per path
+    ///   - `is_ultimate` matches the golden `ultimate` flag per path
     ///   - `find_store_path` resolves each hash back to its full store path
     ///   - `serveable_hashes` returns exactly the set of serveable paths
     ///
@@ -430,9 +457,32 @@ chmod -R a+rw /work
             .map(|info| (info.path.clone(), info))
             .collect();
 
+        // `ultimate` isn't part of `PathInfo` (nothing that consumes a
+        // `PathInfo` needs it), so read the flag straight from the golden JSON
+        // to check `is_ultimate` against.
+        #[derive(serde::Deserialize)]
+        struct GoldenUltimate {
+            #[serde(default)]
+            ultimate: bool,
+        }
+        let golden_ultimate: HashMap<String, GoldenUltimate> =
+            serde_json::from_str(&golden_json).expect("parse golden ultimate flags");
+
         let db = NixDb::open_path(&db_copy).await.expect("open NixDb");
 
         assert!(!paths.is_empty(), "no paths produced by setup");
+
+        // The `is_ultimate` check below is only meaningful if the fixture
+        // exercises both states: the built paths are ultimate, the substituted
+        // bash path is not.
+        assert!(
+            paths.iter().any(|p| golden_ultimate[p].ultimate),
+            "fixture produced no ultimate path",
+        );
+        assert!(
+            paths.iter().any(|p| !golden_ultimate[p].ultimate),
+            "fixture produced no non-ultimate path",
+        );
 
         for store_path in &paths {
             // "/nix/store/" is 11 chars; the hash is the next 32.
@@ -456,6 +506,14 @@ chmod -R a+rw /work
                     .expect("is_path_serveable query"),
                 expected.is_serveable(),
                 "is_path_serveable mismatch for {store_path}",
+            );
+
+            // The dedicated `is_ultimate` query must agree with the golden
+            // `ultimate` flag.
+            assert_eq!(
+                db.is_ultimate(store_path).await.expect("is_ultimate query"),
+                golden_ultimate[store_path].ultimate,
+                "is_ultimate mismatch for {store_path}",
             );
 
             // The hash prefix must resolve back to the full store path.
@@ -487,5 +545,47 @@ chmod -R a+rw /work
                 "serveable_hashes membership mismatch for {store_path}",
             );
         }
+    }
+
+    /// `is_ultimate` reads the `ultimate` column, treats a `null` (the common
+    /// case for substituted paths) as false, and reports an unknown path as an
+    /// error the way `nix path-info` does. Runs against an in-memory database,
+    /// so it needs no Docker daemon.
+    #[tokio::test]
+    async fn is_ultimate_reads_column_treating_null_as_false() {
+        let db = NixDb::open_in_memory().await.expect("open in-memory db");
+        db.pool
+            .get()
+            .await
+            .expect("connection")
+            .interact(|conn| {
+                conn.execute_batch(
+                    "INSERT INTO ValidPaths (path, hash, narSize, ultimate) VALUES \
+                     ('/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-built', 'sha256:00', 1, 1), \
+                     ('/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-subst', 'sha256:00', 1, NULL)",
+                )
+            })
+            .await
+            .expect("interact")
+            .expect("insert rows");
+
+        assert!(
+            db.is_ultimate("/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-built")
+                .await
+                .expect("ultimate query"),
+            "path with ultimate=1 should be ultimate",
+        );
+        assert!(
+            !db.is_ultimate("/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-subst")
+                .await
+                .expect("non-ultimate query"),
+            "path with ultimate=NULL should not be ultimate",
+        );
+        assert!(
+            db.is_ultimate("/nix/store/cccccccccccccccccccccccccccccccc-missing")
+                .await
+                .is_err(),
+            "unknown path should error",
+        );
     }
 }

--- a/src/ogygia-nixutils/src/nix.rs
+++ b/src/ogygia-nixutils/src/nix.rs
@@ -83,7 +83,7 @@ impl Nix {
     /// Whether `store_path` was built locally rather than substituted from a
     /// binary cache (Nix's `ultimate` flag).
     pub async fn is_ultimate(&self, store_path: &str) -> Result<bool> {
-        self.cli().is_ultimate(store_path).await
+        self.db().await?.is_ultimate(store_path).await
     }
 
     /// Sign the store paths in `paths` with the key in `key_file`. Paths that


### PR DESCRIPTION
`Nix::is_ultimate` shelled out to `nix path-info --json`, spawning a
`nix` process per store path — needlessly slow now that the rest of the
handle's store metadata is served from the Nix SQLite database.

This moves the query to a direct, index-backed lookup on the
`ValidPaths.ultimate` column (with `null` treated as false, and an unknown
path reported as an error, exactly as before), and drops the now-unused
CLI implementation. `ultimate` also becomes a field of `PathInfo` so it is
part of the full path-info record `find_path_info` and `parse_path_info_json`
produce, and the `PathInfo` doc no longer claims to be scoped to one
downstream consumer. The `Nix` interface is unchanged, so iris push carries
over untouched.

Reading the flag from the same database as the other queries removes the
per-path subprocess while preserving the observable behaviour.

Test plan:
- Extended the container equivalence test (`nix_db_matches_nix_path_info`) with
  a substituted (non-ultimate) path, so the field-for-field
  `find_path_info` vs `nix path-info --json` comparison now covers `ultimate`,
  and the dedicated `is_ultimate` query is checked against the same golden
  flag. The oracle is Nix's own output.
- Added an in-memory `NixDb` unit test covering `ultimate = 1`, a `null`
  column (treated as false), and an unknown path (error), plus `ultimate`
  assertions in the `parse_path_info_json` unit tests.
- Ran `cargo test -p ogygia-nixutils`, `cargo clippy --workspace --all-targets`,
  `cargo fmt`.
- CI