### PR TITLE
ogygia-updated: treat landed jj commits as merged via change-id

### DIFF
--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -330,7 +330,7 @@ fn update_to_tip(
     let current = read_revision(&config.host.current_revision_path)?;
     let next_boot = read_revision(&config.next_boot_revision_path())?;
 
-    if !force && !repo.is_ancestor(current, tip)? {
+    if !force && !on_branch(repo, current, tip)? {
         return Ok(Outcome::NotOnBranch {
             revision: current.to_string(),
         });
@@ -361,7 +361,7 @@ fn update_to_tip(
 
     // A hand-staged off-branch next-boot system is preserved by the
     // scheduler, but a manual trigger resets the boot default to the tip.
-    let next_boot_on_branch = force || repo.is_ancestor(next_boot, tip)?;
+    let next_boot_on_branch = force || on_branch(repo, next_boot, tip)?;
     activate(config, system, &store_path, tip, next_boot_on_branch)
 }
 
@@ -386,6 +386,22 @@ fn target_commit(target: &CanaryTarget) -> Result<Oid> {
             Oid::from_str(commit).with_context(|| format!("parsing pinned canary commit {commit}"))
         }
     }
+}
+
+/// Whether `revision` is on the branch leading to `tip`, either as a plain
+/// ancestor or as a deployed jj revision whose every change has since
+/// landed there (rewritten, keeping its change-id). Such a fully-landed
+/// revision updates like a merged one; a stack with any change still
+/// outstanding does not.
+fn on_branch(repo: &Repo, revision: Oid, tip: Oid) -> Result<bool> {
+    if repo.is_ancestor(revision, tip)? {
+        return Ok(true);
+    }
+    if repo.changes_landed(revision, tip)? {
+        info!(%revision, "deployed changes have all landed on the tracked branch");
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 fn activate(
@@ -448,6 +464,7 @@ mod tests {
     use crate::config::HostConfig;
     use crate::config::RepoConfig;
     use crate::repo::testutil::commit;
+    use crate::repo::testutil::commit_with_change_id;
     use crate::repo::testutil::init_origin;
 
     /// A fixed clock for deterministic expiry tests.
@@ -679,6 +696,48 @@ mod tests {
                     fixture.config.repo_path().display()
                 )),
                 Call::SwitchToConfiguration(Activation::Test),
+            ]
+        );
+    }
+
+    #[test]
+    fn landed_revision_updates_like_a_merge() {
+        let (fixture, initial) = Fixture::new();
+        // The host runs a jj commit deployed from a branch; it has since
+        // landed on main rewritten, keeping its change-id.
+        let deployed = commit_with_change_id(
+            &fixture.origin,
+            "deploy",
+            &[initial],
+            "deployed",
+            "kxyzkxyzkxyz",
+        );
+        let landed = commit_with_change_id(
+            &fixture.origin,
+            "main",
+            &[initial],
+            "landed",
+            "kxyzkxyzkxyz",
+        );
+        fixture.set_current(deployed);
+        fixture.set_next_boot(deployed);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: landed.to_string()
+            }
+        );
+        // The landed next-boot revision counts as on-branch, so the boot
+        // profile moves too rather than getting a test-only activation.
+        assert_eq!(
+            system.calls.borrow()[1..],
+            [
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
             ]
         );
     }

--- a/src/ogygia-updated/src/repo.rs
+++ b/src/ogygia-updated/src/repo.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -14,6 +15,10 @@ use tracing::info;
 /// non-tracked branches (e.g. archived deployed commits) stay available
 /// for ancestry checks.
 const FETCH_REFSPEC: &str = "+refs/heads/*:refs/remotes/origin/*";
