### PR TITLE
ogygia-updated: prefetch a cache-warm closure before building

### DIFF
--- a/nixos/updated/default.nix
+++ b/nixos/updated/default.nix
@@ -38,6 +38,13 @@ in
         - `host.name` (string) — attribute name of this host's
           nixosConfiguration in the flake. Defaults to the FQDN.
 
+        - `build.prefetch_attr` (string) — a cache-resident edition of
+          this host's closure (typically with the expensive
+          commit-specific parts removed) substituted with `--max-jobs 0`
+          before the real build. If it cannot be substituted the cycle is
+          skipped rather than built locally, so cache-dependent hosts
+          never fall back to a full build.
+
         - `activate.allow_reboot` (bool) — reboot automatically when an
           update changes the kernel. Default: false.
 

--- a/src/ogygia-updated/src/config.rs
+++ b/src/ogygia-updated/src/config.rs
@@ -48,6 +48,13 @@ pub struct HostConfig {
 pub struct BuildConfig {
     /// Flake attribute to build. Defaults to the host's toplevel.
     pub flake_attr: Option<String>,
+    /// A cache-resident edition of this host's closure, typically with the
+    /// expensive commit-specific parts removed, that the real build largely
+    /// shares. Substituted with `--max-jobs 0` before the build to warm the
+    /// store; if it cannot be substituted the cycle is skipped rather than
+    /// built locally, so cache-dependent hosts never fall back to a full
+    /// build.
+    pub prefetch_attr: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use anyhow::Result;
 use git2::Oid;
 use tracing::info;
+use tracing::warn;
 
 use crate::config::Config;
 use crate::repo::Repo;
@@ -29,6 +30,9 @@ pub enum Outcome {
     /// The new system needs a new kernel; it is the boot default and a
     /// reboot has been scheduled.
     RebootScheduled { commit: String },
+    /// The cache-warm closure could not be substituted, so the cycle was
+    /// skipped rather than built locally. Retried on the next cycle.
+    PrefetchUnavailable { commit: String },
 }
 
 impl fmt::Display for Outcome {
@@ -47,6 +51,12 @@ impl fmt::Display for Outcome {
             }
             Outcome::RebootScheduled { commit } => {
                 write!(f, "staged {commit} for boot and scheduled a reboot")
+            }
+            Outcome::PrefetchUnavailable { commit } => {
+                write!(
+                    f,
+                    "cache-warm closure for {commit} is unavailable; skipping until the cache catches up"
+                )
             }
         }
     }
@@ -93,6 +103,19 @@ fn run(config: &Config, system: &impl System, trigger: Trigger) -> Result<Outcom
     repo.checkout(tip)?;
 
     let flake = format!("git+file://{}", config.repo.path.display());
+    // The prefetch substitutes a cache-resident edition of the closure so
+    // the real build only makes the commit-specific remainder. If it
+    // cannot be substituted the cache is not yet ready, and a host that
+    // relies on it must not fall back to a full local build; skip the
+    // cycle and retry once the cache catches up.
+    if let Some(prefetch_attr) = &config.build.prefetch_attr
+        && let Err(error) = system.prefetch(&format!("{flake}#{prefetch_attr}"))
+    {
+        warn!(%error, "cache-warm closure unavailable; skipping the update");
+        return Ok(Outcome::PrefetchUnavailable {
+            commit: tip.to_string(),
+        });
+    }
     let store_path = system.build(&format!("{flake}#{}", config.flake_attr()))?;
     info!(store_path = %store_path.display(), "built new system");
 
@@ -168,6 +191,7 @@ mod tests {
 
     #[derive(Debug, PartialEq, Eq)]
     enum Call {
+        Prefetch(String),
         Build(String),
         SetProfile(PathBuf),
         SwitchToConfiguration(Activation),
@@ -179,9 +203,20 @@ mod tests {
         calls: RefCell<Vec<Call>>,
         booted_kernel: Option<&'static str>,
         built_kernel: Option<&'static str>,
+        fail_prefetch: bool,
     }
 
     impl System for MockSystem {
+        fn prefetch(&self, flake_ref: &str) -> Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(Call::Prefetch(flake_ref.to_string()));
+            if self.fail_prefetch {
+                anyhow::bail!("prefetch unavailable");
+            }
+            Ok(())
+        }
+
         fn build(&self, flake_ref: &str) -> Result<PathBuf> {
             self.calls
                 .borrow_mut()
@@ -439,6 +474,67 @@ mod tests {
                 Call::SetProfile(fixture.config.activate.profile.clone()),
                 Call::SwitchToConfiguration(Activation::Switch),
             ]
+        );
+    }
+
+    #[test]
+    fn prefetch_precedes_the_build() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let mut config = fixture.config;
+        config.build.prefetch_attr = Some("checks.x86_64-linux.prefetch".to_string());
+
+        let system = MockSystem::default();
+        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        let flake = format!("git+file://{}", config.repo.path.display());
+        assert_eq!(
+            system.calls.borrow()[..2],
+            [
+                Call::Prefetch(format!("{flake}#checks.x86_64-linux.prefetch")),
+                Call::Build(format!(
+                    "{flake}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel"
+                )),
+            ]
+        );
+    }
+
+    #[test]
+    fn failed_prefetch_skips_the_build() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let mut config = fixture.config;
+        config.build.prefetch_attr = Some("checks.x86_64-linux.prefetch".to_string());
+
+        let system = MockSystem {
+            fail_prefetch: true,
+            ..MockSystem::default()
+        };
+        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::PrefetchUnavailable {
+                commit: second.to_string()
+            }
+        );
+        // A cache-dependent host never falls back to a local build.
+        assert_eq!(
+            *system.calls.borrow(),
+            [Call::Prefetch(format!(
+                "git+file://{}#checks.x86_64-linux.prefetch",
+                config.repo.path.display()
+            ))]
         );
     }
 

