### PR TITLE
updated: pull-based auto-update daemon and ogygia update subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,7 @@ dependencies = [
  "futures",
  "hostname",
  "ogygia-nixutils",
+ "ogygia-updated",
  "reqwest",
  "serde",
  "serde_json",
@@ -1999,6 +2000,22 @@ dependencies = [
  "tokio",
  "tracing",
  "which",
+]
+
+[[package]]
+name = "ogygia-updated"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "git2",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -97,8 +97,9 @@
             ];
           };
 
-          # ogygia's default `irisd` feature depends on the ogygia-nixutils
-          # path crate, so both crates' sources must be present when building it.
+          # ogygia's default `irisd` and `updated` features depend on the
+          # ogygia-nixutils and ogygia-updated path crates, so their sources
+          # must be present when building it.
           ogygiaSrc = lib.fileset.toSource {
             root = ./.;
             fileset = lib.fileset.unions [
@@ -106,6 +107,7 @@
               ./Cargo.lock
               (craneLib.fileset.commonCargoSources ./src/ogygia)
               (craneLib.fileset.commonCargoSources ./src/ogygia-nixutils)
+              (craneLib.fileset.commonCargoSources ./src/ogygia-updated)
             ];
           };
 
@@ -135,6 +137,9 @@
             # carries a runtime dependency on nebula. Only set here, so plain
             # cargo builds (e.g. the dev shell) keep runtime PATH discovery.
             env.OGYGIA_NEBULA_CERT_BIN = "${pkgs.nebula}/bin/nebula-cert";
+            postInstall = ''
+              ${pkgs.patchelf}/bin/patchelf --set-rpath "${lib.makeLibraryPath [ pkgs.openssl ]}" $out/bin/ogygia
+            '';
           });
 
           # ogygia-nixutils is a library crate with no deployable artifact; it
@@ -152,6 +157,15 @@
             pname = "ogygia-hostinfod";
             cargoExtraArgs = "-p ogygia-hostinfod";
             src = fileSetForCrate ./src/ogygia-hostinfod;
+          });
+
+          ogygia-updated = craneLib.buildPackage (individualCrateArgs // {
+            pname = "ogygia-updated";
+            cargoExtraArgs = "-p ogygia-updated";
+            src = fileSetForCrate ./src/ogygia-updated;
+            postInstall = ''
+              ${pkgs.patchelf}/bin/patchelf --set-rpath "${lib.makeLibraryPath [ pkgs.openssl ]}" $out/bin/ogygia-updated
+            '';
           });
 
           ogygia-dashboard = craneLib.buildPackage (individualCrateArgs // {
@@ -191,7 +205,7 @@
         in
         {
           packages = {
-            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard ogygia-nextest-archive;
+            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard ogygia-updated ogygia-nextest-archive;
             default = ogygia;
           };
 
@@ -210,6 +224,12 @@
               pkgs.cargo-nextest
               pkgs.zstd
             ];
+            # Doctests are not part of the nextest archive, so they are
+            # compiled from source in this shell; give it the same build
+            # inputs as the crate derivations so openssl-sys and prost
+            # find their headers and tools.
+            nativeBuildInputs = commonArgs.nativeBuildInputs;
+            buildInputs = commonArgs.buildInputs;
             # Test binaries from the nextest archive link the nix openssl
             # dynamically but carry no usable runpath, and the nix dynamic
             # loader does not search the runner's system libraries.
@@ -219,7 +239,7 @@
           formatter = treefmtEval.config.build.wrapper;
 
           checks = {
-            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard;
+            inherit ogygia ogygia-irisd ogygia-hostinfod ogygia-dashboard ogygia-updated;
 
             ogygia-clippy = craneLib.cargoClippy (commonArgs // {
               inherit cargoArtifacts;
@@ -279,6 +299,7 @@
         _module.args.ogygia-irisd = self.packages.${pkgs.stdenv.hostPlatform.system}.ogygia-irisd;
         _module.args.ogygia-hostinfod = self.packages.${pkgs.stdenv.hostPlatform.system}.ogygia-hostinfod;
         _module.args.ogygia-dashboard = self.packages.${pkgs.stdenv.hostPlatform.system}.ogygia-dashboard;
+        _module.args.ogygia-updated = self.packages.${pkgs.stdenv.hostPlatform.system}.ogygia-updated;
       };
 
       ci = nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" ] (system:

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -30,6 +30,7 @@ in
     ./nebula
     ./hostinfod
     ./dashboard
+    ./updated
   ];
 
   config = lib.mkIf cfg.enable {

--- a/nixos/updated/default.nix
+++ b/nixos/updated/default.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ogygia-updated, ... }:
+
+let
+  cfg = config.ogygia.updated;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  configFile = tomlFormat.generate "ogygia-updated.toml" cfg.settings;
+in
+{
+  options.ogygia.updated = {
+    enable = lib.mkEnableOption "the ogygia automatic update daemon";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = ogygia-updated;
+      description = "The ogygia-updated package to use.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = tomlFormat.type;
+      };
+      default = { };
+      description = ''
+        Freeform configuration for ogygia-updated, serialized directly to
+        TOML. Keys map 1:1 to the application config schema. Any key not
+        set here uses the application's compiled-in default.
+
+        Commonly used keys:
+
+        - `repo.url` (string) — git remote to track. Defaults to
+          `ogygia.gitRemoteUrl`.
+
+        - `repo.branch` (string) — branch whose tip the host follows.
+          Default: "main".
+
+        - `host.name` (string) — attribute name of this host's
+          nixosConfiguration in the flake. Defaults to the FQDN.
+
+        - `activate.allow_reboot` (bool) — reboot automatically when an
+          update changes the kernel. Default: false.
+
+        - `activate.reboot_delay_minutes` (int) — minutes to wait before
+          an automatic reboot. Default: 15.
+
+        - `daemon.initial_delay_seconds` (int) — delay before the first
+          update cycle after startup. Default: 900.
+
+        - `daemon.interval_seconds` (int) — seconds between update
+          cycles. Default: 3600.
+
+        - `daemon.jitter_seconds` (int) — upper bound of the random
+          extra delay added to each interval. Default: 1800.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    ogygia.updated.settings = {
+      repo.url = lib.mkDefault config.ogygia.gitRemoteUrl;
+      host.name = lib.mkDefault config.networking.fqdn;
+    };
+
+    systemd.services.ogygia-updated = {
+      description = "Ogygia Automatic Update Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      # The daemon activates new configurations, so switch-to-configuration
+      # runs as its child and must never take it down mid-update. Instead
+      # the daemon exits after activating and Restart brings it back under
+      # the new unit definition.
+      restartIfChanged = false;
+      stopIfChanged = false;
+
+      path = [ config.nix.package config.systemd.package ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/ogygia-updated --config ${configFile}";
+        Restart = "always";
+        RestartSec = "5s";
+        StateDirectory = "ogygia-updated";
+        # Holds the control socket; root-only so filesystem permissions
+        # authorize manual `ogygia update` triggers.
+        RuntimeDirectory = "ogygia-updated";
+        RuntimeDirectoryMode = "0700";
+      };
+
+      environment = {
+        RUST_LOG = lib.mkDefault "info";
+      };
+    };
+  };
+}

