### PR TITLE
nixos: make Nebula cert validity configurable per host

### DIFF
--- a/nixos/nebula/default.nix
+++ b/nixos/nebula/default.nix
@@ -109,6 +109,15 @@ in
       example = [ "ssh" "etcd-server" ];
     };
 
+    validitySecs = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 90 * 86400;
+      description = ''
+        Validity period, in seconds, for this host's certificate: how long the
+        certificate is valid for after it is rekeyed.
+      '';
+    };
+
     firewall.inbound = lib.mkOption {
       type = lib.types.listOf firewallRuleType;
       default = [ ];

--- a/nixos/tests/nebula-module.nix
+++ b/nixos/tests/nebula-module.nix
@@ -66,6 +66,11 @@ let
     modules = [ ogygiaModule baseModule firewallA firewallB ];
   };
 
+  # A per-host override of validitySecs, which rekey reads off config.
+  customValiditySystem = lib.nixosSystem {
+    modules = [ ogygiaModule baseModule { ogygia.nebula.validitySecs = 3600; } ];
+  };
+
   failedAssertions = sys: builtins.filter (a: !a.assertion) sys.config.assertions;
 
   noPubKeySystem = lib.nixosSystem {
@@ -112,6 +117,9 @@ pkgs.runCommand "ogygia-nebula-module"
   nativeBuildInputs = [ pkgs.jq ];
   inherit expectedSpecHash;
   actualSpecHash = validSystem.config.ogygia.nebula.specHash;
+  defaultValidity = toString validSystem.config.ogygia.nebula.validitySecs;
+  customValidity = toString customValiditySystem.config.ogygia.nebula.validitySecs;
+  customValiditySpecHash = customValiditySystem.config.ogygia.nebula.specHash;
   validCertPath = toString validSystem.config.ogygia.nebula.certPath;
   serviceCert = toString validSystem.config.services.nebula.networks.ogygia.cert;
   serviceCa = toString validSystem.config.services.nebula.networks.ogygia.ca;
@@ -137,6 +145,20 @@ pkgs.runCommand "ogygia-nebula-module"
 
   if [ "$actualSpecHash" != "$expectedSpecHash" ]; then
     echo "specHash mismatch: got '$actualSpecHash', expected '$expectedSpecHash'" >&2
+    exit 1
+  fi
+
+  # validitySecs defaults to 90 days and honours a per-host override.
+  if [ "$defaultValidity" != "7776000" ]; then
+    echo "validitySecs default should be 7776000 (90d), got '$defaultValidity'" >&2
+    exit 1
+  fi
+  if [ "$customValidity" != "3600" ]; then
+    echo "validitySecs override should surface as 3600, got '$customValidity'" >&2
+    exit 1
+  fi
+  if [ "$customValiditySpecHash" != "$expectedSpecHash" ]; then
+    echo "validitySecs must not affect specHash: got '$customValiditySpecHash'" >&2
     exit 1
   fi
 

--- a/src/ogygia/src/nebula/config.rs
+++ b/src/ogygia/src/nebula/config.rs
@@ -15,7 +15,6 @@ use anyhow::anyhow;
 pub const ENV_CA_KEY: &str = "OGYGIA_NEBULA_CA_KEY";
 
 pub const DEFAULT_NETWORK_NAME: &str = "ogygia";
-pub const DEFAULT_VALIDITY_SECS: u64 = 90 * 86400;
 pub const DEFAULT_CA_DURATION_SECS: u64 = 10 * 365 * 86400;
 
 /// Resolved fleet configuration.

--- a/src/ogygia/src/nebula/flake_eval.rs
+++ b/src/ogygia/src/nebula/flake_eval.rs
@@ -33,6 +33,8 @@ pub struct HostInfo {
     pub enabled: bool,
     pub spec_hash: Option<String>,
     pub spec: Option<HostSpec>,
+    /// Validity period, in seconds, to sign this host's cert for.
+    pub validity_secs: u64,
 }
 
 /// List the names of every host in `flake_ref#nixosConfigurations`.
@@ -57,12 +59,16 @@ pub async fn host_info(nix: &Nix, flake_ref: &str, host: &str) -> Result<HostInf
         #[serde(rename = "specHash")]
         spec_hash: Option<String>,
         spec: Option<HostSpec>,
+        // `or null` for flakes whose module predates validitySecs; drop the
+        // fallback once every host has updated.
+        #[serde(rename = "validitySecs")]
+        validity_secs: Option<u64>,
     }
 
     let raw: Raw = nix
         .eval_json(
             &format!("{flake_ref}#nixosConfigurations.\"{host}\".config.ogygia.nebula"),
-            Some("cfg: { inherit (cfg) enable specHash spec; }"),
+            Some("cfg: { inherit (cfg) enable specHash spec; validitySecs = cfg.validitySecs or null; }"),
         )
         .await?;
 
@@ -71,5 +77,6 @@ pub async fn host_info(nix: &Nix, flake_ref: &str, host: &str) -> Result<HostInf
         enabled: raw.enable,
         spec_hash: raw.spec_hash,
         spec: raw.spec,
+        validity_secs: raw.validity_secs.unwrap_or(90 * 86400),
     })
 }

--- a/src/ogygia/src/nebula/rekey.rs
+++ b/src/ogygia/src/nebula/rekey.rs
@@ -11,7 +11,6 @@ use clap::Args;
 use ogygia_nixutils::Nix;
 
 use super::config::Config;
-use super::config::DEFAULT_VALIDITY_SECS;
 use super::flake_eval;
 use super::nebula_cert;
 use super::nebula_cert::SignArgs;
@@ -118,7 +117,7 @@ async fn async_run(args: &RekeyArgs) -> Result<()> {
                 name: &info.host,
                 networks: &networks,
                 groups: &spec.groups,
-                duration_seconds: DEFAULT_VALIDITY_SECS,
+                duration_seconds: info.validity_secs,
                 out_cert: &cert_path,
             },
         )


### PR DESCRIPTION
The `ogygia nebula rekey` signer hard-coded a 90-day certificate validity (DEFAULT_VALIDITY_SECS), with no way for an operator to lengthen or shorten the lifetime of a host's cert.

This adds a settable `ogygia.nebula.validitySecs` NixOS option (default 90 days) that rekey evaluates per host alongside the existing spec and passes to `nebula-cert -duration`. It is deliberately kept out of the cert spec hash, so changing it does not rotate an existing cert on its own — `ogygia nebula rekey --force --host <name>` re-signs with the new period.

Operators can now set per-host certificate lifetimes in Nix while the content-addressed cert layout and specHash are unchanged, preserving the existing default behaviour for hosts that do not set the option.

Test plan:
- Extended nixos/tests/nebula-module.nix to assert the option defaults to 7776000s (90d), that a per-host override surfaces unchanged, and that it does not perturb specHash. Ran `nix build .#checks.x86_64-linux.ogygia-nebula-module` (passes) and `cargo build`/`cargo clippy -p ogygia` (clean).