+
+/// Maximum commits scanned on either side of the divergence when deciding
+/// whether an off-branch revision's changes have landed.
+const MAX_LANDED_SCAN: usize = 1000;
 
 /// The daemon's private clone of the configuration repository.
 pub struct Repo {
@@ -81,6 +86,68 @@ impl Repo {
             .with_context(|| format!("finding merge base of {a} and {b}"))
     }
 
+    /// Whether every commit on `revision` but not yet on `tip` has a
+    /// counterpart on `tip` sharing its change-id. This is the change-id
+    /// generalisation of ancestry: jj rewrites commits as they land but
+    /// preserves the change-id, so a deployed revision counts as merged
+    /// once each of its changes reappears on the branch under a new git
+    /// hash — even a whole stack landed one commit at a time.
+    ///
+    /// A single un-landed change is enough to fail: a deployed head whose
+    /// change-id is on the branch has *not* merged if an ancestor of it
+    /// hasn't. A commit without a change-id (plain git) cannot be shown to
+    /// have landed, so its presence on `revision` fails too, as does a
+    /// `revision` the clone has never fetched.
+    pub fn changes_landed(&self, revision: Oid, tip: Oid) -> Result<bool> {
+        if self.inner.find_commit(revision).is_err() {
+            return Ok(false);
+        }
+
+        // Change-ids carried by the branch, bounded to the history since
+        // the two diverged so an unrelated older change can't match.
+        let base = self.inner.merge_base(revision, tip).ok();
+        let mut branch_walk = self.inner.revwalk().context("starting branch walk")?;
+        branch_walk.push(tip).context("walking from branch tip")?;
+        if let Some(base) = base {
+            branch_walk.hide(base).context("hiding common history")?;
+        }
+        let mut landed = HashSet::new();
+        for oid in branch_walk.take(MAX_LANDED_SCAN) {
+            let oid = oid.context("walking branch history")?;
+            let commit = self
+                .inner
+                .find_commit(oid)
+                .with_context(|| format!("finding commit {oid}"))?;
+            if let Some(id) = change_id(&commit) {
+                landed.insert(id);
+            }
+        }
+
+        // Every change unique to the deployed revision must be among them.
+        let mut deployed_walk = self.inner.revwalk().context("starting deployed walk")?;
+        deployed_walk
+            .push(revision)
+            .context("walking from the deployed revision")?;
+        deployed_walk
+            .hide(tip)
+            .context("hiding commits already on the branch")?;
+        for (scanned, oid) in deployed_walk.enumerate() {
+            if scanned >= MAX_LANDED_SCAN {
+                return Ok(false);
+            }
+            let oid = oid.context("walking the deployed revision")?;
+            let commit = self
+                .inner
+                .find_commit(oid)
+                .with_context(|| format!("finding commit {oid}"))?;
+            match change_id(&commit) {
+                Some(id) if landed.contains(&id) => {}
+                _ => return Ok(false),
+            }
+        }
+        Ok(true)
+    }
+
     /// Force the working tree onto `commit` with a detached HEAD, leaving
     /// it clean so flake evaluation sees the commit as the revision.
     pub fn checkout(&self, commit: Oid) -> Result<()> {
@@ -101,6 +168,15 @@ impl Repo {
     }
 }
 
+/// The change-id header jj preserves when rewriting a commit, e.g. when
+/// landing it onto the tracked branch.
+fn change_id(commit: &git2::Commit) -> Option<Vec<u8>> {
+    commit
+        .header_field_bytes("change-id")
+        .ok()
+        .map(|buf| buf.to_vec())
+}
+
 #[cfg(test)]
 pub mod testutil {
     use std::path::Path;
@@ -109,14 +185,20 @@ pub mod testutil {
     use git2::Repository;
     use git2::Signature;
 
+    fn tree_with_marker(repository: &Repository, marker: &str) -> Oid {
+        let blob = repository.blob(marker.as_bytes()).unwrap();
+        let mut builder = repository.treebuilder(None).unwrap();
+        builder.insert("marker", blob, 0o100644).unwrap();
+        builder.write().unwrap()
+    }
+
     /// Create a commit in `repository` updating `branch`, with `marker`
     /// written to a file to make each tree distinct.
     pub fn commit(repository: &Repository, branch: &str, parents: &[Oid], marker: &str) -> Oid {
         let signature = Signature::now("test", "test@example.com").unwrap();
-        let blob = repository.blob(marker.as_bytes()).unwrap();
-        let mut builder = repository.treebuilder(None).unwrap();
-        builder.insert("marker", blob, 0o100644).unwrap();
-        let tree = repository.find_tree(builder.write().unwrap()).unwrap();
+        let tree = repository
+            .find_tree(tree_with_marker(repository, marker))
+            .unwrap();
         let parents: Vec<_> = parents
             .iter()
             .map(|oid| repository.find_commit(*oid).unwrap())
@@ -132,6 +214,41 @@ pub mod testutil {
                 &parent_refs,
             )
             .unwrap()
+    }
+
+    /// Like `commit`, but with a jj-style change-id header embedded in
+    /// the commit object.
+    pub fn commit_with_change_id(
+        repository: &Repository,
+        branch: &str,
+        parents: &[Oid],
+        marker: &str,
+        change_id: &str,
+    ) -> Oid {
+        let signature = Signature::now("test", "test@example.com").unwrap();
+        let tree = repository
+            .find_tree(tree_with_marker(repository, marker))
+            .unwrap();
+        let parents: Vec<_> = parents
+            .iter()
+            .map(|oid| repository.find_commit(*oid).unwrap())
+            .collect();
+        let parent_refs: Vec<_> = parents.iter().collect();
+        let buffer = repository
+            .commit_create_buffer(&signature, &signature, marker, &tree, &parent_refs)
+            .unwrap();
+        let text = std::str::from_utf8(&buffer).unwrap();
+        let (headers, message) = text.split_once("\n\n").unwrap();
+        let raw = format!("{headers}\nchange-id {change_id}\n\n{message}");
+        let oid = repository
+            .odb()
+            .unwrap()
+            .write(git2::ObjectType::Commit, raw.as_bytes())
+            .unwrap();
+        repository
+            .reference(&format!("refs/heads/{branch}"), oid, true, "test")
+            .unwrap();
+        oid
     }
 
     /// Initialize an origin repository with an initial commit on main.
@@ -150,6 +267,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::testutil::commit;
+    use super::testutil::commit_with_change_id;
     use super::testutil::init_origin;
     use super::*;
 
@@ -235,5 +353,88 @@ mod tests {
         let statuses = repo.inner.statuses(None).unwrap();
         assert!(statuses.is_empty());
         assert_eq!(repo.inner.head().unwrap().target(), Some(second));
+    }
+
+    #[test]
+    fn single_landed_change_counts_as_merged() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+        let deployed =
+            commit_with_change_id(&origin, "deploy", &[initial], "deployed", "kxyzkxyzkxyz");
+        let landed = commit_with_change_id(&origin, "main", &[initial], "landed", "kxyzkxyzkxyz");
+
+        let repo = open(&origin_path, &clone_path);
+        repo.fetch().unwrap();
+
+        // The rewritten commit has a new git hash, so it is not an ancestor,
+        // but its change-id landed on the branch.
+        assert!(!repo.is_ancestor(deployed, landed).unwrap());
+        assert!(repo.changes_landed(deployed, landed).unwrap());
+    }
+
+    #[test]
+    fn a_whole_landed_stack_counts_as_merged() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+
+        // A two-commit stack deployed from a branch...
+        let lower = commit_with_change_id(&origin, "deploy", &[initial], "lower", "aaaaaaaaaaaa");
+        let deployed = commit_with_change_id(&origin, "deploy", &[lower], "upper", "bbbbbbbbbbbb");
+        // ...both rewritten onto main, keeping their change-ids.
+        let relanded = commit_with_change_id(&origin, "main", &[initial], "lower", "aaaaaaaaaaaa");
+        let tip = commit_with_change_id(&origin, "main", &[relanded], "upper", "bbbbbbbbbbbb");
+
+        let repo = open(&origin_path, &clone_path);
+        repo.fetch().unwrap();
+
+        assert!(repo.changes_landed(deployed, tip).unwrap());
+    }
+
+    #[test]
+    fn a_stack_with_an_outstanding_change_has_not_merged() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+
+        // The host runs a two-commit stack...
+        let lower = commit_with_change_id(&origin, "deploy", &[initial], "lower", "aaaaaaaaaaaa");
+        let deployed = commit_with_change_id(&origin, "deploy", &[lower], "upper", "bbbbbbbbbbbb");
+        // ...but only the upper change has landed; the lower one has not.
+        let tip = commit_with_change_id(&origin, "main", &[initial], "upper", "bbbbbbbbbbbb");
+
+        let repo = open(&origin_path, &clone_path);
+        repo.fetch().unwrap();
+
+        // The deployed head's change-id is on the branch, but its
+        // still-outstanding ancestor means the stack has not merged.
+        assert!(!repo.changes_landed(deployed, tip).unwrap());
+    }
+
+    #[test]
+    fn differing_or_missing_change_ids_are_not_landed() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+        let deployed =
+            commit_with_change_id(&origin, "deploy", &[initial], "deployed", "kxyzkxyzkxyz");
+        let plain = commit(&origin, "side", &[initial], "plain");
+        let landed = commit_with_change_id(&origin, "main", &[initial], "landed", "koooooooooo");
+
+        let repo = open(&origin_path, &clone_path);
+        repo.fetch().unwrap();
+
+        // A change-id is present on both sides but differs.
+        assert!(!repo.changes_landed(deployed, landed).unwrap());
+        // The deployed commit has no change-id header at all.
+        assert!(!repo.changes_landed(plain, landed).unwrap());
+        // The deployed commit is unknown to the repository.
+        let unknown = Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+        assert!(!repo.changes_landed(unknown, landed).unwrap());
     }
 }


### PR DESCRIPTION
A host can be deployed directly onto a jj commit — as a canary or a hand-picked branch build — that later lands on the tracked branch. jj rewrites the commit as it lands, so the landed commit has a new git hash and the updater saw the running revision as off-branch and refused to ever resume tracking it.

When the running or next-boot revision is not an ancestor of the branch tip, the daemon compares change-ids rather than hashes: it collects the change-ids the branch carries since the two diverged and requires every change unique to the deployed revision to appear among them. A deployed stack therefore counts as landed only once all of its changes have, not merely its head, and a plain-git commit — which carries no change-id — never qualifies. The fetch mirrors all heads, so deployed commits reachable from other branches stay resolvable.

Recognizing a fully-landed revision makes updating from a deployed jj commit behave like updating across a merge, so hosts rejoin the tracked branch automatically once their changes land.

Test plan:
- Added repo unit tests for the change-id subset check: a single landed change and a whole landed stack both count as merged, a stack with an outstanding ancestor does not, and differing, missing, or unknown change-ids are not landed.
- Added an engine test asserting a deployed jj commit whose changes landed on the branch updates like a merge, moving the boot profile.
- CI