--- a/src/ogygia-updated/Cargo.toml
+++ b/src/ogygia-updated/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ogygia-updated"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+git2 = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/src/ogygia-updated/src/config.rs
+++ b/src/ogygia-updated/src/config.rs
@@ -1,0 +1,221 @@
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use serde::Deserialize;
+
+/// Daemon configuration, deserialized from TOML.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    pub repo: RepoConfig,
+    pub host: HostConfig,
+    #[serde(default)]
+    pub build: BuildConfig,
+    #[serde(default)]
+    pub activate: ActivateConfig,
+    #[serde(default)]
+    pub daemon: DaemonConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepoConfig {
+    /// Git remote to track.
+    pub url: String,
+    /// Where the daemon keeps its private clone.
+    #[serde(default = "default_repo_path")]
+    pub path: PathBuf,
+    /// Branch whose tip the host follows.
+    #[serde(default = "default_branch")]
+    pub branch: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostConfig {
+    /// Attribute name of this host's nixosConfiguration in the flake.
+    pub name: String,
+    /// File holding the commit the running system was built from.
+    #[serde(default = "default_current_revision_path")]
+    pub current_revision_path: PathBuf,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildConfig {
+    /// Flake attribute to build. Defaults to the host's toplevel.
+    pub flake_attr: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ActivateConfig {
+    /// Reboot automatically when an update changes the kernel.
+    #[serde(default)]
+    pub allow_reboot: bool,
+    /// Minutes to wait before an automatic reboot.
+    #[serde(default = "default_reboot_delay_minutes")]
+    pub reboot_delay_minutes: u32,
+    /// System profile updated with the new generation.
+    #[serde(default = "default_profile")]
+    pub profile: PathBuf,
+    /// Booted system compared against the new generation to detect
+    /// kernel changes.
+    #[serde(default = "default_booted_system")]
+    pub booted_system: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DaemonConfig {
+    /// Seconds to wait after startup before the first update.
+    #[serde(default = "default_initial_delay_seconds")]
+    pub initial_delay_seconds: u64,
+    /// Seconds between update cycles.
+    #[serde(default = "default_interval_seconds")]
+    pub interval_seconds: u64,
+    /// Upper bound of the random extra delay added to each interval.
+    #[serde(default = "default_jitter_seconds")]
+    pub jitter_seconds: u64,
+    /// Control socket manual update triggers are received on.
+    #[serde(default = "default_socket_path")]
+    pub socket_path: PathBuf,
+}
+
+impl Config {
+    pub fn load(path: &Path) -> Result<Self> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("reading config file {}", path.display()))?;
+        toml::from_str(&raw).with_context(|| format!("parsing config file {}", path.display()))
+    }
+
+    /// Flake attribute to build, defaulting to this host's toplevel.
+    pub fn flake_attr(&self) -> String {
+        self.build.flake_attr.clone().unwrap_or_else(|| {
+            format!(
+                "nixosConfigurations.\"{}\".config.system.build.toplevel",
+                self.host.name
+            )
+        })
+    }
+
+    /// File holding the commit the next boot's system was built from.
+    pub fn next_boot_revision_path(&self) -> PathBuf {
+        self.activate.profile.join("sw/share/ogygia/build-revision")
+    }
+}
+
+impl Default for ActivateConfig {
+    fn default() -> Self {
+        Self {
+            allow_reboot: false,
+            reboot_delay_minutes: default_reboot_delay_minutes(),
+            profile: default_profile(),
+            booted_system: default_booted_system(),
+        }
+    }
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay_seconds: default_initial_delay_seconds(),
+            interval_seconds: default_interval_seconds(),
+            jitter_seconds: default_jitter_seconds(),
+            socket_path: default_socket_path(),
+        }
+    }
+}
+
+fn default_repo_path() -> PathBuf {
+    PathBuf::from("/var/lib/ogygia-updated/repo")
+}
+
+fn default_branch() -> String {
+    "main".to_string()
+}
+
+fn default_current_revision_path() -> PathBuf {
+    PathBuf::from("/run/current-system/sw/share/ogygia/build-revision")
+}
+
+fn default_reboot_delay_minutes() -> u32 {
+    15
+}
+
+fn default_profile() -> PathBuf {
+    PathBuf::from("/nix/var/nix/profiles/system")
+}
+
+fn default_booted_system() -> PathBuf {
+    PathBuf::from("/run/booted-system")
+}
+
+fn default_socket_path() -> PathBuf {
+    PathBuf::from(crate::control::DEFAULT_SOCKET_PATH)
+}
+
+fn default_initial_delay_seconds() -> u64 {
+    900
+}
+
+fn default_interval_seconds() -> u64 {
+    3600
+}
+
+fn default_jitter_seconds() -> u64 {
+    1800
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimal_config_uses_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+            [repo]
+            url = "https://git.example.com/nixos.git"
+
+            [host]
+            name = "host.example.com"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.repo.branch, "main");
+        assert_eq!(
+            config.repo.path,
+            PathBuf::from("/var/lib/ogygia-updated/repo")
+        );
+        assert_eq!(
+            config.flake_attr(),
+            "nixosConfigurations.\"host.example.com\".config.system.build.toplevel"
+        );
+        assert_eq!(
+            config.next_boot_revision_path(),
+            PathBuf::from("/nix/var/nix/profiles/system/sw/share/ogygia/build-revision")
+        );
+        assert!(!config.activate.allow_reboot);
+        assert_eq!(config.daemon.interval_seconds, 3600);
+    }
+
+    #[test]
+    fn unknown_keys_are_rejected() {
+        let result: Result<Config, _> = toml::from_str(
+            r#"
+            [repo]
+            url = "https://git.example.com/nixos.git"
+            urll = "typo"
+
+            [host]
+            name = "host.example.com"
+            "#,
+        );
+        assert!(result.is_err());
+    }
+}

