### PR TITLE
nebula: open up directory permissions

### DIFF
--- a/nixos/nebula/default.nix
+++ b/nixos/nebula/default.nix
@@ -248,7 +248,7 @@ in
       })
       topology.lighthouses;
 
-    systemd.tmpfiles.rules = [ "d /etc/nebula 0700 root root - -" ];
+    systemd.tmpfiles.rules = [ "d /etc/nebula 0755 root root - -" ];
 
     services.nebula.networks.ogygia = {
       ca = caCertFile;


### PR DESCRIPTION
On system.stateVersion >= 25.11, Nebula configs are symlinked into /etc/nebula instead of referenced directly from the store. This means we need to be able to enter this directory.

Change directory permissions for /etc/nebula to 0755 from 0700.

Test plan:
- CI