### PR TITLE
updated: add canary command to trial a branch with a timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1894,7 @@ dependencies = [
  "etcd-client",
  "futures",
  "hostname",
+ "humantime",
  "ogygia-nixutils",
  "ogygia-updated",
  "reqwest",
@@ -2007,6 +2014,7 @@ name = "ogygia-updated"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "git2",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "ogygia-workspace"
 # CLI and config
 clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = "1.0"
+humantime = "2"
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
 etcd-client = "0.19"

--- a/src/ogygia-updated/Cargo.toml
+++ b/src/ogygia-updated/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 git2 = { workspace = true }
 rand = { workspace = true }

--- a/src/ogygia-updated/src/canary.rs
+++ b/src/ogygia-updated/src/canary.rs
@@ -1,0 +1,233 @@
+//! Persisted state for a canary: a trial that holds the host on a
+//! chosen build instead of the tracked branch tip.
+//!
+//! The daemon exits and is restarted by systemd after every activation,
+//! so this outlives the process and is the sole record of an in-flight
+//! trial. The file is absent until the first canary runs; afterwards it
+//! always describes the current or most-recent one, so `canary status`
+//! can explain how the last trial ended.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Which build a canary holds the host on. One variant today; a
+/// branch-following mode slots in later without touching the lifecycle
+/// or the engine's floor, expiry, and finish handling, which are all
+/// target-agnostic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum CanaryTarget {
+    /// A commit resolved when the canary was issued. `branch` is kept for
+    /// provenance and display only — the host does not track it.
+    Pinned { branch: String, commit: String },
+    // Following { branch: String },  // future: re-resolve the tip each cycle
+}
+
+/// Lifecycle of the current or most-recent canary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum CanaryState {
+    /// A trial in progress.
+    Active {
+        target: CanaryTarget,
+        /// Absolute deadline; `None` for a canary with no timeout.
+        expires_at: Option<DateTime<Utc>>,
+        /// Kernel boot id when the trial began. A change means the host
+        /// rebooted, losing the trial's ephemeral test activation.
+        boot_id: String,
+    },
+    /// A trial that ended, retained so `canary status` can explain how.
+    Finished {
+        target: CanaryTarget,
+        at: DateTime<Utc>,
+        reason: FinishReason,
+    },
+}
+
+/// Why a canary stopped holding the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    /// The pinned commit became an ancestor of the tracked tip.
+    Merged,
+    /// The deadline passed.
+    Expired,
+    /// A bare `ogygia update` superseded it.
+    Cleared,
+    /// The host rebooted, losing the trial's ephemeral test activation.
+    Rebooted,
+    /// The running system was replaced out of band — a manual switch, with
+    /// no reboot.
+    Overwritten,
+}
+
+impl FinishReason {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            FinishReason::Merged => "merged",
+            FinishReason::Expired => "expired",
+            FinishReason::Cleared => "cleared",
+            FinishReason::Rebooted => "rebooted",
+            FinishReason::Overwritten => "overwritten",
+        }
+    }
+}
+
+impl CanaryState {
+    /// Load the record, or `None` if no canary has ever run.
+    pub fn load(path: &Path) -> Result<Option<Self>> {
+        let raw = match fs::read_to_string(path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("reading canary state {}", path.display()));
+            }
+        };
+        let state = serde_json::from_str(&raw)
+            .with_context(|| format!("parsing canary state {}", path.display()))?;
+        Ok(Some(state))
+    }
+
+    /// A human-readable status line. `running` and `boot_floor` are the
+    /// commits the host currently runs and will next boot; they are only
+    /// rendered for an in-progress trial.
+    pub fn describe(&self, now: DateTime<Utc>, running: &str, boot_floor: &str) -> String {
+        match self {
+            CanaryState::Active {
+                target: CanaryTarget::Pinned { branch, commit },
+                expires_at,
+                ..
+            } => {
+                let expiry = match expires_at {
+                    Some(at) => format!(
+                        "expires {} (in {}h)",
+                        at.format("%Y-%m-%d %H:%MZ"),
+                        (*at - now).num_hours()
+                    ),
+                    None => "no timeout".to_string(),
+                };
+                format!(
+                    "trialling {branch} @{commit}; running {running}, boot floor {boot_floor}; {expiry}"
+                )
+            }
+            CanaryState::Finished {
+                target: CanaryTarget::Pinned { branch, commit },
+                at,
+                reason,
+            } => format!(
+                "no active canary; last: {branch} @{commit} finished {} ({})",
+                at.format("%Y-%m-%d %H:%MZ"),
+                reason.label(),
+            ),
+        }
+    }
+
+    /// Persist the record, replacing any previous one atomically.
+    pub fn store(&self, path: &Path) -> Result<()> {
+        let payload = serde_json::to_vec_pretty(self).context("encoding canary state")?;
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, &payload)
+            .with_context(|| format!("writing canary state {}", tmp.display()))?;
+        fs::rename(&tmp, path)
+            .with_context(|| format!("replacing canary state {}", path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_is_no_canary() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("canary.json");
+        assert!(CanaryState::load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn active_and_finished_round_trip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("canary.json");
+        let target = CanaryTarget::Pinned {
+            branch: "feature".to_string(),
+            commit: "a".repeat(40),
+        };
+
+        let active = CanaryState::Active {
+            target: target.clone(),
+            expires_at: Some("2026-07-18T12:00:00Z".parse().unwrap()),
+            boot_id: "boot-1".to_string(),
+        };
+        active.store(&path).unwrap();
+        assert!(matches!(
+            CanaryState::load(&path).unwrap(),
+            Some(CanaryState::Active {
+                expires_at: Some(_),
+                ..
+            })
+        ));
+
+        // Storing again replaces the record rather than appending.
+        let finished = CanaryState::Finished {
+            target,
+            at: "2026-07-18T12:00:00Z".parse().unwrap(),
+            reason: FinishReason::Merged,
+        };
+        finished.store(&path).unwrap();
+        assert!(matches!(
+            CanaryState::load(&path).unwrap(),
+            Some(CanaryState::Finished {
+                reason: FinishReason::Merged,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn describe_covers_active_and_finished() {
+        let now: DateTime<Utc> = "2026-07-17T00:00:00Z".parse().unwrap();
+        let target = CanaryTarget::Pinned {
+            branch: "feature".to_string(),
+            commit: "abc".to_string(),
+        };
+
+        let active = CanaryState::Active {
+            target: target.clone(),
+            expires_at: Some("2026-07-18T00:00:00Z".parse().unwrap()),
+            boot_id: "boot-1".to_string(),
+        };
+        assert_eq!(
+            active.describe(now, "def", "ghi"),
+            "trialling feature @abc; running def, boot floor ghi; expires 2026-07-18 00:00Z (in 24h)"
+        );
+
+        let forever = CanaryState::Active {
+            target: target.clone(),
+            expires_at: None,
+            boot_id: "boot-1".to_string(),
+        };
+        assert_eq!(
+            forever.describe(now, "def", "ghi"),
+            "trialling feature @abc; running def, boot floor ghi; no timeout"
+        );
+
+        let finished = CanaryState::Finished {
+            target,
+            at: now,
+            reason: FinishReason::Merged,
+        };
+        assert_eq!(
+            finished.describe(now, "def", "ghi"),
+            "no active canary; last: feature @abc finished 2026-07-17 00:00Z (merged)"
+        );
+    }
+}

--- a/src/ogygia-updated/src/config.rs
+++ b/src/ogygia-updated/src/config.rs
@@ -10,6 +10,9 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Directory the daemon owns; holds its clone and canary state.
+    #[serde(default = "default_state_dir")]
+    pub state_dir: PathBuf,
     pub repo: RepoConfig,
     pub host: HostConfig,
     #[serde(default)]
@@ -25,9 +28,6 @@ pub struct Config {
 pub struct RepoConfig {
     /// Git remote to track.
     pub url: String,
-    /// Where the daemon keeps its private clone.
-    #[serde(default = "default_repo_path")]
-    pub path: PathBuf,
     /// Branch whose tip the host follows.
     #[serde(default = "default_branch")]
     pub branch: String,
@@ -113,6 +113,16 @@ impl Config {
     pub fn next_boot_revision_path(&self) -> PathBuf {
         self.activate.profile.join("sw/share/ogygia/build-revision")
     }
+
+    /// The daemon's private clone of the configuration repository.
+    pub fn repo_path(&self) -> PathBuf {
+        self.state_dir.join("repo")
+    }
+
+    /// File recording the current or most-recent canary.
+    pub fn canary_state_path(&self) -> PathBuf {
+        self.state_dir.join("canary.json")
+    }
 }
 
 impl Default for ActivateConfig {
@@ -137,8 +147,8 @@ impl Default for DaemonConfig {
     }
 }
 
-fn default_repo_path() -> PathBuf {
-    PathBuf::from("/var/lib/ogygia-updated/repo")
+fn default_state_dir() -> PathBuf {
+    PathBuf::from("/var/lib/ogygia-updated")
 }
 
 fn default_branch() -> String {
@@ -196,8 +206,12 @@ mod tests {
 
         assert_eq!(config.repo.branch, "main");
         assert_eq!(
-            config.repo.path,
+            config.repo_path(),
             PathBuf::from("/var/lib/ogygia-updated/repo")
+        );
+        assert_eq!(
+            config.canary_state_path(),
+            PathBuf::from("/var/lib/ogygia-updated/canary.json")
         );
         assert_eq!(
             config.flake_attr(),

--- a/src/ogygia-updated/src/control.rs
+++ b/src/ogygia-updated/src/control.rs
@@ -29,11 +29,21 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A command for the daemon, sent over the control socket. Each variant
 /// carries only the data its operation needs.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum Request {
-    /// Reset the target to the configured branch tip and run a cycle now.
+    /// Reset the target to the configured branch tip and run a cycle now,
+    /// clearing any active canary.
     Update,
+    /// Trial `branch`: pin its tip and hold the host there until `timeout`
+    /// seconds pass (no timeout if `None`), the commit merges, or an
+    /// update supersedes it.
+    Canary {
+        branch: String,
+        timeout: Option<u64>,
+    },
+    /// Report the current or most-recent canary without running a cycle.
+    CanaryStatus,
 }
 
 /// The daemon's answer to a trigger: the result message of the cycle it
@@ -41,10 +51,26 @@ pub enum Request {
 /// `Result`, e.g. `{"Ok":"switched to abc"}` or `{"Err":"..."}`.
 pub type Response = Result<String, String>;
 
-/// Trigger an update cycle in the daemon listening on `socket_path` and
-/// wait for it to finish, returning its result message. Errors if the
-/// daemon cannot be reached or reports a failed cycle.
+/// Reset the host to the tracked branch tip now, clearing any canary.
 pub fn request_update(socket_path: &Path) -> Result<String> {
+    send(socket_path, &Request::Update)
+}
+
+/// Start a canary trialling `branch`, held for `timeout` seconds (no
+/// timeout if `None`).
+pub fn request_canary(socket_path: &Path, branch: String, timeout: Option<u64>) -> Result<String> {
+    send(socket_path, &Request::Canary { branch, timeout })
+}
+
+/// Ask the daemon to describe the current or most-recent canary.
+pub fn request_canary_status(socket_path: &Path) -> Result<String> {
+    send(socket_path, &Request::CanaryStatus)
+}
+
+/// Send `request` to the daemon listening on `socket_path` and return its
+/// result message. Errors if the daemon cannot be reached or reports a
+/// failure.
+fn send(socket_path: &Path, request: &Request) -> Result<String> {
     let mut stream = UnixStream::connect(socket_path).with_context(|| {
         format!(
             "connecting to {}; is ogygia-updated running, and are you root?",
@@ -52,13 +78,11 @@ pub fn request_update(socket_path: &Path) -> Result<String> {
         )
     })?;
 
-    let mut request = serde_json::to_vec(&Request::Update)?;
-    request.push(b'\n');
-    stream
-        .write_all(&request)
-        .context("sending update request")?;
+    let mut payload = serde_json::to_vec(request)?;
+    payload.push(b'\n');
+    stream.write_all(&payload).context("sending request")?;
 
-    // No read timeout: the cycle legitimately takes as long as a build.
+    // No read timeout: a cycle legitimately takes as long as a build.
     let mut line = String::new();
     BufReader::new(&stream)
         .read_line(&mut line)
@@ -83,10 +107,10 @@ pub fn bind(socket_path: &Path) -> Result<UnixListener> {
     Ok(listener)
 }
 
-/// Accept trigger connections and hand them to the update loop, which
-/// answers each with the result of the cycle it ran. Invalid requests
-/// are answered immediately without triggering a cycle.
-pub fn listen(listener: UnixListener, triggers: mpsc::Sender<UnixStream>) {
+/// Accept connections, parse each request, and hand it with its stream to
+/// the daemon loop, which answers once it has served the command. Invalid
+/// requests are answered immediately without reaching the loop.
+pub fn listen(listener: UnixListener, requests: mpsc::Sender<(Request, UnixStream)>) {
     for stream in listener.incoming() {
         let Ok(mut stream) = stream else { continue };
         let _ = stream.set_read_timeout(Some(REQUEST_TIMEOUT));
@@ -95,12 +119,12 @@ pub fn listen(listener: UnixListener, triggers: mpsc::Sender<UnixStream>) {
         if BufReader::new(&stream).read_line(&mut line).is_err() {
             continue;
         }
-        if serde_json::from_str::<Request>(&line).is_err() {
+        let Ok(request) = serde_json::from_str::<Request>(&line) else {
             respond(&mut stream, Err("invalid request".to_string()));
             continue;
-        }
+        };
 
-        if triggers.send(stream).is_err() {
+        if requests.send((request, stream)).is_err() {
             return;
         }
     }
@@ -129,7 +153,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn request_update_round_trips() {
+    fn requests_round_trip_with_their_parsed_command() {
         let dir = tempfile::TempDir::new().unwrap();
         let socket_path = dir.path().join("control.sock");
         let listener = bind(&socket_path).unwrap();
@@ -137,15 +161,29 @@ mod tests {
         let (sender, receiver) = mpsc::channel();
         thread::spawn(move || listen(listener, sender));
         let server = thread::spawn(move || {
-            let mut stream = receiver.recv().unwrap();
+            let (request, mut stream) = receiver.recv().unwrap();
+            assert_eq!(request, Request::Update);
             respond(&mut stream, Ok("switched to abc".to_string()));
-            let mut stream = receiver.recv().unwrap();
-            respond(&mut stream, Err("update failed".to_string()));
+
+            let (request, mut stream) = receiver.recv().unwrap();
+            assert_eq!(
+                request,
+                Request::Canary {
+                    branch: "feature".to_string(),
+                    timeout: Some(3600),
+                }
+            );
+            respond(&mut stream, Err("no such branch".to_string()));
+
+            let (request, mut stream) = receiver.recv().unwrap();
+            assert_eq!(request, Request::CanaryStatus);
+            respond(&mut stream, Ok("no canary".to_string()));
         });
 
         assert_eq!(request_update(&socket_path).unwrap(), "switched to abc");
-        let error = request_update(&socket_path).unwrap_err();
-        assert_eq!(error.to_string(), "update failed");
+        let error = request_canary(&socket_path, "feature".to_string(), Some(3600)).unwrap_err();
+        assert_eq!(error.to_string(), "no such branch");
+        assert_eq!(request_canary_status(&socket_path).unwrap(), "no canary");
         server.join().unwrap();
     }
 

--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -1,13 +1,20 @@
 use std::fmt;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
+use chrono::DateTime;
+use chrono::Utc;
 use git2::Oid;
 use tracing::info;
 use tracing::warn;
 
+use crate::canary::CanaryState;
+use crate::canary::CanaryTarget;
+use crate::canary::FinishReason;
 use crate::config::Config;
 use crate::repo::Repo;
 use crate::system::Activation;
@@ -33,6 +40,16 @@ pub enum Outcome {
     /// The cache-warm closure could not be substituted, so the cycle was
     /// skipped rather than built locally. Retried on the next cycle.
     PrefetchUnavailable { commit: String },
+    /// A canary was started: the commit runs while a safe boot floor is
+    /// staged for the next reboot.
+    CanaryStarted {
+        commit: String,
+        floor: String,
+        expires_at: Option<DateTime<Utc>>,
+    },
+    /// A scheduled cycle held the running trial in place, keeping the boot
+    /// floor current without touching the running system.
+    CanaryHeld { commit: String, floor: String },
 }
 
 impl fmt::Display for Outcome {
@@ -58,39 +75,262 @@ impl fmt::Display for Outcome {
                     "cache-warm closure for {commit} is unavailable; skipping until the cache catches up"
                 )
             }
+            Outcome::CanaryStarted {
+                commit,
+                floor,
+                expires_at,
+            } => {
+                write!(f, "trialling {commit}; boot floor {floor}; ")?;
+                match expires_at {
+                    Some(at) => write!(f, "expires {}", at.format("%Y-%m-%d %H:%MZ")),
+                    None => write!(f, "no timeout"),
+                }
+            }
+            Outcome::CanaryHeld { commit, floor } => {
+                write!(f, "holding canary {commit}; boot floor {floor}")
+            }
         }
     }
 }
 
+impl Outcome {
+    /// Whether the running system was replaced, so the daemon must exit
+    /// for systemd to restart it under the new unit. A bare boot-default
+    /// change (reboot scheduled, canary floor staged) leaves the running
+    /// system untouched and does not qualify; only starting a canary
+    /// re-drives the running system among the canary outcomes.
+    pub fn activated(&self) -> bool {
+        matches!(
+            self,
+            Outcome::Switched { .. }
+                | Outcome::TestActivated { .. }
+                | Outcome::CanaryStarted { .. }
+        )
+    }
+}
+
 /// What initiated an update cycle.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Trigger {
     /// The daemon's own interval fired. A host deliberately running or
-    /// booting an off-branch build is left alone.
+    /// booting an off-branch build is left alone, and an active canary is
+    /// held, expired, or retired once its commit merges.
     Scheduled,
-    /// An operator asked for a cycle over the control socket. The host is
-    /// pulled back onto the branch tip regardless of what it is running,
-    /// so scheduled updates resume.
+    /// An operator asked for a plain update. Any canary is cleared and the
+    /// host is pulled back onto the branch tip regardless of what it runs.
     Manual,
+    /// An operator asked to trial `branch`. Its tip is pinned now and the
+    /// host is held there until the timeout elapses, the commit merges, or
+    /// a manual update supersedes it.
+    StartCanary {
+        branch: String,
+        timeout: Option<Duration>,
+    },
 }
 
 /// Run one update cycle.
 pub fn run_once(config: &Config, trigger: Trigger) -> Result<Outcome> {
-    run(config, &RealSystem, trigger)
+    run(config, &RealSystem, Utc::now(), &read_boot_id()?, trigger)
 }
 
-fn run(config: &Config, system: &impl System, trigger: Trigger) -> Result<Outcome> {
+fn run(
+    config: &Config,
+    system: &impl System,
+    now: DateTime<Utc>,
+    boot_id: &str,
+    trigger: Trigger,
+) -> Result<Outcome> {
+    let repo = Repo::open_or_clone(&config.repo_path(), &config.repo.url)?;
+    repo.fetch()?;
+    let main_tip = repo.tip(&config.repo.branch)?;
+    let canary = CanaryState::load(&config.canary_state_path())?;
+    info!(%main_tip, branch = %config.repo.branch, ?trigger, "fetched");
+
+    match trigger {
+        Trigger::StartCanary { branch, timeout } => {
+            let expires_at = timeout.map(|d| now + chrono::Duration::seconds(d.as_secs() as i64));
+            start_canary(
+                config, system, &repo, boot_id, main_tip, &branch, expires_at,
+            )
+        }
+        Trigger::Manual => {
+            if let Some(CanaryState::Active { target, .. }) = &canary {
+                finish_canary(config, now, target, FinishReason::Cleared)?;
+                info!("cleared active canary for a manual update");
+            }
+            update_to_tip(config, system, &repo, main_tip, true)
+        }
+        Trigger::Scheduled => scheduled(config, system, &repo, now, boot_id, main_tip, canary),
+    }
+}
+
+/// The kernel's boot id, which changes on every boot.
+fn read_boot_id() -> Result<String> {
+    let path = "/proc/sys/kernel/random/boot_id";
+    Ok(fs::read_to_string(path)
+        .with_context(|| format!("reading {path}"))?
+        .trim()
+        .to_string())
+}
+
+/// A scheduled cycle: follow the tracked branch, or end an active canary
+/// on the first terminal condition in precedence order — reboot, then
+/// out-of-band switch, then merge, then timeout — so a host that left the
+/// trial records why, even if the commit also merged or the deadline
+/// lapsed while it was gone. Every ending resumes normal tracking.
+fn scheduled(
+    config: &Config,
+    system: &impl System,
+    repo: &Repo,
+    now: DateTime<Utc>,
+    boot_id: &str,
+    main_tip: Oid,
+    canary: Option<CanaryState>,
+) -> Result<Outcome> {
+    let Some(CanaryState::Active {
+        target,
+        expires_at,
+        boot_id: started_boot,
+    }) = canary
+    else {
+        return update_to_tip(config, system, repo, main_tip, false);
+    };
+
+    let commit = target_commit(&target)?;
+
+    // A reboot loses the ephemeral test activation, so the trial is over.
+    // This outranks merge and expiry, which may both have come true while
+    // the host was down. The trial is never reapplied; we record the reason
+    // and resume normal tracking this cycle, rolling forward from the floor.
+    if boot_id != started_boot {
+        finish_canary(config, now, &target, FinishReason::Rebooted)?;
+        info!("canary host rebooted; ending the trial and resuming the tracked branch");
+        return update_to_tip(config, system, repo, main_tip, false);
+    }
+
+    // No reboot, but the host is no longer running the trial: it was
+    // switched out of band by hand. Resume tracking, which leaves a
+    // deliberately off-branch system alone.
+    let current = read_revision(&config.host.current_revision_path)?;
+    if current != commit {
+        finish_canary(config, now, &target, FinishReason::Overwritten)?;
+        info!("canary overwritten out of band; ending the trial and resuming the tracked branch");
+        return update_to_tip(config, system, repo, main_tip, false);
+    }
+
+    // Still trialling. Once the commit lands on the tracked branch the
+    // canary has served its purpose; resume following the tip.
+    if repo.is_ancestor(commit, main_tip)? {
+        finish_canary(config, now, &target, FinishReason::Merged)?;
+        info!("canary merged; resuming the tracked branch");
+        return update_to_tip(config, system, repo, main_tip, false);
+    }
+
+    if expires_at.is_some_and(|deadline| now >= deadline) {
+        finish_canary(config, now, &target, FinishReason::Expired)?;
+        info!("canary timed out; reverting to the tracked branch");
+        return update_to_tip(config, system, repo, main_tip, true);
+    }
+
+    // Hold the trial open: keep the boot floor recent, but never re-drive
+    // the running system.
+    let floor = stage_boot_floor(config, system, repo, commit, main_tip)?;
+    Ok(Outcome::CanaryHeld {
+        commit: commit.to_string(),
+        floor: floor.to_string(),
+    })
+}
+
+/// Pin `branch`'s tip and hold the host on it.
+fn start_canary(
+    config: &Config,
+    system: &impl System,
+    repo: &Repo,
+    boot_id: &str,
+    main_tip: Oid,
+    branch: &str,
+    expires_at: Option<DateTime<Utc>>,
+) -> Result<Outcome> {
+    let commit = repo.tip(branch)?;
+    CanaryState::Active {
+        target: CanaryTarget::Pinned {
+            branch: branch.to_string(),
+            commit: commit.to_string(),
+        },
+        expires_at,
+        boot_id: boot_id.to_string(),
+    }
+    .store(&config.canary_state_path())?;
+
+    let floor = stage_boot_floor(config, system, repo, commit, main_tip)?;
+
+    // Apply the trial once, as an ephemeral test activation. Scheduled
+    // cycles never reapply it, so a reboot ends it for good.
+    let current = read_revision(&config.host.current_revision_path)?;
+    if current != commit {
+        let store_path = checkout_and_build(config, system, repo, commit)?;
+        system.switch_to_configuration(&store_path, Activation::Test)?;
+    }
+
+    Ok(Outcome::CanaryStarted {
+        commit: commit.to_string(),
+        floor: floor.to_string(),
+        expires_at,
+    })
+}
+
+/// Stage `merge-base(commit, main_tip)` as the boot default so a reboot
+/// lands on a recent tracked commit rather than the trial. Boot only: it
+/// never touches the running system and never schedules a reboot. Returns
+/// the floor.
+fn stage_boot_floor(
+    config: &Config,
+    system: &impl System,
+    repo: &Repo,
+    commit: Oid,
+    main_tip: Oid,
+) -> Result<Oid> {
+    let floor = repo.merge_base(commit, main_tip)?;
+    let next_boot = read_revision(&config.next_boot_revision_path())?;
+
+    if next_boot != floor {
+        let floor_path = checkout_and_build(config, system, repo, floor)?;
+        system.set_profile(&config.activate.profile, &floor_path)?;
+        system.switch_to_configuration(&floor_path, Activation::Boot)?;
+    }
+
+    Ok(floor)
+}
+
+/// Record a canary as finished so `canary status` can explain how it ended.
+fn finish_canary(
+    config: &Config,
+    now: DateTime<Utc>,
+    target: &CanaryTarget,
+    reason: FinishReason,
+) -> Result<()> {
+    CanaryState::Finished {
+        target: target.clone(),
+        at: now,
+        reason,
+    }
+    .store(&config.canary_state_path())
+}
+
+/// Update the host to `tip`. `force` overrides the scheduler's guards
+/// that otherwise leave a deliberately off-branch running or next-boot
+/// system alone.
+fn update_to_tip(
+    config: &Config,
+    system: &impl System,
+    repo: &Repo,
+    tip: Oid,
+    force: bool,
+) -> Result<Outcome> {
     let current = read_revision(&config.host.current_revision_path)?;
     let next_boot = read_revision(&config.next_boot_revision_path())?;
 
-    let repo = Repo::open_or_clone(&config.repo)?;
-    repo.fetch()?;
-    let tip = repo.tip(&config.repo.branch)?;
-    info!(%current, %next_boot, %tip, branch = %config.repo.branch, ?trigger, "fetched");
-
-    // The scheduler leaves a deliberately off-branch host alone; a manual
-    // trigger overrides that to pull it back onto the branch.
-    if trigger == Trigger::Scheduled && !repo.is_ancestor(current, tip)? {
+    if !force && !repo.is_ancestor(current, tip)? {
         return Ok(Outcome::NotOnBranch {
             revision: current.to_string(),
         });
@@ -102,7 +342,7 @@ fn run(config: &Config, system: &impl System, trigger: Trigger) -> Result<Outcom
 
     repo.checkout(tip)?;
 
-    let flake = format!("git+file://{}", config.repo.path.display());
+    let flake = format!("git+file://{}", config.repo_path().display());
     // The prefetch substitutes a cache-resident edition of the closure so
     // the real build only makes the commit-specific remainder. If it
     // cannot be substituted the cache is not yet ready, and a host that
@@ -121,11 +361,31 @@ fn run(config: &Config, system: &impl System, trigger: Trigger) -> Result<Outcom
 
     // A hand-staged off-branch next-boot system is preserved by the
     // scheduler, but a manual trigger resets the boot default to the tip.
-    let next_boot_on_branch = match trigger {
-        Trigger::Manual => true,
-        Trigger::Scheduled => repo.is_ancestor(next_boot, tip)?,
-    };
+    let next_boot_on_branch = force || repo.is_ancestor(next_boot, tip)?;
     activate(config, system, &store_path, tip, next_boot_on_branch)
+}
+
+/// Check out `commit`, leaving a clean tree, and build this host's system.
+fn checkout_and_build(
+    config: &Config,
+    system: &impl System,
+    repo: &Repo,
+    commit: Oid,
+) -> Result<PathBuf> {
+    repo.checkout(commit)?;
+    let flake = format!("git+file://{}", config.repo_path().display());
+    let store_path = system.build(&format!("{flake}#{}", config.flake_attr()))?;
+    info!(store_path = %store_path.display(), %commit, "built system");
+    Ok(store_path)
+}
+
+/// Parse the run commit from a canary target.
+fn target_commit(target: &CanaryTarget) -> Result<Oid> {
+    match target {
+        CanaryTarget::Pinned { commit, .. } => {
+            Oid::from_str(commit).with_context(|| format!("parsing pinned canary commit {commit}"))
+        }
+    }
 }
 
 fn activate(
@@ -181,6 +441,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::canary::FinishReason;
     use crate::config::ActivateConfig;
     use crate::config::BuildConfig;
     use crate::config::DaemonConfig;
@@ -188,6 +449,15 @@ mod tests {
     use crate::config::RepoConfig;
     use crate::repo::testutil::commit;
     use crate::repo::testutil::init_origin;
+
+    /// A fixed clock for deterministic expiry tests.
+    fn now() -> DateTime<Utc> {
+        "2026-07-17T00:00:00Z".parse().unwrap()
+    }
+
+    /// The boot id a canary is started in; a cycle passing a different one
+    /// looks like a reboot.
+    const BOOT: &str = "boot-session-a";
 
     #[derive(Debug, PartialEq, Eq)]
     enum Call {
@@ -272,9 +542,9 @@ mod tests {
             fs::create_dir_all(profile.join("sw/share/ogygia")).unwrap();
 
             let config = Config {
+                state_dir: dir.path().to_path_buf(),
                 repo: RepoConfig {
                     url: origin_path.to_str().unwrap().to_string(),
-                    path: dir.path().join("clone"),
                     branch: "main".to_string(),
                 },
                 host: HostConfig {
@@ -321,7 +591,7 @@ mod tests {
         fixture.set_next_boot(initial);
 
         let system = MockSystem::default();
-        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(outcome, Outcome::UpToDate);
         assert!(system.calls.borrow().is_empty());
@@ -335,7 +605,7 @@ mod tests {
         let second = commit(&fixture.origin, "main", &[initial], "second");
 
         let system = MockSystem::default();
-        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -345,7 +615,7 @@ mod tests {
         );
         let flake_ref = format!(
             "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
-            fixture.config.repo.path.display()
+            fixture.config.repo_path().display()
         );
         assert_eq!(
             *system.calls.borrow(),
@@ -358,7 +628,7 @@ mod tests {
 
         // The working tree was left checked out at the new commit.
         assert_eq!(
-            fs::read_to_string(fixture.config.repo.path.join("marker")).unwrap(),
+            fs::read_to_string(fixture.config.repo_path().join("marker")).unwrap(),
             "second"
         );
     }
@@ -372,7 +642,7 @@ mod tests {
         fixture.set_next_boot(initial);
 
         let system = MockSystem::default();
-        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -392,7 +662,7 @@ mod tests {
         fixture.set_next_boot(side);
 
         let system = MockSystem::default();
-        let outcome = run(&fixture.config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -406,7 +676,7 @@ mod tests {
             vec![
                 Call::Build(format!(
                     "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
-                    fixture.config.repo.path.display()
+                    fixture.config.repo_path().display()
                 )),
                 Call::SwitchToConfiguration(Activation::Test),
             ]
@@ -422,7 +692,7 @@ mod tests {
         fixture.set_next_boot(initial);
 
         let system = MockSystem::default();
-        let outcome = run(&fixture.config, &system, Trigger::Manual).unwrap();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Manual).unwrap();
 
         // The off-branch guard is overridden and the host is switched onto
         // the branch tip.
@@ -437,7 +707,7 @@ mod tests {
             vec![
                 Call::Build(format!(
                     "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
-                    fixture.config.repo.path.display()
+                    fixture.config.repo_path().display()
                 )),
                 Call::SetProfile(fixture.config.activate.profile.clone()),
                 Call::SwitchToConfiguration(Activation::Switch),
@@ -454,7 +724,7 @@ mod tests {
         fixture.set_next_boot(side);
 
         let system = MockSystem::default();
-        let outcome = run(&fixture.config, &system, Trigger::Manual).unwrap();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Manual).unwrap();
 
         // Rather than test-activating around the hand-staged boot entry,
         // the manual trigger resets the boot default to the tip.
@@ -469,7 +739,7 @@ mod tests {
             vec![
                 Call::Build(format!(
                     "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
-                    fixture.config.repo.path.display()
+                    fixture.config.repo_path().display()
                 )),
                 Call::SetProfile(fixture.config.activate.profile.clone()),
                 Call::SwitchToConfiguration(Activation::Switch),
@@ -487,7 +757,7 @@ mod tests {
         config.build.prefetch_attr = Some("checks.x86_64-linux.prefetch".to_string());
 
         let system = MockSystem::default();
-        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -495,7 +765,7 @@ mod tests {
                 commit: second.to_string()
             }
         );
-        let flake = format!("git+file://{}", config.repo.path.display());
+        let flake = format!("git+file://{}", config.repo_path().display());
         assert_eq!(
             system.calls.borrow()[..2],
             [
@@ -520,7 +790,7 @@ mod tests {
             fail_prefetch: true,
             ..MockSystem::default()
         };
-        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -533,7 +803,7 @@ mod tests {
             *system.calls.borrow(),
             [Call::Prefetch(format!(
                 "git+file://{}#checks.x86_64-linux.prefetch",
-                config.repo.path.display()
+                config.repo_path().display()
             ))]
         );
     }
@@ -553,7 +823,7 @@ mod tests {
             built_kernel: Some("kernel-1"),
             ..MockSystem::default()
         };
-        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -586,7 +856,7 @@ mod tests {
             built_kernel: Some("kernel-2"),
             ..MockSystem::default()
         };
-        let outcome = run(&config, &system, Trigger::Scheduled).unwrap();
+        let outcome = run(&config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
 
         assert_eq!(
             outcome,
@@ -602,5 +872,268 @@ mod tests {
                 Call::ScheduleReboot(15),
             ]
         );
+    }
+
+    fn flake_ref(config: &Config) -> String {
+        format!(
+            "git+file://{}#nixosConfigurations.\"host.example.com\".config.system.build.toplevel",
+            config.repo_path().display()
+        )
+    }
+
+    fn store_active(config: &Config, commit: Oid, expires_at: Option<DateTime<Utc>>) {
+        CanaryState::Active {
+            target: CanaryTarget::Pinned {
+                branch: "canary".to_string(),
+                commit: commit.to_string(),
+            },
+            expires_at,
+            boot_id: BOOT.to_string(),
+        }
+        .store(&config.canary_state_path())
+        .unwrap();
+    }
+
+    fn finish_reason(config: &Config) -> FinishReason {
+        match CanaryState::load(&config.canary_state_path())
+            .unwrap()
+            .unwrap()
+        {
+            CanaryState::Finished { reason, .. } => reason,
+            other => panic!("expected a finished canary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn start_canary_runs_commit_and_stages_boot_floor() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+
+        let system = MockSystem::default();
+        let outcome = run(
+            &fixture.config,
+            &system,
+            now(),
+            BOOT,
+            Trigger::StartCanary {
+                branch: "canary".to_string(),
+                timeout: Some(Duration::from_secs(86400)),
+            },
+        )
+        .unwrap();
+
+        // The trial runs the branch tip; the boot floor is the branch point
+        // with the tracked tip (here `second`).
+        assert_eq!(
+            outcome,
+            Outcome::CanaryStarted {
+                commit: side.to_string(),
+                floor: second.to_string(),
+                expires_at: Some(now() + chrono::Duration::seconds(86400)),
+            }
+        );
+        assert!(outcome.activated());
+
+        let flake = flake_ref(&fixture.config);
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(flake.clone()),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Boot),
+                Call::Build(flake),
+                Call::SwitchToConfiguration(Activation::Test),
+            ]
+        );
+
+        // The canary was pinned to the resolved commit, not the branch name.
+        let state = CanaryState::load(&fixture.config.canary_state_path())
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            state,
+            CanaryState::Active {
+                target: CanaryTarget::Pinned { commit, .. },
+                expires_at: Some(_),
+                boot_id,
+            } if commit == side.to_string() && boot_id == BOOT
+        ));
+    }
+
+    #[test]
+    fn scheduled_holds_an_active_canary_in_place() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        fixture.set_current(side);
+        fixture.set_next_boot(second);
+        store_active(&fixture.config, side, None);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::CanaryHeld {
+                commit: side.to_string(),
+                floor: second.to_string(),
+            }
+        );
+        assert!(!outcome.activated());
+        assert!(system.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn rebooted_canary_ends_and_resumes_tracking() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let third = commit(&fixture.origin, "main", &[second], "third");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        // Rebooted onto the boot floor (merge-base(side, third) = second);
+        // the timeout also lapsed while the host was down.
+        fixture.set_current(second);
+        fixture.set_next_boot(second);
+        store_active(
+            &fixture.config,
+            side,
+            Some(now() - chrono::Duration::hours(1)),
+        );
+
+        // A changed boot id ends the trial as Rebooted (outranking the
+        // lapsed timeout) and resumes tracking in the same cycle.
+        let system = MockSystem::default();
+        let outcome = run(
+            &fixture.config,
+            &system,
+            now(),
+            "boot-session-b",
+            Trigger::Scheduled,
+        )
+        .unwrap();
+
+        // Rolled forward to the tracked tip, not reapplied onto the trial.
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: third.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Rebooted);
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(flake_ref(&fixture.config)),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+    }
+
+    #[test]
+    fn overwritten_canary_ends_and_respects_off_branch_switch() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let hand = commit(&fixture.origin, "hand", &[second], "hand");
+        // Same boot session, but the host was hand-switched to an off-branch
+        // commit.
+        fixture.set_current(hand);
+        fixture.set_next_boot(second);
+        store_active(&fixture.config, side, None);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        // Ended as Overwritten; normal tracking leaves the deliberate
+        // off-branch switch alone.
+        assert_eq!(
+            outcome,
+            Outcome::NotOnBranch {
+                revision: hand.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Overwritten);
+        assert!(system.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn expired_canary_reverts_to_the_tracked_tip() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        fixture.set_current(side);
+        fixture.set_next_boot(second);
+        store_active(
+            &fixture.config,
+            side,
+            Some(now() - chrono::Duration::hours(1)),
+        );
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        // The off-branch running system is forced back onto the tip.
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Expired);
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(flake_ref(&fixture.config)),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+    }
+
+    #[test]
+    fn merged_canary_resumes_the_tracked_tip() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        // The branch merges back into main via a merge commit.
+        let merge = commit(&fixture.origin, "main", &[second, side], "merge");
+        fixture.set_current(side);
+        fixture.set_next_boot(second);
+        store_active(&fixture.config, side, None);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: merge.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Merged);
+    }
+
+    #[test]
+    fn manual_update_clears_an_active_canary() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        fixture.set_current(side);
+        fixture.set_next_boot(second);
+        store_active(&fixture.config, side, None);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Manual).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Cleared);
     }
 }

--- a/src/ogygia-updated/src/lib.rs
+++ b/src/ogygia-updated/src/lib.rs
@@ -13,11 +13,15 @@
 
 pub mod control;
 
+mod canary;
 mod config;
 mod engine;
 mod repo;
 mod system;
 
+pub use canary::CanaryState;
+pub use canary::CanaryTarget;
+pub use canary::FinishReason;
 pub use config::Config;
 pub use engine::Outcome;
 pub use engine::Trigger;

--- a/src/ogygia-updated/src/main.rs
+++ b/src/ogygia-updated/src/main.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::mpsc;
 use std::sync::mpsc::RecvTimeoutError;
@@ -6,11 +7,14 @@ use std::time::Duration;
 
 use anyhow::Result;
 use anyhow::bail;
+use chrono::Utc;
 use clap::Parser;
+use ogygia_updated::CanaryState;
 use ogygia_updated::Config;
 use ogygia_updated::Outcome;
 use ogygia_updated::Trigger;
 use ogygia_updated::control;
+use ogygia_updated::control::Request;
 use rand::RngExt;
 use tracing::error;
 use tracing::info;
@@ -45,19 +49,45 @@ fn main() -> Result<()> {
     thread::spawn(move || control::listen(listener, sender));
 
     // Wait out the initial delay or the interval between cycles, but run
-    // immediately when an update is requested over the control socket.
-    let mut wait = Duration::from_secs(config.daemon.initial_delay_seconds);
+    // immediately when a command arrives — and never sleep past an active
+    // canary's deadline, so it is reverted on time.
+    let mut wait = wait_duration(
+        &config,
+        Duration::from_secs(config.daemon.initial_delay_seconds),
+    );
     loop {
-        let request = match receiver.recv_timeout(wait) {
-            Ok(stream) => Some(stream),
+        let received = match receiver.recv_timeout(wait) {
+            Ok(pair) => Some(pair),
             Err(RecvTimeoutError::Timeout) => None,
             Err(RecvTimeoutError::Disconnected) => bail!("control socket listener exited"),
         };
-        let trigger = if request.is_some() {
-            info!("update requested over the control socket");
-            Trigger::Manual
-        } else {
-            Trigger::Scheduled
+
+        let (trigger, reply) = match received {
+            None => (Trigger::Scheduled, None),
+            Some((request, mut stream)) => match request {
+                // A status query is answered from persisted state, without
+                // running a cycle.
+                Request::CanaryStatus => {
+                    let response = canary_status(&config).map_err(|error| format!("{error:#}"));
+                    control::respond(&mut stream, response);
+                    wait = wait_duration(&config, interval(&config));
+                    continue;
+                }
+                Request::Update => {
+                    info!("manual update requested over the control socket");
+                    (Trigger::Manual, Some(stream))
+                }
+                Request::Canary { branch, timeout } => {
+                    info!(branch, ?timeout, "canary requested over the control socket");
+                    (
+                        Trigger::StartCanary {
+                            branch,
+                            timeout: timeout.map(Duration::from_secs),
+                        },
+                        Some(stream),
+                    )
+                }
+            },
         };
 
         let result = ogygia_updated::run_once(&config, trigger);
@@ -72,7 +102,7 @@ fn main() -> Result<()> {
                 Err(message)
             }
         };
-        if let Some(mut stream) = request {
+        if let Some(mut stream) = reply {
             control::respond(&mut stream, response);
         }
 
@@ -81,18 +111,55 @@ fn main() -> Result<()> {
         // (restartIfChanged is off so it cannot kill its own parent
         // mid-cycle); exit so systemd brings the daemon back under the
         // new definition.
-        if matches!(
-            result,
-            Ok(Outcome::Switched { .. } | Outcome::TestActivated { .. })
-        ) {
+        if result.as_ref().is_ok_and(Outcome::activated) {
             info!("activated a new configuration; exiting to adopt its unit definition");
             return Ok(());
         }
 
-        let jitter = match config.daemon.jitter_seconds {
-            0 => 0,
-            bound => rand::rng().random_range(0..bound),
-        };
-        wait = Duration::from_secs(config.daemon.interval_seconds + jitter);
+        wait = wait_duration(&config, interval(&config));
     }
+}
+
+/// The base gap between scheduled cycles, with jitter applied.
+fn interval(config: &Config) -> Duration {
+    let jitter = match config.daemon.jitter_seconds {
+        0 => 0,
+        bound => rand::rng().random_range(0..bound),
+    };
+    Duration::from_secs(config.daemon.interval_seconds + jitter)
+}
+
+/// Clamp `base` to an active canary's remaining time so the daemon wakes
+/// to revert it on schedule. A lapsed deadline yields a zero wait, running
+/// the reverting cycle at once.
+fn wait_duration(config: &Config, base: Duration) -> Duration {
+    if let Ok(Some(CanaryState::Active {
+        expires_at: Some(deadline),
+        ..
+    })) = CanaryState::load(&config.canary_state_path())
+    {
+        let remaining = (deadline - Utc::now()).to_std().unwrap_or(Duration::ZERO);
+        base.min(remaining)
+    } else {
+        base
+    }
+}
+
+/// Render the current or most-recent canary for `canary status`.
+fn canary_status(config: &Config) -> Result<String> {
+    match CanaryState::load(&config.canary_state_path())? {
+        None => Ok("no canary".to_string()),
+        Some(state) => {
+            let running = read_revision(&config.host.current_revision_path);
+            let boot_floor = read_revision(&config.next_boot_revision_path());
+            Ok(state.describe(Utc::now(), &running, &boot_floor))
+        }
+    }
+}
+
+/// Best-effort read of a build-revision file for display.
+fn read_revision(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .map(|raw| raw.trim().to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
 }

--- a/src/ogygia-updated/src/repo.rs
+++ b/src/ogygia-updated/src/repo.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -8,8 +9,6 @@ use git2::Repository;
 use git2::build::CheckoutBuilder;
 use git2::build::RepoBuilder;
 use tracing::info;
-
-use crate::config::RepoConfig;
 
 /// Refspec mirroring every remote head, so commits only reachable from
 /// non-tracked branches (e.g. archived deployed commits) stay available
@@ -22,20 +21,19 @@ pub struct Repo {
 }
 
 impl Repo {
-    pub fn open_or_clone(config: &RepoConfig) -> Result<Self> {
-        let inner = match Repository::open(&config.path) {
+    pub fn open_or_clone(path: &Path, url: &str) -> Result<Self> {
+        let inner = match Repository::open(path) {
             Ok(repository) => repository,
             Err(error) if error.code() == ErrorCode::NotFound => {
-                info!(url = %config.url, path = %config.path.display(), "cloning repository");
-                fs::create_dir_all(&config.path)
-                    .with_context(|| format!("creating {}", config.path.display()))?;
+                info!(url, path = %path.display(), "cloning repository");
+                fs::create_dir_all(path).with_context(|| format!("creating {}", path.display()))?;
                 RepoBuilder::new()
-                    .clone(&config.url, &config.path)
-                    .with_context(|| format!("cloning {}", config.url))?
+                    .clone(url, path)
+                    .with_context(|| format!("cloning {url}"))?
             }
             Err(error) => {
                 return Err(error)
-                    .with_context(|| format!("opening repository {}", config.path.display()));
+                    .with_context(|| format!("opening repository {}", path.display()));
             }
         };
         Ok(Self { inner })
@@ -73,6 +71,14 @@ impl Repo {
         self.inner
             .graph_descendant_of(descendant, ancestor)
             .context("walking commit graph")
+    }
+
+    /// Newest commit that is an ancestor of both `a` and `b` — the point
+    /// their histories diverge. Errors if they share no history.
+    pub fn merge_base(&self, a: Oid, b: Oid) -> Result<Oid> {
+        self.inner
+            .merge_base(a, b)
+            .with_context(|| format!("finding merge base of {a} and {b}"))
     }
 
     /// Force the working tree onto `commit` with a detached HEAD, leaving
@@ -146,14 +152,9 @@ mod tests {
     use super::testutil::commit;
     use super::testutil::init_origin;
     use super::*;
-    use crate::config::RepoConfig;
 
-    fn repo_config(origin: &Path, clone: &Path) -> RepoConfig {
-        RepoConfig {
-            url: origin.to_str().unwrap().to_string(),
-            path: clone.to_path_buf(),
-            branch: "main".to_string(),
-        }
+    fn open(origin: &Path, clone: &Path) -> Repo {
+        Repo::open_or_clone(clone, origin.to_str().unwrap()).unwrap()
     }
 
     #[test]
@@ -163,8 +164,7 @@ mod tests {
         let clone_path = dir.path().join("clone");
         let (origin, initial) = init_origin(&origin_path);
 
-        let config = repo_config(&origin_path, &clone_path);
-        let repo = Repo::open_or_clone(&config).unwrap();
+        let repo = open(&origin_path, &clone_path);
         repo.fetch().unwrap();
         assert_eq!(repo.tip("main").unwrap(), initial);
 
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(repo.tip("main").unwrap(), second);
 
         // Reopening finds the existing clone rather than recloning.
-        let repo = Repo::open_or_clone(&config).unwrap();
+        let repo = open(&origin_path, &clone_path);
         assert_eq!(repo.tip("main").unwrap(), second);
     }
 
@@ -186,7 +186,7 @@ mod tests {
         let second = commit(&origin, "main", &[initial], "second");
         let side = commit(&origin, "side", &[initial], "side");
 
-        let repo = Repo::open_or_clone(&repo_config(&origin_path, &clone_path)).unwrap();
+        let repo = open(&origin_path, &clone_path);
         repo.fetch().unwrap();
 
         assert!(repo.is_ancestor(initial, second).unwrap());
@@ -199,6 +199,24 @@ mod tests {
     }
 
     #[test]
+    fn merge_base_finds_the_branch_point() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+        let main_tip = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "side", &[initial], "side");
+
+        let repo = open(&origin_path, &clone_path);
+        repo.fetch().unwrap();
+
+        // The side branch diverged from main at the initial commit.
+        assert_eq!(repo.merge_base(side, main_tip).unwrap(), initial);
+        // A commit already on the branch is its own merge base with the tip.
+        assert_eq!(repo.merge_base(initial, main_tip).unwrap(), initial);
+    }
+
+    #[test]
     fn checkout_leaves_clean_tree_at_commit() {
         let dir = TempDir::new().unwrap();
         let origin_path = dir.path().join("origin");
@@ -206,7 +224,7 @@ mod tests {
         let (origin, initial) = init_origin(&origin_path);
         let second = commit(&origin, "main", &[initial], "second");
 
-        let repo = Repo::open_or_clone(&repo_config(&origin_path, &clone_path)).unwrap();
+        let repo = open(&origin_path, &clone_path);
         repo.fetch().unwrap();
         repo.checkout(second).unwrap();
 

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -19,6 +19,7 @@ nebula = [
 ]
 updated = [
     "dep:ogygia-updated",
+    "dep:humantime",
 ]
 
 [dependencies]
@@ -44,3 +45,4 @@ which = { workspace = true, optional = true }
 
 # Optional deps for updated feature
 ogygia-updated = { path = "../ogygia-updated", optional = true }
+humantime = { workspace = true, optional = true }

--- a/src/ogygia/src/update/mod.rs
+++ b/src/ogygia/src/update/mod.rs
@@ -1,22 +1,85 @@
-//! Manual trigger for the pull-based system updater.
+//! Client for the ogygia-updated daemon: manual updates and canaries.
 
+use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 
+use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
+use clap::Subcommand;
 
-/// Ask the ogygia-updated daemon to run an update cycle now.
+/// Drive the ogygia-updated daemon (root only). With no subcommand, reset
+/// the host to the tracked branch tip now.
 #[derive(Args)]
 pub struct UpdateArgs {
     /// Control socket of the ogygia-updated daemon
     #[arg(long, default_value = ogygia_updated::control::DEFAULT_SOCKET_PATH)]
     socket: PathBuf,
+
+    #[command(subcommand)]
+    command: Option<UpdateCommand>,
+}
+
+#[derive(Subcommand)]
+enum UpdateCommand {
+    /// Trial a branch on this host, or report the active trial
+    Canary(CanaryArgs),
+}
+
+/// `canary <branch>` starts a trial; `canary status` reports one.
+#[derive(Args)]
+#[command(args_conflicts_with_subcommands = true)]
+struct CanaryArgs {
+    /// Branch to trial; its tip is pinned onto this host now
+    branch: Option<String>,
+
+    /// How long to hold the trial before reverting (e.g. 24h, 90m, 2d)
+    #[arg(
+        long = "for",
+        value_name = "DURATION",
+        default_value = "24h",
+        conflicts_with = "forever"
+    )]
+    duration: humantime::Duration,
+
+    /// Hold the trial with no timeout
+    #[arg(long)]
+    forever: bool,
+
+    #[command(subcommand)]
+    command: Option<CanaryCommand>,
+}
+
+#[derive(Subcommand)]
+enum CanaryCommand {
+    /// Show the current or most-recent canary
+    Status,
 }
 
 impl UpdateArgs {
     pub fn run(&self) -> Result<()> {
-        let message = ogygia_updated::control::request_update(&self.socket)?;
+        let message = match &self.command {
+            None => ogygia_updated::control::request_update(&self.socket)?,
+            Some(UpdateCommand::Canary(canary)) => canary.run(&self.socket)?,
+        };
         println!("{message}");
         Ok(())
+    }
+}
+
+impl CanaryArgs {
+    fn run(&self, socket: &Path) -> Result<String> {
+        match &self.command {
+            Some(CanaryCommand::Status) => ogygia_updated::control::request_canary_status(socket),
+            None => {
+                let branch = self
+                    .branch
+                    .clone()
+                    .context("a branch to trial is required (or use `canary status`)")?;
+                let timeout = (!self.forever).then(|| Duration::from(self.duration).as_secs());
+                ogygia_updated::control::request_canary(socket, branch, timeout)
+            }
+        }
     }
 }


### PR DESCRIPTION
The daemon could only follow the tracked branch tip or be manually pulled back to it, with no way to ask it to trial an unmerged branch and nothing to bound or automatically end such a trial.

This adds `ogygia update canary <branch>` (with `--for`/`--forever`) and `canary status`, backed by `Canary`/`CanaryStatus` control requests and a persisted canary record. A canary pins the branch tip and applies it once as an ephemeral test activation, while staging `merge-base(commit, tracked tip)` as the boot default so a reboot lands on a recent tracked commit. Each scheduled cycle only maintains that boot floor and ends the trial on the first terminal event: the commit merges, the timeout expires, a plain update supersedes it, or the host leaves the trial — a reboot, detected via the kernel boot id, or an out-of-band switch. The daemon clamps its sleep to the deadline so it reverts on time. The per-file `repo.path` setting is replaced with a single `state_dir`.

Pinning a resolved commit (not the branch) keeps the trial deterministic; because the activation is never reapplied, a reboot safely drops the host to the boot floor instead of being healed back onto the trial; and recording why each trial ended — reboot versus manual overwrite included — lets `canary status` report the truth rather than a stale "trialling".

Test plan:
- Added unit tests: engine canary start/hold/merge/expire/manual-clear and reboot/overwrite displacement, Repo::merge_base, control request round-trip, canary state store/load and status rendering
- Ran `cargo test -p ogygia -p ogygia-updated` (65 tests pass)
- Manually checked CLI parsing: `canary <branch>`, `--for`/`--forever` conflict, missing-branch error, and `canary status`
- CI runs the workspace test suite