--- a/src/ogygia-updated/src/control.rs
+++ b/src/ogygia-updated/src/control.rs
@@ -1,0 +1,174 @@
+//! Control socket for triggering update cycles in the running daemon.
+//!
+//! The daemon is the sole owner of the repository clone, the system
+//! profile, and the update schedule; manual updates ask it to run a
+//! cycle now rather than running the engine themselves. Authorization
+//! is delegated to filesystem permissions on the socket.
+
+use std::fs;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixListener;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::warn;
+
+pub const DEFAULT_SOCKET_PATH: &str = "/run/ogygia-updated/control.sock";
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A command for the daemon, sent over the control socket. Each variant
+/// carries only the data its operation needs.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum Request {
+    /// Reset the target to the configured branch tip and run a cycle now.
+    Update,
+}
+
+/// The daemon's answer to a trigger: the result message of the cycle it
+/// ran, or the reason it could not run one. Serialized as a JSON
+/// `Result`, e.g. `{"Ok":"switched to abc"}` or `{"Err":"..."}`.
+pub type Response = Result<String, String>;
+
+/// Trigger an update cycle in the daemon listening on `socket_path` and
+/// wait for it to finish, returning its result message. Errors if the
+/// daemon cannot be reached or reports a failed cycle.
+pub fn request_update(socket_path: &Path) -> Result<String> {
+    let mut stream = UnixStream::connect(socket_path).with_context(|| {
+        format!(
+            "connecting to {}; is ogygia-updated running, and are you root?",
+            socket_path.display()
+        )
+    })?;
+
+    let mut request = serde_json::to_vec(&Request::Update)?;
+    request.push(b'\n');
+    stream
+        .write_all(&request)
+        .context("sending update request")?;
+
+    // No read timeout: the cycle legitimately takes as long as a build.
+    let mut line = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut line)
+        .context("reading daemon response")?;
+    match serde_json::from_str::<Response>(&line).context("parsing daemon response")? {
+        Ok(message) => Ok(message),
+        Err(message) => bail!(message),
+    }
+}
+
+/// Bind the control socket, replacing a stale one from a previous run
+/// and restricting it to root.
+pub fn bind(socket_path: &Path) -> Result<UnixListener> {
+    if socket_path.exists() {
+        fs::remove_file(socket_path)
+            .with_context(|| format!("removing stale socket {}", socket_path.display()))?;
+    }
+    let listener = UnixListener::bind(socket_path)
+        .with_context(|| format!("binding control socket {}", socket_path.display()))?;
+    fs::set_permissions(socket_path, fs::Permissions::from_mode(0o600))
+        .context("restricting control socket permissions")?;
+    Ok(listener)
+}
+
+/// Accept trigger connections and hand them to the update loop, which
+/// answers each with the result of the cycle it ran. Invalid requests
+/// are answered immediately without triggering a cycle.
+pub fn listen(listener: UnixListener, triggers: mpsc::Sender<UnixStream>) {
+    for stream in listener.incoming() {
+        let Ok(mut stream) = stream else { continue };
+        let _ = stream.set_read_timeout(Some(REQUEST_TIMEOUT));
+
+        let mut line = String::new();
+        if BufReader::new(&stream).read_line(&mut line).is_err() {
+            continue;
+        }
+        if serde_json::from_str::<Request>(&line).is_err() {
+            respond(&mut stream, Err("invalid request".to_string()));
+            continue;
+        }
+
+        if triggers.send(stream).is_err() {
+            return;
+        }
+    }
+}
+
+/// Answer a trigger connection. Failures only lose the reply, never the
+/// update cycle, so they are logged and swallowed.
+pub fn respond(stream: &mut UnixStream, response: Response) {
+    let mut payload = match serde_json::to_vec(&response) {
+        Ok(payload) => payload,
+        Err(error) => {
+            warn!(%error, "failed to encode control response");
+            return;
+        }
+    };
+    payload.push(b'\n');
+    if let Err(error) = stream.write_all(&payload) {
+        warn!(%error, "failed to answer on the control socket");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn request_update_round_trips() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let socket_path = dir.path().join("control.sock");
+        let listener = bind(&socket_path).unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || listen(listener, sender));
+        let server = thread::spawn(move || {
+            let mut stream = receiver.recv().unwrap();
+            respond(&mut stream, Ok("switched to abc".to_string()));
+            let mut stream = receiver.recv().unwrap();
+            respond(&mut stream, Err("update failed".to_string()));
+        });
+
+        assert_eq!(request_update(&socket_path).unwrap(), "switched to abc");
+        let error = request_update(&socket_path).unwrap_err();
+        assert_eq!(error.to_string(), "update failed");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn stale_sockets_are_replaced_and_garbage_is_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let socket_path = dir.path().join("control.sock");
+        drop(bind(&socket_path).unwrap());
+
+        // A leftover socket file from a previous run is replaced.
+        let listener = bind(&socket_path).unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || listen(listener, sender));
+
+        let mut stream = UnixStream::connect(&socket_path).unwrap();
+        stream.write_all(b"not json\n").unwrap();
+        let mut line = String::new();
+        BufReader::new(&stream).read_line(&mut line).unwrap();
+        let response: Response = serde_json::from_str(&line).unwrap();
+        assert!(response.is_err());
+
+        // The garbage request never reached the update loop.
+        assert!(receiver.try_recv().is_err());
+    }
+}

