### PR TITLE
ogygia-dashboard: archive deployed commits to a persistent branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1609,6 +1610,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -1891,6 +1906,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "chrono",
  "clap",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # Git
-git2 = { version = "0.21", features = ["https"] }
+git2 = { version = "0.21", features = ["https", "ssh"] }
 tempfile = "3.0"
 
 # Enums

--- a/flake.nix
+++ b/flake.nix
@@ -210,6 +210,10 @@
               pkgs.cargo-nextest
               pkgs.zstd
             ];
+            # Test binaries from the nextest archive link the nix openssl
+            # dynamically but carry no usable runpath, and the nix dynamic
+            # loader does not search the runner's system libraries.
+            LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.openssl ];
           };
 
           formatter = treefmtEval.config.build.wrapper;

--- a/nixos/dashboard/default.nix
+++ b/nixos/dashboard/default.nix
@@ -12,6 +12,17 @@ let
     server = cfg.serverConfig;
     git = {
       remote_url = ogygiaConfig.gitRemoteUrl;
+    } // lib.optionalAttrs cfg.ssh.enable {
+      ssh = {
+        url = cfg.ssh.url;
+        key_path = "/run/credentials/ogygia-dashboard.service/ssh-key";
+      } // lib.optionalAttrs (cfg.ssh.hostKey != null) {
+        host_key = cfg.ssh.hostKey;
+      };
+    } // lib.optionalAttrs cfg.archive.enable {
+      archive = {
+        branch = cfg.archive.branch;
+      };
     };
     etcd = {
       endpoints = etcdCfg.endpoints;
@@ -51,6 +62,38 @@ in
       description = "Server bind configuration passed to the dashboard TOML config.";
       example = { port = 8080; };
     };
+
+    ssh = {
+      enable = lib.mkEnableOption "SSH transport for all git operations, allowing private repositories and pushing";
+
+      url = lib.mkOption {
+        type = lib.types.str;
+        description = "SSH URL for the repository at ogygia.gitRemoteUrl.";
+        example = "git@git.example.com:user/repo.git";
+      };
+
+      keyFile = lib.mkOption {
+        type = lib.types.str;
+        description = "Path to an SSH private key, e.g. a Gitea deploy key. Loaded via systemd LoadCredential. Needs write access when archive is enabled.";
+      };
+
+      hostKey = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Expected SSH host key of the server in known_hosts format. Any host key is accepted when null.";
+        example = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI...";
+      };
+    };
+
+    archive = {
+      enable = lib.mkEnableOption "archiving deployed commits to a persistent branch so they survive force-pushes";
+
+      branch = lib.mkOption {
+        type = lib.types.str;
+        default = "ogygia/deployed-commits-archive";
+        description = "Branch the deployed commits are archived to.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -58,6 +101,10 @@ in
       {
         assertion = etcdCfg.endpoints != [ ];
         message = "ogygia.etcd.endpoints must not be empty when ogygia.dashboard is enabled.";
+      }
+      {
+        assertion = cfg.archive.enable -> cfg.ssh.enable;
+        message = "ogygia.dashboard.archive requires ogygia.dashboard.ssh for pushing.";
       }
     ];
 
@@ -88,10 +135,17 @@ in
         MemoryDenyWriteExecute = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
+      } // lib.optionalAttrs cfg.ssh.enable {
+        LoadCredential = [ "ssh-key:${cfg.ssh.keyFile}" ];
       };
 
       environment = {
         RUST_LOG = lib.mkDefault "info";
+      } // lib.optionalAttrs cfg.ssh.enable {
+        # libgit2's SSH transport resolves $HOME/.ssh/known_hosts before the
+        # host key callback and fails outright ("error loading known_hosts")
+        # when HOME is unset, which it is under DynamicUser.
+        HOME = "/run/ogygia-dashboard";
       };
     };
   };

--- a/src/ogygia-dashboard/Cargo.toml
+++ b/src/ogygia-dashboard/Cargo.toml
@@ -32,6 +32,7 @@ toml = { workspace = true }
 
 # Git
 git2 = { workspace = true }
+base64 = { workspace = true }
 tempfile = { workspace = true }
 chrono = { workspace = true }
 

