### PR TITLE
ogygia-dashboard: restore git2 https/TLS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,9 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -1569,6 +1572,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -1995,9 +1999,27 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking"
@@ -2600,7 +2622,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -3022,7 +3044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Git
-git2 = "0.21"
+git2 = { version = "0.21", features = ["https"] }
 tempfile = "3.0"
 
 # Enums


### PR DESCRIPTION
git2 0.21 changed its default feature set to empty, dropping the https feature that was previously on by default. The workspace depended on git2 with default features, so the bundled libgit2 built without a TLS backend and every https clone failed at runtime with "there is no TLS stream available", preventing ogygia-dashboard from starting.

Enable the https feature explicitly on the workspace git2 dependency and regenerate the lockfile, which pulls openssl-sys/openssl-probe back in and compiles libgit2 with an openssl TLS transport.

This fixes startup because the dashboard clones its nixos repo over https as the first step of AppState::new, which now succeeds.

Test plan:
- Reproduced the failure on the Nix-built binary: https clone failed with "there is no TLS stream available; class=Ssl (16)".
- After the fix, rebuilt .#ogygia-dashboard and reran: the binary links libssl.so.3, the https clone succeeds, and startup proceeds to the etcd connect step (only failing on a locally-unreachable etcd, as expected).