--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -1,0 +1,510 @@
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+use git2::Oid;
+use tracing::info;
+
+use crate::config::Config;
+use crate::repo::Repo;
+use crate::system::Activation;
+use crate::system::RealSystem;
+use crate::system::System;
+
+/// Result of one update cycle.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// The running and next-boot systems already match the branch tip.
+    UpToDate,
+    /// The running system was not built from the tracked branch, so it
+    /// was left alone.
+    NotOnBranch { revision: String },
+    /// The new system was activated and made the boot default.
+    Switched { commit: String },
+    /// The next-boot system was not built from the tracked branch, so
+    /// the new system was activated without touching the boot profile.
+    TestActivated { commit: String },
+    /// The new system needs a new kernel; it is the boot default and a
+    /// reboot has been scheduled.
+    RebootScheduled { commit: String },
+}
+
+impl fmt::Display for Outcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Outcome::UpToDate => write!(f, "system is up to date"),
+            Outcome::NotOnBranch { revision } => {
+                write!(
+                    f,
+                    "running revision {revision} is not on the tracked branch; not updating"
+                )
+            }
+            Outcome::Switched { commit } => write!(f, "switched to {commit}"),
+            Outcome::TestActivated { commit } => {
+                write!(f, "activated {commit} without changing the boot default")
+            }
+            Outcome::RebootScheduled { commit } => {
+                write!(f, "staged {commit} for boot and scheduled a reboot")
+            }
+        }
+    }
+}
+
+/// What initiated an update cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trigger {
+    /// The daemon's own interval fired. A host deliberately running or
+    /// booting an off-branch build is left alone.
+    Scheduled,
+    /// An operator asked for a cycle over the control socket. The host is
+    /// pulled back onto the branch tip regardless of what it is running,
+    /// so scheduled updates resume.
+    Manual,
+}
+
+/// Run one update cycle.
+pub fn run_once(config: &Config, trigger: Trigger) -> Result<Outcome> {
+    run(config, &RealSystem, trigger)
+}
+
+fn run(config: &Config, system: &impl System, trigger: Trigger) -> Result<Outcome> {
+    let current = read_revision(&config.host.current_revision_path)?;
+    let next_boot = read_revision(&config.next_boot_revision_path())?;
+
+    let repo = Repo::open_or_clone(&config.repo)?;
+    repo.fetch()?;
+    let tip = repo.tip(&config.repo.branch)?;
+    info!(%current, %next_boot, %tip, branch = %config.repo.branch, ?trigger, "fetched");
+
+    // The scheduler leaves a deliberately off-branch host alone; a manual
+    // trigger overrides that to pull it back onto the branch.
+    if trigger == Trigger::Scheduled && !repo.is_ancestor(current, tip)? {
+        return Ok(Outcome::NotOnBranch {
+            revision: current.to_string(),
+        });
+    }
+
+    if current == tip && next_boot == tip {
+        return Ok(Outcome::UpToDate);
+    }
+
+    repo.checkout(tip)?;
+
+    let flake = format!("git+file://{}", config.repo.path.display());
+    let store_path = system.build(&format!("{flake}#{}", config.flake_attr()))?;
+    info!(store_path = %store_path.display(), "built new system");
+
+    // A hand-staged off-branch next-boot system is preserved by the
+    // scheduler, but a manual trigger resets the boot default to the tip.
+    let next_boot_on_branch = match trigger {
+        Trigger::Manual => true,
+        Trigger::Scheduled => repo.is_ancestor(next_boot, tip)?,
+    };
+    activate(config, system, &store_path, tip, next_boot_on_branch)
+}
+
+fn activate(
+    config: &Config,
+    system: &impl System,
+    store_path: &Path,
+    tip: Oid,
+    next_boot_on_branch: bool,
+) -> Result<Outcome> {
+    let commit = tip.to_string();
+
+    // A next-boot system off the tracked branch was deliberately staged
+    // by hand; activate the update without clobbering it.
+    if !next_boot_on_branch {
+        system.switch_to_configuration(store_path, Activation::Test)?;
+        return Ok(Outcome::TestActivated { commit });
+    }
+
+    if !config.activate.allow_reboot {
+        system.set_profile(&config.activate.profile, store_path)?;
+        system.switch_to_configuration(store_path, Activation::Switch)?;
+        return Ok(Outcome::Switched { commit });
+    }
+
+    system.set_profile(&config.activate.profile, store_path)?;
+    system.switch_to_configuration(store_path, Activation::Boot)?;
+    if system.kernel_links(&config.activate.booted_system) == system.kernel_links(store_path) {
+        system.switch_to_configuration(store_path, Activation::Test)?;
+        Ok(Outcome::Switched { commit })
+    } else {
+        system.schedule_reboot(config.activate.reboot_delay_minutes)?;
+        Ok(Outcome::RebootScheduled { commit })
+    }
+}
+
+fn read_revision(path: &Path) -> Result<Oid> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading build revision {}", path.display()))?;
+    Oid::from_str(raw.trim()).with_context(|| {
+        format!(
+            "parsing build revision {:?} from {}",
+            raw.trim(),
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::config::ActivateConfig;
+    use crate::config::BuildConfig;
+    use crate::config::DaemonConfig;
+    use crate::config::HostConfig;
+    use crate::config::RepoConfig;
+    use crate::repo::testutil::commit;
+    use crate::repo::testutil::init_origin;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Call {
+        Build(String),
+        SetProfile(PathBuf),
+        SwitchToConfiguration(Activation),
+        ScheduleReboot(u32),
+    }
+
+    #[derive(Default)]
+    struct MockSystem {
+        calls: RefCell<Vec<Call>>,
+        booted_kernel: Option<&'static str>,
+        built_kernel: Option<&'static str>,
+    }
+
+    impl System for MockSystem {
+        fn build(&self, flake_ref: &str) -> Result<PathBuf> {
+            self.calls
+                .borrow_mut()
+                .push(Call::Build(flake_ref.to_string()));
+            Ok(PathBuf::from("/nix/store/new-system"))
+        }
+
+        fn set_profile(&self, profile: &Path, _store_path: &Path) -> Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(Call::SetProfile(profile.to_path_buf()));
+            Ok(())
+        }
+
+        fn switch_to_configuration(&self, _store_path: &Path, action: Activation) -> Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(Call::SwitchToConfiguration(action));
+            Ok(())
+        }
+
+        fn kernel_links(&self, system: &Path) -> [Option<PathBuf>; 3] {
+            let kernel = if system == Path::new("/run/booted-system") {
+                self.booted_kernel
+            } else {
+                self.built_kernel
+            };
+            [kernel.map(PathBuf::from), None, None]
+        }
+
+        fn schedule_reboot(&self, delay_minutes: u32) -> Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(Call::ScheduleReboot(delay_minutes));
+            Ok(())
+        }
+    }
+
+    struct Fixture {
+        // Held so the temporary directory outlives the test.
+        _dir: TempDir,
+        origin: git2::Repository,
+        config: Config,
+    }
+
+    impl Fixture {
+        fn new() -> (Self, Oid) {
+            let dir = TempDir::new().unwrap();
+            let origin_path = dir.path().join("origin");
+            let (origin, initial) = init_origin(&origin_path);
+
+            let profile = dir.path().join("profile");
+            fs::create_dir_all(profile.join("sw/share/ogygia")).unwrap();
+
+            let config = Config {
+                repo: RepoConfig {
+                    url: origin_path.to_str().unwrap().to_string(),
+                    path: dir.path().join("clone"),
+                    branch: "main".to_string(),
+                },
+                host: HostConfig {
+                    name: "host.example.com".to_string(),
+                    current_revision_path: dir.path().join("current-revision"),
+                },
+                build: BuildConfig::default(),
+                activate: ActivateConfig {
+                    profile,
+                    ..ActivateConfig::default()
+                },
+                daemon: DaemonConfig::default(),
+            };
+
+            let fixture = Self {
+                _dir: dir,
+                origin,
+                config,
+            };
+            (fixture, initial)
+        }
+
+        fn set_current(&self, revision: Oid) {
+            fs::write(
+                &self.config.host.current_revision_path,
+                format!("{revision}\n"),
+            )
+            .unwrap();
+        }
+
+        fn set_next_boot(&self, revision: Oid) {
+            fs::write(
+                self.config.next_boot_revision_path(),
+                format!("{revision}\n"),
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn up_to_date_makes_no_changes() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(outcome, Outcome::UpToDate);
+        assert!(system.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn update_switches_to_the_new_commit() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        let flake_ref = format!(
+            "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
+            fixture.config.repo.path.display()
+        );
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(flake_ref),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+
+        // The working tree was left checked out at the new commit.
+        assert_eq!(
+            fs::read_to_string(fixture.config.repo.path.join("marker")).unwrap(),
+            "second"
+        );
+    }
+
+    #[test]
+    fn off_branch_current_revision_blocks_the_update() {
+        let (fixture, initial) = Fixture::new();
+        let side = commit(&fixture.origin, "side", &[initial], "side");
+        commit(&fixture.origin, "main", &[initial], "second");
+        fixture.set_current(side);
+        fixture.set_next_boot(initial);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::NotOnBranch {
+                revision: side.to_string()
+            }
+        );
+        assert!(system.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn off_branch_next_boot_gets_test_activation_only() {
+        let (fixture, initial) = Fixture::new();
+        let side = commit(&fixture.origin, "side", &[initial], "side");
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        fixture.set_current(initial);
+        fixture.set_next_boot(side);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::TestActivated {
+                commit: second.to_string()
+            }
+        );
+        let calls = system.calls.borrow();
+        assert_eq!(
+            *calls,
+            vec![
+                Call::Build(format!(
+                    "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
+                    fixture.config.repo.path.display()
+                )),
+                Call::SwitchToConfiguration(Activation::Test),
+            ]
+        );
+    }
+
+    #[test]
+    fn manual_recovers_an_off_branch_running_system() {
+        let (fixture, initial) = Fixture::new();
+        let side = commit(&fixture.origin, "side", &[initial], "side");
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        fixture.set_current(side);
+        fixture.set_next_boot(initial);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, Trigger::Manual).unwrap();
+
+        // The off-branch guard is overridden and the host is switched onto
+        // the branch tip.
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(format!(
+                    "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
+                    fixture.config.repo.path.display()
+                )),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+    }
+
+    #[test]
+    fn manual_resets_an_off_branch_next_boot() {
+        let (fixture, initial) = Fixture::new();
+        let side = commit(&fixture.origin, "side", &[initial], "side");
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        fixture.set_current(initial);
+        fixture.set_next_boot(side);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, Trigger::Manual).unwrap();
+
+        // Rather than test-activating around the hand-staged boot entry,
+        // the manual trigger resets the boot default to the tip.
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(format!(
+                    "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
+                    fixture.config.repo.path.display()
+                )),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+    }
+
+    #[test]
+    fn unchanged_kernel_switches_without_reboot() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let mut config = fixture.config;
+        config.activate.allow_reboot = true;
+        config.activate.booted_system = PathBuf::from("/run/booted-system");
+
+        let system = MockSystem {
+            booted_kernel: Some("kernel-1"),
+            built_kernel: Some("kernel-1"),
+            ..MockSystem::default()
+        };
+        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(
+            system.calls.borrow()[1..],
+            [
+                Call::SetProfile(config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Boot),
+                Call::SwitchToConfiguration(Activation::Test),
+            ]
+        );
+    }
+
+    #[test]
+    fn changed_kernel_schedules_a_reboot() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let mut config = fixture.config;
+        config.activate.allow_reboot = true;
+        config.activate.booted_system = PathBuf::from("/run/booted-system");
+
+        let system = MockSystem {
+            booted_kernel: Some("kernel-1"),
+            built_kernel: Some("kernel-2"),
+            ..MockSystem::default()
+        };
+        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::RebootScheduled {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(
+            system.calls.borrow()[1..],
+            [
+                Call::SetProfile(config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Boot),
+                Call::ScheduleReboot(15),
+            ]
+        );
+    }
+}