--- a/src/ogygia-dashboard/src/archive.rs
+++ b/src/ogygia-dashboard/src/archive.rs
@@ -1,0 +1,137 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use git2::Oid;
+
+use crate::config::ArchiveConfig;
+use crate::etcd::Etcd;
+use crate::etcd::HostStates;
+use crate::git::GitManager;
+
+/// Spawn the background task keeping every commit referenced in etcd
+/// reachable from the archive branch. Runs one pass immediately, then one per
+/// host state change.
+pub fn spawn(config: ArchiveConfig, git: Arc<GitManager>, etcd: Arc<Etcd>) {
+    tokio::spawn(async move {
+        let mut changes = etcd.subscribe();
+        let mut archived: HashSet<Oid> = HashSet::new();
+
+        loop {
+            loop {
+                let state = etcd.state().await;
+                let candidates = collect_candidates(&state, &archived);
+                if candidates.is_empty() {
+                    break;
+                }
+
+                let git = git.clone();
+                let config = config.clone();
+                let result =
+                    tokio::task::spawn_blocking(move || git.archive_commits(&config, &candidates))
+                        .await
+                        .expect("archive task panicked");
+
+                match result {
+                    Ok(done) => {
+                        archived.extend(done);
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::error!("Failed to archive deployed commits: {e:#}");
+                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    }
+                }
+            }
+
+            if changes.changed().await.is_err() {
+                return;
+            }
+        }
+    });
+}
+
+/// Commits referenced by any host state that are not yet archived, paired
+/// with the archive commit message describing who deployed them.
+fn collect_candidates(state: &HostStates, archived: &HashSet<Oid>) -> Vec<(Oid, String)> {
+    let mut oids: Vec<Oid> = state
+        .host_states
+        .values()
+        .flat_map(|states| states.values().flatten().copied())
+        .filter(|oid| !archived.contains(oid))
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    oids.sort();
+
+    oids.into_iter()
+        .map(|oid| (oid, commit_message(oid, state)))
+        .collect()
+}
+
+fn commit_message(oid: Oid, state: &HostStates) -> String {
+    let mut hosts: Vec<String> = state
+        .host_states
+        .iter()
+        .filter_map(|(host, states)| {
+            let matching: Vec<String> = states
+                .iter()
+                .filter(|(_, deployed)| **deployed == Some(oid))
+                .map(|(state, _)| state.as_ref().to_string())
+                .collect();
+            (!matching.is_empty()).then(|| format!("- {host} ({})", matching.join(", ")))
+        })
+        .collect();
+    hosts.sort();
+
+    format!(
+        "Archive {} after deployment\n\nDeployed to:\n{}\n",
+        &oid.to_string()[..12],
+        hosts.join("\n")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use enum_map::enum_map;
+
+    use super::*;
+    use crate::nixos::CommitState;
+
+    #[test]
+    fn test_collect_candidates() {
+        let a = Oid::from_str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        let b = Oid::from_str("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").unwrap();
+
+        let mut state = HostStates::default();
+        state.host_states.insert(
+            "host1".to_string(),
+            enum_map! {
+                CommitState::Booted => Some(a),
+                CommitState::Current => Some(b),
+                CommitState::NextBoot => Some(b),
+            },
+        );
+        state.host_states.insert(
+            "host2".to_string(),
+            enum_map! {
+                CommitState::Booted => Some(b),
+                CommitState::Current => Some(b),
+                CommitState::NextBoot => None,
+            },
+        );
+
+        let candidates = collect_candidates(&state, &HashSet::from([a]));
+        let (oid, message) = match candidates.as_slice() {
+            [candidate] => candidate,
+            other => panic!("expected one candidate, got {other:?}"),
+        };
+        assert_eq!(*oid, b);
+        assert_eq!(
+            message,
+            "Archive bbbbbbbbbbbb after deployment\n\n\
+             Deployed to:\n\
+             - host1 (current, nextboot)\n\
+             - host2 (booted, current)\n"
+        );
+    }
+}

--- a/src/ogygia-dashboard/src/config.rs
+++ b/src/ogygia-dashboard/src/config.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -35,7 +36,39 @@ pub enum Bind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitConfig {
+    /// HTTPS URL of the repository, used for web links and the Gitea API,
+    /// and for anonymous git access when `ssh` is not configured.
     pub remote_url: String,
+    #[serde(default)]
+    pub ssh: Option<SshConfig>,
+    #[serde(default)]
+    pub archive: Option<ArchiveConfig>,
+}
+
+/// SSH transport for all git operations, allowing private repositories
+/// and pushing. Requires a key with write access when `archive` is set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SshConfig {
+    /// SSH URL for the same repository as `remote_url`.
+    pub url: String,
+    /// Private key, e.g. a Gitea deploy key.
+    pub key_path: PathBuf,
+    /// Expected host key of the server in known_hosts format
+    /// ("ssh-ed25519 AAAA..."). Any host key is accepted when unset.
+    #[serde(default)]
+    pub host_key: Option<String>,
+}
+
+/// Archival of deployed commits to a persistent branch, keeping them
+/// reachable after the branch they were deployed from is force-pushed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArchiveConfig {
+    #[serde(default = "default_archive_branch")]
+    pub branch: String,
+}
+
+fn default_archive_branch() -> String {
+    "ogygia/deployed-commits-archive".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,6 +107,21 @@ impl Config {
         for endpoint in &self.etcd.endpoints {
             if endpoint.is_empty() {
                 return Err(anyhow::anyhow!("etcd endpoint cannot be empty"));
+            }
+        }
+
+        if let Some(ssh) = &self.git.ssh
+            && ssh.url.is_empty()
+        {
+            return Err(anyhow::anyhow!("git.ssh.url cannot be empty"));
+        }
+
+        if let Some(archive) = &self.git.archive {
+            if self.git.ssh.is_none() {
+                return Err(anyhow::anyhow!("git.archive requires git.ssh for pushing"));
+            }
+            if archive.branch.is_empty() {
+                return Err(anyhow::anyhow!("git.archive.branch cannot be empty"));
             }
         }
 
@@ -171,6 +219,8 @@ mod tests {
             },
             git: GitConfig {
                 remote_url: "https://git.example.com/user/repo.git".to_string(),
+                ssh: None,
+                archive: None,
             },
             etcd: EtcdConfig {
                 endpoints: vec!["http://etcd1:2379".to_string()],
@@ -211,6 +261,50 @@ endpoints = ["http://etcd1:2379", "http://etcd2:2379"]
         assert_eq!(config.etcd.prefix, "/ogygia/nixos/versions");
         assert_eq!(config.title, "Status Page");
         assert!(config.hostname_strip_suffix.is_none());
+        assert!(config.git.ssh.is_none());
+        assert!(config.git.archive.is_none());
+    }
+
+    #[test]
+    fn test_load_ssh_and_archive_config() {
+        let toml_content = r#"
+[server]
+port = 9090
+
+[git]
+remote_url = "https://git.example.com/testuser/testrepo.git"
+
+[git.ssh]
+url = "git@git.example.com:testuser/testrepo.git"
+key_path = "/run/credentials/key"
+
+[git.archive]
+
+[etcd]
+endpoints = ["http://etcd1:2379"]
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+
+        let config = Config::load_from_file(temp_file.path()).unwrap();
+
+        let ssh = config.git.ssh.unwrap();
+        assert_eq!(ssh.url, "git@git.example.com:testuser/testrepo.git");
+        assert_eq!(ssh.key_path, PathBuf::from("/run/credentials/key"));
+        assert!(ssh.host_key.is_none());
+
+        let archive = config.git.archive.unwrap();
+        assert_eq!(archive.branch, "ogygia/deployed-commits-archive");
+    }
+
+    #[test]
+    fn test_validation_archive_requires_ssh() {
+        let mut config = test_config();
+        config.git.archive = Some(ArchiveConfig {
+            branch: default_archive_branch(),
+        });
+        assert!(config.validate().is_err());
     }
 
     #[test]

--- a/src/ogygia-dashboard/src/etcd.rs
+++ b/src/ogygia-dashboard/src/etcd.rs
@@ -21,6 +21,7 @@ pub struct HostStates {
 
 pub struct Etcd {
     states: Mutex<Arc<HostStates>>,
+    changed: tokio::sync::watch::Sender<()>,
 }
 
 impl Etcd {
@@ -30,6 +31,7 @@ impl Etcd {
 
         let me = Arc::new(Self {
             states: Default::default(),
+            changed: tokio::sync::watch::Sender::new(()),
         });
 
         // Load initial state
@@ -77,6 +79,11 @@ impl Etcd {
         self.states.lock().await.clone()
     }
 
+    /// Receiver notified whenever the host states change.
+    pub fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
+        self.changed.subscribe()
+    }
+
     async fn load_all(&self, client: &mut Client, prefix: &str) -> Result<()> {
         let resp = client
             .get(prefix, Some(GetOptions::new().with_prefix()))
@@ -115,6 +122,7 @@ impl Etcd {
         }
 
         states.version += 1;
+        self.changed.send_replace(());
         tracing::info!(
             "Loaded {} hosts from etcd, version: {}",
             states.host_states.len(),
@@ -176,6 +184,7 @@ impl Etcd {
                         entry[commit_state] = commit;
 
                         states.version += 1;
+                        self.changed.send_replace(());
 
                         let old_str = old.map(|c| c.to_string()[..12].to_string());
                         let new_str = commit.as_ref().map(|c| c.to_string()[..12].to_string());
@@ -194,6 +203,7 @@ impl Etcd {
                             host_map[commit_state] = None;
                         }
                         states.version += 1;
+                        self.changed.send_replace(());
                         tracing::info!("Host '{}' state '{}' deleted", host, commit_state.as_ref());
                     }
                 }

--- a/src/ogygia-dashboard/src/git.rs
+++ b/src/ogygia-dashboard/src/git.rs
@@ -3,18 +3,23 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use chrono::TimeZone;
 use chrono::Utc;
 use git2::Oid;
 use git2::Repository;
 use tempfile::TempDir;
 
+use crate::config::ArchiveConfig;
 use crate::config::Config;
+use crate::config::SshConfig;
 use crate::nixos::CommitInfo;
 
 pub struct GitManager {
     temp_dir: Option<TempDir>,
     repo_path: Option<PathBuf>, // For test cases only
+    ssh: Option<SshConfig>,
 }
 
 // Implement Send + Sync for GitManager since we manage our own repo access
@@ -26,12 +31,26 @@ impl GitManager {
         let temp_dir = TempDir::new().context("Failed to create temp directory")?;
         let repo_path = temp_dir.path();
 
-        Repository::clone(config.git_repo_url(), repo_path)
-            .context("Failed to clone nixos repository")?;
+        let ssh = config.git.ssh.clone();
+        {
+            let url = ssh
+                .as_ref()
+                .map_or(config.git_repo_url(), |ssh| ssh.url.as_str());
+            let mut builder = git2::build::RepoBuilder::new();
+            if let Some(ssh) = &ssh {
+                let mut fo = git2::FetchOptions::new();
+                fo.remote_callbacks(ssh_callbacks(ssh));
+                builder.fetch_options(fo);
+            }
+            builder
+                .clone(url, repo_path)
+                .context("Failed to clone nixos repository")?;
+        }
 
         Ok(Self {
             temp_dir: Some(temp_dir),
             repo_path: None,
+            ssh,
         })
     }
 
@@ -48,27 +67,100 @@ impl GitManager {
 
     pub async fn fetch_updates(&self) -> Result<()> {
         let repo = self.open_repo()?;
-        let mut remote = repo
-            .find_remote("origin")
-            .context("Failed to find origin remote")?;
+        fetch(&repo, self.ssh.as_ref())
+    }
 
-        // Configure fetch options for comprehensive updates
-        let mut fo = git2::FetchOptions::new();
-        fo.download_tags(git2::AutotagOption::All);
-        fo.prune(git2::FetchPrune::On);
+    /// Make every candidate commit reachable from the archive branch by
+    /// pushing a chain of merge commits on top of it, so the commits survive
+    /// their original branch being force-pushed. Returns the commits that are
+    /// now reachable from the branch; candidates that could not be resolved
+    /// locally are omitted and can be retried later.
+    pub fn archive_commits(
+        &self,
+        config: &ArchiveConfig,
+        candidates: &[(Oid, String)],
+    ) -> Result<HashSet<Oid>> {
+        let repo = self.open_repo()?;
+        let tracking_ref = format!("refs/remotes/origin/{}", config.branch);
+        let local_ref = format!("refs/heads/{}", config.branch);
 
-        remote
-            .fetch(
-                &[
-                    "+refs/heads/*:refs/remotes/origin/*",
-                    "+refs/tags/*:refs/tags/*",
-                ],
-                Some(&mut fo),
-                None,
-            )
-            .context("Failed to fetch with full options")?;
+        // Compare-and-swap loop: fetch the current archive head, build merge
+        // commits on top of it, and push without force. A rejected push means
+        // someone else advanced the branch; refetch and rebuild.
+        const MAX_ATTEMPTS: u32 = 3;
+        for attempt in 1..=MAX_ATTEMPTS {
+            fetch(&repo, self.ssh.as_ref())?;
 
-        Ok(())
+            let head = repo
+                .find_reference(&tracking_ref)
+                .ok()
+                .and_then(|r| r.target());
+
+            let mut done = HashSet::new();
+            let mut pending = Vec::new();
+            for (oid, message) in candidates {
+                let reachable = head.is_some_and(|head| {
+                    head == *oid || repo.graph_descendant_of(head, *oid).unwrap_or(false)
+                });
+                if reachable {
+                    done.insert(*oid);
+                } else {
+                    pending.push((*oid, message));
+                }
+            }
+            if pending.is_empty() {
+                return Ok(done);
+            }
+
+            let mut head_commit = head.map(|oid| repo.find_commit(oid)).transpose()?;
+            for (oid, message) in pending {
+                let commit = match repo.find_commit(oid) {
+                    Ok(commit) => commit,
+                    Err(e) => {
+                        tracing::warn!("Cannot archive {oid}: not found after fetch: {e}");
+                        continue;
+                    }
+                };
+
+                // Only reachability matters, so take the archived commit's
+                // tree as-is instead of merging.
+                let signature = git2::Signature::now("ogygia-dashboard", "dashboard@ogygia")?;
+                let parents: Vec<&git2::Commit> =
+                    head_commit.iter().chain(std::iter::once(&commit)).collect();
+                let merged = repo.commit(
+                    None,
+                    &signature,
+                    &signature,
+                    message,
+                    &commit.tree()?,
+                    &parents,
+                )?;
+                head_commit = Some(repo.find_commit(merged)?);
+                done.insert(oid);
+            }
+
+            let Some(new_head) = &head_commit else {
+                return Ok(done);
+            };
+            repo.reference(&local_ref, new_head.id(), true, "archive deployed commits")
+                .context("Failed to update local archive branch")?;
+
+            match push_archive_branch(&repo, self.ssh.as_ref(), &config.branch, &local_ref) {
+                Ok(()) => {
+                    tracing::info!(
+                        "Archived {} commit(s) to branch '{}'",
+                        done.len(),
+                        config.branch
+                    );
+                    return Ok(done);
+                }
+                Err(e) if attempt < MAX_ATTEMPTS => {
+                    tracing::warn!("Archive push failed (attempt {attempt}), retrying: {e:#}");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        unreachable!("archive push loop returns on final attempt")
     }
 
     /// Get commit metadata for the specified commit hashes.
@@ -213,5 +305,285 @@ impl GitManager {
             branch,
             hosts_using: vec![hostname.to_string()],
         })
+    }
+}
+
+fn ssh_callbacks(ssh: &SshConfig) -> git2::RemoteCallbacks<'_> {
+    let mut callbacks = git2::RemoteCallbacks::new();
+    callbacks.credentials(|_url, username_from_url, _allowed| {
+        git2::Cred::ssh_key(
+            username_from_url.unwrap_or("git"),
+            None,
+            &ssh.key_path,
+            None,
+        )
+    });
+    callbacks.certificate_check(|cert, host| check_host_key(cert, host, ssh.host_key.as_deref()));
+    callbacks
+}
+
+fn fetch(repo: &Repository, ssh: Option<&SshConfig>) -> Result<()> {
+    let mut remote = repo
+        .find_remote("origin")
+        .context("Failed to find origin remote")?;
+
+    // Configure fetch options for comprehensive updates
+    let mut fo = git2::FetchOptions::new();
+    fo.download_tags(git2::AutotagOption::All);
+    fo.prune(git2::FetchPrune::On);
+    if let Some(ssh) = ssh {
+        fo.remote_callbacks(ssh_callbacks(ssh));
+    }
+
+    remote
+        .fetch(
+            &[
+                "+refs/heads/*:refs/remotes/origin/*",
+                "+refs/tags/*:refs/tags/*",
+            ],
+            Some(&mut fo),
+            None,
+        )
+        .context("Failed to fetch with full options")?;
+
+    Ok(())
+}
+
+fn push_archive_branch(
+    repo: &Repository,
+    ssh: Option<&SshConfig>,
+    branch: &str,
+    local_ref: &str,
+) -> Result<()> {
+    let mut remote = repo
+        .find_remote("origin")
+        .context("Failed to find origin remote")?;
+
+    let rejection = std::cell::RefCell::new(None);
+    {
+        let mut callbacks = ssh.map_or_else(git2::RemoteCallbacks::new, ssh_callbacks);
+        // A rejected ref update (e.g. non-fast-forward) completes the push
+        // successfully, so it has to be collected from the callback.
+        callbacks.push_update_reference(|_refname, status| {
+            if let Some(status) = status {
+                *rejection.borrow_mut() = Some(status.to_string());
+            }
+            Ok(())
+        });
+
+        let mut options = git2::PushOptions::new();
+        options.remote_callbacks(callbacks);
+        remote
+            .push(
+                &[&format!("{local_ref}:refs/heads/{branch}")],
+                Some(&mut options),
+            )
+            .context("Failed to push archive branch")?;
+    }
+
+    match rejection.into_inner() {
+        Some(status) => Err(anyhow::anyhow!("Push of '{branch}' rejected: {status}")),
+        None => Ok(()),
+    }
+}
+
+fn check_host_key(
+    cert: &git2::cert::Cert,
+    host: &str,
+    pinned: Option<&str>,
+) -> Result<git2::CertificateCheckStatus, git2::Error> {
+    let Some(host_key) = cert.as_hostkey().and_then(|k| k.hostkey()) else {
+        return Ok(git2::CertificateCheckStatus::CertificatePassthrough);
+    };
+
+    match pinned {
+        Some(pinned) => {
+            // Accept any known_hosts style field ("ssh-ed25519 AAAA... comment").
+            if pinned
+                .split_whitespace()
+                .any(|field| BASE64.decode(field).is_ok_and(|key| key == host_key))
+            {
+                Ok(git2::CertificateCheckStatus::CertificateOk)
+            } else {
+                Err(git2::Error::from_str(&format!(
+                    "SSH host key for '{host}' does not match configured git.ssh.host_key"
+                )))
+            }
+        }
+        None => {
+            tracing::warn!(
+                "Accepting unverified SSH host key for '{host}': {}; set git.ssh.host_key to pin it",
+                BASE64.encode(host_key)
+            );
+            Ok(git2::CertificateCheckStatus::CertificateOk)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use git2::Signature;
+
+    use super::*;
+
+    const ARCHIVE_BRANCH: &str = "ogygia/deployed-commits-archive";
+
+    fn create_commit(repo: &Repository, branch: &str, content: &str, parent: Option<Oid>) -> Oid {
+        let blob = repo.blob(content.as_bytes()).unwrap();
+        let mut builder = repo.treebuilder(None).unwrap();
+        builder.insert("file", blob, 0o100644).unwrap();
+        let tree = repo.find_tree(builder.write().unwrap()).unwrap();
+        let signature = Signature::now("test", "test@example.com").unwrap();
+        let parents: Vec<git2::Commit> = parent
+            .map(|oid| repo.find_commit(oid).unwrap())
+            .into_iter()
+            .collect();
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        let oid = repo
+            .commit(None, &signature, &signature, content, &tree, &parent_refs)
+            .unwrap();
+        repo.reference(&format!("refs/heads/{branch}"), oid, true, "test")
+            .unwrap();
+        oid
+    }
+
+    fn push(repo: &Repository, refspec: &str) {
+        let mut origin = repo.find_remote("origin").unwrap();
+        origin.push(&[refspec], None).unwrap();
+    }
+
+    fn setup() -> (TempDir, Repository, Repository, GitManager, ArchiveConfig) {
+        let dir = TempDir::new().unwrap();
+        let remote_path = dir.path().join("remote.git");
+        let remote = Repository::init_bare(&remote_path).unwrap();
+        create_commit(&remote, "main", "initial", None);
+
+        let clone_path = dir.path().join("clone");
+        let clone = Repository::clone(remote_path.to_str().unwrap(), &clone_path).unwrap();
+        let manager = GitManager {
+            temp_dir: None,
+            repo_path: Some(clone_path),
+            ssh: None,
+        };
+        let config = ArchiveConfig {
+            branch: ARCHIVE_BRANCH.to_string(),
+        };
+        (dir, remote, clone, manager, config)
+    }
+
+    fn archive_head(remote: &Repository) -> Oid {
+        remote
+            .find_reference(&format!("refs/heads/{ARCHIVE_BRANCH}"))
+            .unwrap()
+            .target()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_archive_bootstrap_and_dedup() {
+        let (_dir, remote, clone, manager, config) = setup();
+        let c1 = create_commit(&clone, "pr", "c1", None);
+        push(&clone, "refs/heads/pr:refs/heads/pr");
+
+        let done = manager
+            .archive_commits(&config, &[(c1, "Archive c1".to_string())])
+            .unwrap();
+        assert_eq!(done, HashSet::from([c1]));
+
+        let head = archive_head(&remote);
+        let head_commit = remote.find_commit(head).unwrap();
+        assert_eq!(head_commit.message().unwrap(), "Archive c1");
+        assert_eq!(head_commit.parent_ids().collect::<Vec<_>>(), vec![c1]);
+
+        // Re-archiving an already reachable commit is a no-op.
+        let done = manager
+            .archive_commits(&config, &[(c1, "Archive c1".to_string())])
+            .unwrap();
+        assert_eq!(done, HashSet::from([c1]));
+        assert_eq!(archive_head(&remote), head);
+    }
+
+    #[test]
+    fn test_archive_survives_force_push() {
+        let (_dir, remote, clone, manager, config) = setup();
+        let c1 = create_commit(&clone, "pr", "c1", None);
+        push(&clone, "refs/heads/pr:refs/heads/pr");
+        manager
+            .archive_commits(&config, &[(c1, "Archive c1".to_string())])
+            .unwrap();
+        let first_head = archive_head(&remote);
+
+        // Force-push an unrelated commit over the PR branch.
+        let c2 = create_commit(&clone, "pr", "c2", None);
+        push(&clone, "+refs/heads/pr:refs/heads/pr");
+
+        let done = manager
+            .archive_commits(
+                &config,
+                &[
+                    (c1, "Archive c1".to_string()),
+                    (c2, "Archive c2".to_string()),
+                ],
+            )
+            .unwrap();
+        assert_eq!(done, HashSet::from([c1, c2]));
+
+        let head_commit = remote.find_commit(archive_head(&remote)).unwrap();
+        assert_eq!(head_commit.message().unwrap(), "Archive c2");
+        assert_eq!(
+            head_commit.parent_ids().collect::<Vec<_>>(),
+            vec![first_head, c2]
+        );
+        assert_eq!(
+            head_commit.tree_id(),
+            remote.find_commit(c2).unwrap().tree_id()
+        );
+        // c1 is no longer reachable from pr but remains reachable via the archive.
+        assert!(remote.graph_descendant_of(head_commit.id(), c1).unwrap());
+    }
+
+    #[test]
+    fn test_archive_builds_on_latest_remote_head() {
+        let (_dir, remote, clone, manager, config) = setup();
+        let c1 = create_commit(&clone, "pr", "c1", None);
+        push(&clone, "refs/heads/pr:refs/heads/pr");
+        manager
+            .archive_commits(&config, &[(c1, "Archive c1".to_string())])
+            .unwrap();
+
+        // Advance the remote archive branch behind the manager's back.
+        let external = create_commit(&clone, "external", "external", Some(archive_head(&remote)));
+        push(
+            &clone,
+            &format!("refs/heads/external:refs/heads/{ARCHIVE_BRANCH}"),
+        );
+
+        let c2 = create_commit(&clone, "pr", "c2", None);
+        push(&clone, "+refs/heads/pr:refs/heads/pr");
+        manager
+            .archive_commits(&config, &[(c2, "Archive c2".to_string())])
+            .unwrap();
+
+        let head_commit = remote.find_commit(archive_head(&remote)).unwrap();
+        assert_eq!(
+            head_commit.parent_ids().collect::<Vec<_>>(),
+            vec![external, c2]
+        );
+    }
+
+    #[test]
+    fn test_archive_skips_unresolvable_commits() {
+        let (_dir, remote, _clone, manager, config) = setup();
+        let missing = Oid::from_str("cccccccccccccccccccccccccccccccccccccccc").unwrap();
+
+        let done = manager
+            .archive_commits(&config, &[(missing, "Archive missing".to_string())])
+            .unwrap();
+        assert!(done.is_empty());
+        assert!(
+            remote
+                .find_reference(&format!("refs/heads/{ARCHIVE_BRANCH}"))
+                .is_err()
+        );
     }
 }

--- a/src/ogygia-dashboard/src/main.rs
+++ b/src/ogygia-dashboard/src/main.rs
@@ -10,6 +10,7 @@ use tokio::net::TcpListener;
 use tokio::net::UnixListener;
 use tower::ServiceExt;
 
+mod archive;
 mod config;
 mod etcd;
 mod git;

--- a/src/ogygia-dashboard/src/web.rs
+++ b/src/ogygia-dashboard/src/web.rs
@@ -39,7 +39,7 @@ struct CachedPrCount {
 
 pub struct AppState {
     config: Config,
-    git_manager: GitManager,
+    git_manager: Arc<GitManager>,
     etcd: Arc<Etcd>,
     commits_cache: Mutex<Arc<CachedCommits>>,
     html_cache: Mutex<Arc<CachedHtml>>,
@@ -48,9 +48,13 @@ pub struct AppState {
 
 impl AppState {
     pub async fn new(config: Config) -> Result<Self> {
-        let git_manager = GitManager::new(&config).await?;
+        let git_manager = Arc::new(GitManager::new(&config).await?);
         git_manager.fetch_updates().await?;
         let etcd = Etcd::new(&config).await?;
+
+        if let Some(archive) = config.git.archive.clone() {
+            crate::archive::spawn(archive, git_manager.clone(), etcd.clone());
+        }
 
         Ok(Self {
             config,


### PR DESCRIPTION
Hosts report the git commit they are running to etcd, but when a PR branch is force-pushed after a host has moved to it, the old commit becomes unreachable upstream and is eventually garbage collected. The dashboard then shows a permanently missing commit and the deployed tree is lost. The dashboard could also only read public repositories, as its git transport was anonymous https.

This commit adds an optional git.ssh config used for all git transport (clone, fetch, push) with a deploy key, keeping the https remote_url for web links and the Gitea API, and a background archiver modelled on Sapling's sapling-pr-archive branches. The archiver subscribes to the etcd watcher and keeps every commit referenced by any host state reachable from a persistent branch (git.archive.branch, default ogygia/deployed-commits-archive). Each new commit is recorded as a merge commit whose parents are the previous archive head and the deployed commit, taking the deployed tree as-is, and whose body lists the hosts deployed to it. The branch is pushed without force, retrying with a fetch-and-rebuild loop if the push is rejected, and the NixOS module ships the key via systemd LoadCredential.

Archiving on the etcd event means the commit is captured while its original branch still exists upstream, and the single ever-growing branch of merge commits keeps every historical deployment reachable without creating a ref per deployment. Routing reads over the same SSH remote additionally allows hosting a dashboard for a private repository.

Test plan:
- Added tests covering archive bootstrap, no-op re-archiving, commits surviving a force-push, rebuilding on a concurrently advanced remote head, skipping unresolvable commits, and config validation; run in CI with the existing suite, clippy, and cargo-deny.
- The SSH transport and host key pinning are not exercised by tests and need manual verification against a real Gitea deploy key.