### PR TITLE
ogygia: embed nebula-cert path in nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,6 +131,10 @@
             pname = "ogygia";
             cargoExtraArgs = "-p ogygia";
             src = ogygiaSrc;
+            # Embed nebula-cert's store path in the binary so this derivation
+            # carries a runtime dependency on nebula. Only set here, so plain
+            # cargo builds (e.g. the dev shell) keep runtime PATH discovery.
+            env.OGYGIA_NEBULA_CERT_BIN = "${pkgs.nebula}/bin/nebula-cert";
           });
 
           # ogygia-nixutils is a library crate with no deployable artifact; it

--- a/src/ogygia/src/nebula/nebula_cert.rs
+++ b/src/ogygia/src/nebula/nebula_cert.rs
@@ -22,6 +22,13 @@ static BIN: OnceLock<&'static str> = OnceLock::new();
 
 pub fn bin() -> &'static str {
     BIN.get_or_init(|| {
+        // A Nix build embeds the store path of nebula-cert here so the
+        // derivation carries a runtime dependency on nebula. Unset for plain
+        // `cargo build` (e.g. the dev shell), which falls back to discovery.
+        if let Some(path) = option_env!("OGYGIA_NEBULA_CERT_BIN") {
+            tracing::debug!("using embedded nebula-cert path: {}", path);
+            return path;
+        }
         if which::which("nebula-cert").is_ok() {
             tracing::debug!("using nebula-cert from PATH");
             return "nebula-cert";


### PR DESCRIPTION
The ogygia CLI discovered nebula-cert only at runtime via PATH and NixOS fallback locations, so the nix derivation carried no dependency on nebula and a nix-built binary could fail to find it.

bin() now consults a compile-time OGYGIA_NEBULA_CERT_BIN via option_env! and, when set, returns that path; the ogygia buildPackage sets it to ${pkgs.nebula}/bin/nebula-cert. The embedded store path makes nix scan in nebula as a runtime dependency, while the env var is left unset for plain cargo builds so the dev shell keeps runtime PATH discovery.

This ties the nebula dependency to the nix build without leaking the path into non-nix builds.

Test plan:
- CI
- `nix build .#ogygia`: binary embeds the nebula-cert store path and nebula is a runtime reference of the derivation
- `nix develop -c cargo build -p ogygia`: OGYGIA_NEBULA_CERT_BIN unset, compiles and retains PATH discovery