--- a/src/ogygia-updated/src/lib.rs
+++ b/src/ogygia-updated/src/lib.rs
@@ -1,0 +1,24 @@
+//! Pull-based NixOS auto-updater.
+//!
+//! Tracks a branch of the NixOS configuration repository and updates the
+//! local system to its tip: the running and next-boot systems' build
+//! revisions (embedded by `ogygia.versions`) gate the update so hosts
+//! deliberately running unmerged builds are left alone, the new system is
+//! built from a private clone, and activation mirrors nixos-rebuild
+//! (`test`/`switch`/`boot` plus a delayed reboot on kernel changes).
+//!
+//! The `ogygia-updated` daemon owns all update state and runs cycles on
+//! an interval; `ogygia update` asks it to run a cycle now over its
+//! control socket.
+
+pub mod control;
+
+mod config;
+mod engine;
+mod repo;
+mod system;
+
+pub use config::Config;
+pub use engine::Outcome;
+pub use engine::Trigger;
+pub use engine::run_once;

--- a/src/ogygia-updated/src/main.rs
+++ b/src/ogygia-updated/src/main.rs
@@ -1,0 +1,98 @@
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::mpsc::RecvTimeoutError;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::Result;
+use anyhow::bail;
+use clap::Parser;
+use ogygia_updated::Config;
+use ogygia_updated::Outcome;
+use ogygia_updated::Trigger;
+use ogygia_updated::control;
+use rand::RngExt;
+use tracing::error;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+/// Ogygia automatic update daemon.
+#[derive(Parser)]
+#[command(
+    name = "ogygia-updated",
+    version,
+    about = "Ogygia automatic update daemon"
+)]
+struct Args {
+    /// Path to the TOML configuration file
+    #[arg(long)]
+    config: PathBuf,
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("ogygia_updated=info,warn")),
+        )
+        .init();
+
+    let args = Args::parse();
+    let config = Config::load(&args.config)?;
+
+    let listener = control::bind(&config.daemon.socket_path)?;
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || control::listen(listener, sender));
+
+    // Wait out the initial delay or the interval between cycles, but run
+    // immediately when an update is requested over the control socket.
+    let mut wait = Duration::from_secs(config.daemon.initial_delay_seconds);
+    loop {
+        let request = match receiver.recv_timeout(wait) {
+            Ok(stream) => Some(stream),
+            Err(RecvTimeoutError::Timeout) => None,
+            Err(RecvTimeoutError::Disconnected) => bail!("control socket listener exited"),
+        };
+        let trigger = if request.is_some() {
+            info!("update requested over the control socket");
+            Trigger::Manual
+        } else {
+            Trigger::Scheduled
+        };
+
+        let result = ogygia_updated::run_once(&config, trigger);
+        let response = match &result {
+            Ok(outcome) => {
+                info!(%outcome, "update cycle finished");
+                Ok(outcome.to_string())
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                error!(message, "update cycle failed");
+                Err(message)
+            }
+        };
+        if let Some(mut stream) = request {
+            control::respond(&mut stream, response);
+        }
+
+        // Activating a configuration may have replaced this unit's
+        // definition, which switch-to-configuration never restarts
+        // (restartIfChanged is off so it cannot kill its own parent
+        // mid-cycle); exit so systemd brings the daemon back under the
+        // new definition.
+        if matches!(
+            result,
+            Ok(Outcome::Switched { .. } | Outcome::TestActivated { .. })
+        ) {
+            info!("activated a new configuration; exiting to adopt its unit definition");
+            return Ok(());
+        }
+
+        let jitter = match config.daemon.jitter_seconds {
+            0 => 0,
+            bound => rand::rng().random_range(0..bound),
+        };
+        wait = Duration::from_secs(config.daemon.interval_seconds + jitter);
+    }
+}

