### PR TITLE
nebula: add nebula-online@ogygia unit to gate mesh-dependent services

### DIFF
--- a/nixos/nebula/default.nix
+++ b/nixos/nebula/default.nix
@@ -275,5 +275,25 @@ in
     # The mesh handles its own host-firewall via the cert-group rules above;
     # let local services bind freely on the tun.
     networking.firewall.trustedInterfaces = [ "neb.ogygia" ];
+
+    # Convenience unit for downstream services that need the mesh up before
+    # they start — `Requires = nebula-online@ogygia.service`.
+    systemd.services."nebula-online@ogygia" = {
+      description = "Wait for Nebula interface neb.ogygia to come online";
+      after = [ "nebula@ogygia.service" ];
+      requires = [ "nebula@ogygia.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        TimeoutStartSec = "60";
+      };
+      script = ''
+        until ${pkgs.iproute2}/bin/ip addr show neb.ogygia 2>/dev/null \
+          | ${pkgs.gnugrep}/bin/grep -q "inet "; do
+          sleep 1
+        done
+      '';
+    };
   };
 }

--- a/nixos/tests/nebula-module.nix
+++ b/nixos/tests/nebula-module.nix
@@ -125,6 +125,7 @@ pkgs.runCommand "ogygia-nebula-module"
   lighthouseIsLighthouse = lib.boolToString lighthouseSystem.config.services.nebula.networks.ogygia.isLighthouse;
   lighthouseLighthouses = builtins.toJSON lighthouseSystem.config.services.nebula.networks.ogygia.lighthouses;
   lighthouseListenPort = toString lighthouseSystem.config.services.nebula.networks.ogygia.listen.port;
+  nebulaOnlineUnitExists = lib.boolToString (validSystem.config.systemd.services ? "nebula-online@ogygia");
   mergedInbound = builtins.toJSON mergeSystem.config.services.nebula.networks.ogygia.firewall.inbound;
   mergedGroups = builtins.toJSON mergeSystem.config.ogygia.nebula.groups;
   noPubFailedCount = toString (builtins.length (failedAssertions noPubKeySystem));
@@ -184,6 +185,11 @@ pkgs.runCommand "ogygia-nebula-module"
     exit 1
   fi
   echo "$lighthouseLighthouses" | jq -e '. == []' >/dev/null
+
+  if [ "$nebulaOnlineUnitExists" != "true" ]; then
+    echo "nebula-online@ogygia.service is not defined" >&2
+    exit 1
+  fi
 
   echo "$mergedInbound" | jq -e 'length == 2' >/dev/null
   echo "$mergedInbound" | jq -e 'map(select(.port == 22 and (.groups | index("ssh")))) | length == 1' >/dev/null


### PR DESCRIPTION
Services that bind or dial Nebula addresses race the overlay at boot: nebula@ogygia.service is "started" before the tun device has an address, so units ordered after it can still fail to bind.

Add a nebula-online@ogygia oneshot that polls `ip addr show neb.ogygia` until an inet address appears (60s timeout), with RemainAfterExit so it acts as a milestone. Downstream units declare
`requires = [ "nebula-online@ogygia.service" ]` plus the matching `after` to start only once the mesh is reachable.

Polling the interface address is the observable "mesh is up" condition, which systemd ordering on nebula@ogygia alone cannot express.

Test plan:
- CI (the ogygia-nebula-module check asserts the unit is defined on an enabled host).
- Behaviour under a real interface race will be verified when the first consumer service adopts the unit.