--- a/src/ogygia-updated/src/system.rs
+++ b/src/ogygia-updated/src/system.rs
@@ -32,6 +32,8 @@ impl Activation {
 
 /// Side effects of an update cycle, abstracted for testing.
 pub trait System {
+    /// Substitute `flake_ref` from binary caches without building locally.
+    fn prefetch(&self, flake_ref: &str) -> Result<()>;
     /// Build `flake_ref` and return its store path.
     fn build(&self, flake_ref: &str) -> Result<PathBuf>;
     /// Point `profile` at `store_path` as a new generation.
@@ -50,6 +52,16 @@ pub struct RealSystem;
 const EXPERIMENTAL_FEATURES: [&str; 2] = ["--extra-experimental-features", "nix-command flakes"];
 
 impl System for RealSystem {
+    fn prefetch(&self, flake_ref: &str) -> Result<()> {
+        run(Command::new("nix")
+            .arg("build")
+            .args(EXPERIMENTAL_FEATURES)
+            .args(["--max-jobs", "0"])
+            .args(["--option", "always-allow-substitutes", "true"])
+            .arg("--no-link")
+            .arg(flake_ref))
+    }
+
     fn build(&self, flake_ref: &str) -> Result<PathBuf> {
         let mut command = Command::new("nix");
         command


### PR DESCRIPTION
Each update builds the host's new toplevel locally, but small hosts are
served a pre-built edition of the closure by a binary cache (typically
with the expensive commit-specific parts removed) while the full
toplevel is not cached; a cold build asks these hosts to build exactly
what they were provisioned not to.

Adds an optional build.prefetch_attr that, when set, is substituted with
`nix build --max-jobs 0` before the real build to warm the store from
the cache. A failed prefetch means the cache is not yet ready, so the
cycle is skipped (Outcome::PrefetchUnavailable) and retried next interval
rather than falling back to a full local build.

Because the option is opt-in, setting it declares the host cache-dependent;
skipping honours that by never degrading to a build the host cannot
complete, and the daemon self-heals once CI populates the cache.

Test plan:
- New unit tests: prefetch_precedes_the_build asserts the prefetch runs
  before the build; failed_prefetch_skips_the_build asserts a failed
  prefetch skips the build entirely.
- cargo test -p ogygia-updated (17 passed) and cargo clippy, both clean.
- CI