--- a/src/ogygia-updated/src/repo.rs
+++ b/src/ogygia-updated/src/repo.rs
@@ -1,0 +1,221 @@
+use std::fs;
+
+use anyhow::Context;
+use anyhow::Result;
+use git2::ErrorCode;
+use git2::Oid;
+use git2::Repository;
+use git2::build::CheckoutBuilder;
+use git2::build::RepoBuilder;
+use tracing::info;
+
+use crate::config::RepoConfig;
+
+/// Refspec mirroring every remote head, so commits only reachable from
+/// non-tracked branches (e.g. archived deployed commits) stay available
+/// for ancestry checks.
+const FETCH_REFSPEC: &str = "+refs/heads/*:refs/remotes/origin/*";
+
+/// The daemon's private clone of the configuration repository.
+pub struct Repo {
+    inner: Repository,
+}
+
+impl Repo {
+    pub fn open_or_clone(config: &RepoConfig) -> Result<Self> {
+        let inner = match Repository::open(&config.path) {
+            Ok(repository) => repository,
+            Err(error) if error.code() == ErrorCode::NotFound => {
+                info!(url = %config.url, path = %config.path.display(), "cloning repository");
+                fs::create_dir_all(&config.path)
+                    .with_context(|| format!("creating {}", config.path.display()))?;
+                RepoBuilder::new()
+                    .clone(&config.url, &config.path)
+                    .with_context(|| format!("cloning {}", config.url))?
+            }
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("opening repository {}", config.path.display()));
+            }
+        };
+        Ok(Self { inner })
+    }
+
+    pub fn fetch(&self) -> Result<()> {
+        let mut remote = self.inner.find_remote("origin").context("finding origin")?;
+        remote
+            .fetch(&[FETCH_REFSPEC], None, None)
+            .context("fetching from origin")?;
+        Ok(())
+    }
+
+    /// Tip commit of `branch` on the remote.
+    pub fn tip(&self, branch: &str) -> Result<Oid> {
+        let reference = format!("refs/remotes/origin/{branch}");
+        let commit = self
+            .inner
+            .find_reference(&reference)
+            .with_context(|| format!("finding {reference}"))?
+            .peel_to_commit()
+            .with_context(|| format!("resolving {reference} to a commit"))?;
+        Ok(commit.id())
+    }
+
+    /// Whether `ancestor` is `descendant` or one of its ancestors. Commits
+    /// unknown to the repository are not ancestors of anything.
+    pub fn is_ancestor(&self, ancestor: Oid, descendant: Oid) -> Result<bool> {
+        if ancestor == descendant {
+            return Ok(self.inner.find_commit(ancestor).is_ok());
+        }
+        if self.inner.find_commit(ancestor).is_err() {
+            return Ok(false);
+        }
+        self.inner
+            .graph_descendant_of(descendant, ancestor)
+            .context("walking commit graph")
+    }
+
+    /// Force the working tree onto `commit` with a detached HEAD, leaving
+    /// it clean so flake evaluation sees the commit as the revision.
+    pub fn checkout(&self, commit: Oid) -> Result<()> {
+        let object = self
+            .inner
+            .find_object(commit, None)
+            .with_context(|| format!("finding commit {commit}"))?;
+        self.inner
+            .checkout_tree(
+                &object,
+                Some(CheckoutBuilder::new().force().remove_untracked(true)),
+            )
+            .with_context(|| format!("checking out {commit}"))?;
+        self.inner
+            .set_head_detached(commit)
+            .with_context(|| format!("detaching HEAD at {commit}"))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod testutil {
+    use std::path::Path;
+
+    use git2::Oid;
+    use git2::Repository;
+    use git2::Signature;
+
+    /// Create a commit in `repository` updating `branch`, with `marker`
+    /// written to a file to make each tree distinct.
+    pub fn commit(repository: &Repository, branch: &str, parents: &[Oid], marker: &str) -> Oid {
+        let signature = Signature::now("test", "test@example.com").unwrap();
+        let blob = repository.blob(marker.as_bytes()).unwrap();
+        let mut builder = repository.treebuilder(None).unwrap();
+        builder.insert("marker", blob, 0o100644).unwrap();
+        let tree = repository.find_tree(builder.write().unwrap()).unwrap();
+        let parents: Vec<_> = parents
+            .iter()
+            .map(|oid| repository.find_commit(*oid).unwrap())
+            .collect();
+        let parent_refs: Vec<_> = parents.iter().collect();
+        repository
+            .commit(
+                Some(&format!("refs/heads/{branch}")),
+                &signature,
+                &signature,
+                marker,
+                &tree,
+                &parent_refs,
+            )
+            .unwrap()
+    }
+
+    /// Initialize an origin repository with an initial commit on main.
+    pub fn init_origin(path: &Path) -> (Repository, Oid) {
+        let repository = Repository::init(path).unwrap();
+        repository.set_head("refs/heads/main").unwrap();
+        let initial = commit(&repository, "main", &[], "initial");
+        (repository, initial)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::testutil::commit;
+    use super::testutil::init_origin;
+    use super::*;
+    use crate::config::RepoConfig;
+
+    fn repo_config(origin: &Path, clone: &Path) -> RepoConfig {
+        RepoConfig {
+            url: origin.to_str().unwrap().to_string(),
+            path: clone.to_path_buf(),
+            branch: "main".to_string(),
+        }
+    }
+
+    #[test]
+    fn clones_fetches_and_tracks_tip() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+
+        let config = repo_config(&origin_path, &clone_path);
+        let repo = Repo::open_or_clone(&config).unwrap();
+        repo.fetch().unwrap();
+        assert_eq!(repo.tip("main").unwrap(), initial);
+
+        let second = commit(&origin, "main", &[initial], "second");
+        repo.fetch().unwrap();
+        assert_eq!(repo.tip("main").unwrap(), second);
+
+        // Reopening finds the existing clone rather than recloning.
+        let repo = Repo::open_or_clone(&config).unwrap();
+        assert_eq!(repo.tip("main").unwrap(), second);
+    }
+
+    #[test]
+    fn ancestry_covers_unknown_and_side_commits() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "side", &[initial], "side");
+
+        let repo = Repo::open_or_clone(&repo_config(&origin_path, &clone_path)).unwrap();
+        repo.fetch().unwrap();
+
+        assert!(repo.is_ancestor(initial, second).unwrap());
+        assert!(repo.is_ancestor(second, second).unwrap());
+        assert!(!repo.is_ancestor(second, initial).unwrap());
+        assert!(!repo.is_ancestor(side, second).unwrap());
+
+        let unknown = Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+        assert!(!repo.is_ancestor(unknown, second).unwrap());
+    }
+
+    #[test]
+    fn checkout_leaves_clean_tree_at_commit() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+        let second = commit(&origin, "main", &[initial], "second");
+
+        let repo = Repo::open_or_clone(&repo_config(&origin_path, &clone_path)).unwrap();
+        repo.fetch().unwrap();
+        repo.checkout(second).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(clone_path.join("marker")).unwrap(),
+            "second"
+        );
+        let statuses = repo.inner.statuses(None).unwrap();
+        assert!(statuses.is_empty());
+        assert_eq!(repo.inner.head().unwrap().target(), Some(second));
+    }
+}

--- a/src/ogygia-updated/src/system.rs
+++ b/src/ogygia-updated/src/system.rs
@@ -1,0 +1,107 @@
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::str;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use tracing::info;
+
+/// A switch-to-configuration action, mirroring nixos-rebuild.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Activation {
+    /// Activate now without touching the boot loader.
+    Test,
+    /// Activate now and make it the boot default.
+    Switch,
+    /// Make it the boot default for the next boot, without activating now.
+    Boot,
+}
+
+impl Activation {
+    fn arg(self) -> &'static str {
+        match self {
+            Activation::Test => "test",
+            Activation::Switch => "switch",
+            Activation::Boot => "boot",
+        }
+    }
+}
+
+/// Side effects of an update cycle, abstracted for testing.
+pub trait System {
+    /// Build `flake_ref` and return its store path.
+    fn build(&self, flake_ref: &str) -> Result<PathBuf>;
+    /// Point `profile` at `store_path` as a new generation.
+    fn set_profile(&self, profile: &Path, store_path: &Path) -> Result<()>;
+    /// Run `store_path`'s switch-to-configuration with `action`.
+    fn switch_to_configuration(&self, store_path: &Path, action: Activation) -> Result<()>;
+    /// Kernel, initrd, and kernel-modules links of a system, used to
+    /// detect updates that need a reboot. Missing links resolve to None.
+    fn kernel_links(&self, system: &Path) -> [Option<PathBuf>; 3];
+    /// Schedule a reboot in `delay_minutes` minutes.
+    fn schedule_reboot(&self, delay_minutes: u32) -> Result<()>;
+}
+
+pub struct RealSystem;
+
+const EXPERIMENTAL_FEATURES: [&str; 2] = ["--extra-experimental-features", "nix-command flakes"];
+
+impl System for RealSystem {
+    fn build(&self, flake_ref: &str) -> Result<PathBuf> {
+        let mut command = Command::new("nix");
+        command
+            .arg("build")
+            .args(EXPERIMENTAL_FEATURES)
+            .args(["--option", "always-allow-substitutes", "true"])
+            .args(["--no-link", "--print-out-paths"])
+            .arg(flake_ref)
+            .stderr(std::process::Stdio::inherit());
+        info!(?command, "building");
+        let output = command.output().context("running nix build")?;
+        if !output.status.success() {
+            bail!("nix build {flake_ref} failed with {}", output.status);
+        }
+        let stdout = str::from_utf8(&output.stdout).context("decoding nix build output")?;
+        let path = stdout
+            .lines()
+            .next_back()
+            .context("nix build printed no out paths")?;
+        Ok(PathBuf::from(path))
+    }
+
+    fn set_profile(&self, profile: &Path, store_path: &Path) -> Result<()> {
+        run(Command::new("nix-env")
+            .arg("-p")
+            .arg(profile)
+            .arg("--set")
+            .arg(store_path))
+    }
+
+    fn switch_to_configuration(&self, store_path: &Path, action: Activation) -> Result<()> {
+        run(Command::new(store_path.join("bin/switch-to-configuration")).arg(action.arg()))
+    }
+
+    fn kernel_links(&self, system: &Path) -> [Option<PathBuf>; 3] {
+        ["initrd", "kernel", "kernel-modules"].map(|name| fs::read_link(system.join(name)).ok())
+    }
+
+    fn schedule_reboot(&self, delay_minutes: u32) -> Result<()> {
+        run(Command::new("shutdown")
+            .arg("-r")
+            .arg(format!("+{delay_minutes}")))
+    }
+}
+
+fn run(command: &mut Command) -> Result<()> {
+    info!(?command, "running");
+    let status = command
+        .status()
+        .with_context(|| format!("running {:?}", command.get_program()))?;
+    if !status.success() {
+        bail!("{:?} failed with {status}", command.get_program());
+    }
+    Ok(())
+}

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["irisd", "nebula"]
+default = ["irisd", "nebula", "updated"]
 irisd = [
     "dep:reqwest",
     "dep:serde_json",
@@ -16,6 +16,9 @@ nebula = [
     "dep:tempfile",
     "dep:which",
     "dep:ogygia-nixutils",
+]
+updated = [
+    "dep:ogygia-updated",
 ]
 
 [dependencies]
@@ -38,3 +41,6 @@ ogygia-nixutils = { path = "../ogygia-nixutils", optional = true }
 # Optional deps for nebula feature
 tempfile = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
+
+# Optional deps for updated feature
+ogygia-updated = { path = "../ogygia-updated", optional = true }

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -30,6 +30,8 @@ mod iris;
 #[cfg(feature = "nebula")]
 mod nebula;
 mod status;
+#[cfg(feature = "updated")]
+mod update;
 
 use std::process;
 
@@ -57,6 +59,9 @@ enum Command {
     /// Manage Nebula CA, host keys, and certificates
     #[cfg(feature = "nebula")]
     Nebula(nebula::NebulaArgs),
+    /// Update the system to the tracked branch tip (root only)
+    #[cfg(feature = "updated")]
+    Update(update::UpdateArgs),
 }
 
 impl Command {
@@ -67,6 +72,8 @@ impl Command {
             Command::Iris(args) => args.run(),
             #[cfg(feature = "nebula")]
             Command::Nebula(args) => args.run(),
+            #[cfg(feature = "updated")]
+            Command::Update(args) => args.run(),
         }
     }
 }

--- a/src/ogygia/src/update/mod.rs
+++ b/src/ogygia/src/update/mod.rs
@@ -1,0 +1,22 @@
+//! Manual trigger for the pull-based system updater.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+/// Ask the ogygia-updated daemon to run an update cycle now.
+#[derive(Args)]
+pub struct UpdateArgs {
+    /// Control socket of the ogygia-updated daemon
+    #[arg(long, default_value = ogygia_updated::control::DEFAULT_SOCKET_PATH)]
+    socket: PathBuf,
+}
+
+impl UpdateArgs {
+    pub fn run(&self) -> Result<()> {
+        let message = ogygia_updated::control::request_update(&self.socket)?;
+        println!("{message}");
+        Ok(())
+    }
+}


### PR DESCRIPTION
An important part of any island is deciding how it updates.
ogygia.versions provides the NixOS options we need to embed commit
information within the closure, but we don't currently make use of this
information except to render the dashboard and update the deployment
history branch. Start building the infrastructure for ogygia to take
opinionated control of updates. We start minimal, but make design
decisions to allow for a fully featured update solution to be built in
the future.

Adds an ogygia-updated crate whose daemon owns all update state: it
periodically fetches a private clone of the repository, refuses to touch
hosts whose running build revision (embedded by ogygia.versions) is not
on the tracked branch, builds the host's toplevel from the clone, and
activates it directly with nix-env --set and switch-to-configuration,
including test-only activation over hand-staged boot profiles and a
delayed reboot on kernel changes. The daemon must not be expected to
restart as part of a switch as it owns the switch process, so we
have the daemon restart itself if the machine's live state changed.

Add an `ogygia update` subcommand that pokes this daemon and requests it
run an update immediately. There are no arguments to this for now, but
the wire format is extensible. It uses a root owned socket so requires
equivalent root permissions as the `nixos-rebuild` call it replaces.

Test plan:
- New unit tests cover config parsing and defaults, repository cloning,
  ancestry and checkout behaviour, the control socket protocol, and
  every activation decision through a mocked system interface.
- New VM test (checks.x86_64-linux.ogygia-updated-update) exercises the
  module, daemon, and `ogygia update` end to end: no-op when up to date,
  building and switching to a new commit followed by the daemon
  restarting itself, leaving off-branch hosts alone, refusing non-root
  triggers, and a daemon-scheduled cycle.
- CI