### PR TITLE
ogygia-dashboard: alert on expiring Nebula certificates

### DIFF
--- a/nixos/dashboard/default.nix
+++ b/nixos/dashboard/default.nix
@@ -31,6 +31,9 @@ let
     title = cfg.title;
   } // lib.optionalAttrs (cfg.hostnameStripSuffix != null) {
     hostname_strip_suffix = cfg.hostnameStripSuffix;
+  } // lib.optionalAttrs cfg.nebula.enable {
+    # Thresholds are fixed fractions of each cert's validity.
+    nebula.enable = true;
   });
 in
 {
@@ -94,6 +97,14 @@ in
         description = "Branch the deployed commits are archived to.";
       };
     };
+
+    nebula = {
+      enable = lib.mkEnableOption ''
+        Nebula certificate expiry alerts. Evaluates each host's certificate via
+        `nix eval` and reads its expiry with `nebula-cert`, then surfaces alerts
+        as the certificates approach their validity horizon. Expensive, so it
+        runs only when enabled here'';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -112,6 +123,10 @@ in
       description = "Ogygia Dashboard - NixOS Host Status Visualization";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+
+      # The nebula alert producer shells out to `nix eval` (which uses git) and
+      # `nebula-cert`; without alerts the service needs neither.
+      path = lib.optionals cfg.nebula.enable [ pkgs.nix pkgs.nebula pkgs.git ];
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/ogygia-dashboard --config ${configFile}";
@@ -137,15 +152,22 @@ in
         RestrictSUIDSGID = true;
       } // lib.optionalAttrs cfg.ssh.enable {
         LoadCredential = [ "ssh-key:${cfg.ssh.keyFile}" ];
+      } // lib.optionalAttrs cfg.nebula.enable {
+        # The Nix evaluator maps writable-executable pages, which the default
+        # hardening forbids.
+        MemoryDenyWriteExecute = false;
       };
 
       environment = {
         RUST_LOG = lib.mkDefault "info";
-      } // lib.optionalAttrs cfg.ssh.enable {
+      } // lib.optionalAttrs (cfg.ssh.enable || cfg.nebula.enable) {
         # libgit2's SSH transport resolves $HOME/.ssh/known_hosts before the
         # host key callback and fails outright ("error loading known_hosts")
-        # when HOME is unset, which it is under DynamicUser.
+        # when HOME is unset, which it is under DynamicUser. Nix likewise needs
+        # a writable HOME for its evaluation cache.
         HOME = "/run/ogygia-dashboard";
+      } // lib.optionalAttrs cfg.nebula.enable {
+        NIX_CONFIG = "experimental-features = nix-command flakes";
       };
     };
   };

--- a/src/ogygia-dashboard/Cargo.toml
+++ b/src/ogygia-dashboard/Cargo.toml
@@ -43,3 +43,11 @@ enum-map = { workspace = true }
 # Logging
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[features]
+default = ["nebula"]
+# Nebula certificate expiry alerts. On by default; disable with
+# `--no-default-features` to drop the producer (and its `nix`/`nebula-cert`
+# runtime dependencies). Whether it actually runs is gated at runtime by the
+# `[nebula]` config section, so the expensive evaluation stays opt-in there.
+nebula = []

--- a/src/ogygia-dashboard/src/alerts.rs
+++ b/src/ogygia-dashboard/src/alerts.rs
@@ -1,0 +1,94 @@
+//! The dashboard's alert subsystem: a generic model and renderer, always
+//! present regardless of which producers are compiled in. Producers (e.g. the
+//! feature-gated Nebula certificate-expiry watcher in [`crate::nebula`]) fill an
+//! [`AlertsSnapshot`] in the background; the request path only ever renders it.
+
+use crate::config::Config;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AlertLevel {
+    Info,
+    Warning,
+    Critical,
+}
+
+impl AlertLevel {
+    fn label(self) -> &'static str {
+        match self {
+            AlertLevel::Info => "Info",
+            AlertLevel::Warning => "Warning",
+            AlertLevel::Critical => "Critical",
+        }
+    }
+
+    fn css_class(self) -> &'static str {
+        match self {
+            AlertLevel::Info => "alert-info",
+            AlertLevel::Warning => "alert-warning",
+            AlertLevel::Critical => "alert-critical",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Alert {
+    pub level: AlertLevel,
+    pub title: String,
+    pub detail: String,
+    pub hosts: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct AlertsSnapshot {
+    pub alerts: Vec<Alert>,
+}
+
+/// Render the alerts section, or the empty string when there is nothing to show.
+pub fn render_alerts_section(alerts: &[Alert], config: &Config) -> String {
+    if alerts.is_empty() {
+        return String::new();
+    }
+
+    let mut html = String::from(
+        r#"<div class="alerts-section"><div class="section-header"><h2 class="section-title">Alerts</h2></div>"#,
+    );
+
+    for alert in alerts {
+        let badges: String = alert
+            .hosts
+            .iter()
+            .map(|host| {
+                let clean = match &config.hostname_strip_suffix {
+                    Some(suffix) => host.replace(suffix.as_str(), ""),
+                    None => host.clone(),
+                };
+                format!(r#"<span class="host-badge">{}</span>"#, esc(&clean))
+            })
+            .collect();
+
+        html.push_str(&format!(
+            r#"<div class="alert {css}">
+                <span class="alert-level">{level}</span>
+                <div class="alert-body">
+                    <div class="alert-title">{title}</div>
+                    <div class="alert-detail">{detail}</div>
+                    <div class="host-badges">{badges}</div>
+                </div>
+            </div>"#,
+            css = alert.level.css_class(),
+            level = alert.level.label(),
+            title = esc(&alert.title),
+            detail = esc(&alert.detail),
+        ));
+    }
+
+    html.push_str("</div>");
+    html
+}
+
+fn esc(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}

--- a/src/ogygia-dashboard/src/config.rs
+++ b/src/ogygia-dashboard/src/config.rs
@@ -15,6 +15,18 @@ pub struct Config {
     pub title: String,
     #[serde(default)]
     pub hostname_strip_suffix: Option<String>,
+    /// Nebula certificate-expiry alerts. Requires the binary to be built with
+    /// the `nebula` feature (on by default).
+    #[serde(default)]
+    pub nebula: NebulaConfig,
+}
+
+/// Nebula certificate-expiry alerts. Off unless `enable = true`; thresholds are
+/// fixed fractions of each cert's validity.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NebulaConfig {
+    #[serde(default)]
+    pub enable: bool,
 }
 
 fn default_title() -> String {
@@ -228,6 +240,7 @@ mod tests {
             },
             title: default_title(),
             hostname_strip_suffix: None,
+            nebula: NebulaConfig::default(),
         }
     }
 

--- a/src/ogygia-dashboard/src/git.rs
+++ b/src/ogygia-dashboard/src/git.rs
@@ -70,6 +70,24 @@ impl GitManager {
         fetch(&repo, self.ssh.as_ref())
     }
 
+    /// Filesystem path of the working clone, for tools (e.g. `nix eval`) that
+    /// address it directly rather than through the git2 handle.
+    #[cfg(feature = "nebula")]
+    pub fn repo_path(&self) -> Option<PathBuf> {
+        self.temp_dir
+            .as_ref()
+            .map(|d| d.path().to_path_buf())
+            .or_else(|| self.repo_path.clone())
+    }
+
+    /// Whether `oid` is present in the local object database.
+    #[cfg(feature = "nebula")]
+    pub fn has_commit(&self, oid: Oid) -> bool {
+        self.open_repo()
+            .map(|repo| repo.find_commit(oid).is_ok())
+            .unwrap_or(false)
+    }
+
     /// Make every candidate commit reachable from the archive branch by
     /// pushing a chain of merge commits on top of it, so the commits survive
     /// their original branch being force-pushed. Returns the commits that are

--- a/src/ogygia-dashboard/src/main.rs
+++ b/src/ogygia-dashboard/src/main.rs
@@ -10,10 +10,16 @@ use tokio::net::TcpListener;
 use tokio::net::UnixListener;
 use tower::ServiceExt;
 
+// The alert model and renderer are always present; without a producer compiled
+// in (the `nebula` feature) nothing constructs an alert, which is expected.
+#[cfg_attr(not(feature = "nebula"), allow(dead_code))]
+mod alerts;
 mod archive;
 mod config;
 mod etcd;
 mod git;
+#[cfg(feature = "nebula")]
+mod nebula;
 mod nixos;
 mod web;
 

--- a/src/ogygia-dashboard/src/nebula.rs
+++ b/src/ogygia-dashboard/src/nebula.rs
@@ -1,0 +1,562 @@
+//! Nebula certificate-expiry alerts: a background producer feeding the generic
+//! [`crate::alerts`] subsystem. Compiled only with the `nebula` feature.
+//!
+//! Two independent facts feed a host's expiry alert, and they come from
+//! different points in history:
+//!
+//!   * the certificate's real `notAfter` — a property of the *deployed* commit,
+//!     since that's the cert the host is actually pinned to. We `nix eval` the
+//!     host's `ogygia.nebula.certPath` at that commit, then read the expiry out
+//!     of the signed cert with `nebula-cert print`.
+//!   * `validitySecs` — the *policy* the alert thresholds scale against. That's
+//!     a property of *now*, so it's evaluated on the main tip; changing it takes
+//!     effect immediately rather than waiting for every host to redeploy.
+//!
+//! Two cache layers keep work off the request path (see [`spawn`]):
+//!
+//!   * **Layer A** — the per-host expiry snapshot ([`HostExpiry`]). Expensive
+//!     (`nix eval` + `nebula-cert`), so it is recomputed only when the etcd
+//!     host-state version changes, and every eval is memoized.
+//!   * **Layer B** — the [`Alert`] list. Cheap: it derives severity from Layer A
+//!     and the wall clock, so it is recomputed on a timer too, letting a cert
+//!     cross a threshold without any input change.
+//!
+//! Everything degrades gracefully: one un-evaluable historical commit surfaces
+//! as an informational alert rather than blanking the whole section.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use chrono::DateTime;
+use chrono::Utc;
+use git2::Oid;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use crate::alerts::Alert;
+use crate::alerts::AlertLevel;
+use crate::alerts::AlertsSnapshot;
+use crate::config::Config;
+use crate::etcd::Etcd;
+use crate::etcd::HostStates;
+use crate::git::GitManager;
+use crate::nixos::CommitState;
+
+/// An operator's runway before a cert expires is measured as a fraction of the
+/// cert's configured validity, so the windows scale with the policy.
+const INFO_FRACTION: f64 = 0.50;
+const WARNING_FRACTION: f64 = 0.25;
+
+/// How often Layer B is recomputed so threshold crossings surface without an
+/// input change. Day-scale thresholds don't need finer granularity.
+const TICK: Duration = Duration::from_secs(60);
+
+/// Spawn the background task that keeps the alerts snapshot up to date. Runs one
+/// pass immediately, then on every host-state change or timer tick.
+pub fn spawn(
+    config: Config,
+    git: Arc<GitManager>,
+    etcd: Arc<Etcd>,
+    slot: Arc<Mutex<Arc<AlertsSnapshot>>>,
+) {
+    tokio::spawn(async move {
+        let _ = config; // reserved for future per-fleet alert tuning
+        let mut changes = etcd.subscribe();
+        let mut memo = Memo::default();
+        let mut layer_a: Vec<HostExpiry> = Vec::new();
+        let mut resolved_version: Option<usize> = None;
+
+        loop {
+            let state = etcd.state().await;
+
+            if resolved_version != Some(state.version) {
+                match resolve_expiries(&git, &state, &mut memo).await {
+                    Ok(expiries) => {
+                        layer_a = expiries;
+                        resolved_version = Some(state.version);
+                    }
+                    Err(e) => {
+                        // Keep the previous snapshot and retry on the next tick.
+                        tracing::error!("failed to resolve nebula cert expiries: {e:#}");
+                    }
+                }
+            }
+
+            let alerts = compute_alerts(&layer_a, Utc::now());
+            *slot.lock().await = Arc::new(AlertsSnapshot { alerts });
+
+            tokio::select! {
+                r = changes.changed() => {
+                    if r.is_err() {
+                        return; // etcd dropped; nothing left to watch
+                    }
+                }
+                _ = tokio::time::sleep(TICK) => {}
+            }
+        }
+    });
+}
+
+/// Per-host expiry facts (Layer A). `not_after`/`validity_secs` are `None` when
+/// they couldn't be determined; `note` then explains why so Layer B can emit an
+/// informational alert instead of silently dropping the host.
+#[derive(Debug, Clone)]
+struct HostExpiry {
+    host: String,
+    not_after: Option<DateTime<Utc>>,
+    source: Option<CommitState>,
+    validity_secs: Option<u64>,
+    note: Option<String>,
+}
+
+/// Memoized eval results, persisted across version bumps so a change only
+/// re-evaluates the hosts that actually moved. Only successes are cached;
+/// failures are retried on the next recompute.
+#[derive(Default)]
+struct Memo {
+    /// `(host, commit) -> cert store path` (`None` = nebula disabled there).
+    cert_paths: HashMap<(String, Oid), Option<PathBuf>>,
+    /// `cert store path -> notAfter`. Keyed on the cert's content, so a re-sign
+    /// (new expiry) is a new path and re-parses.
+    expiries: HashMap<PathBuf, DateTime<Utc>>,
+    /// `(host, commit) -> validitySecs`.
+    validities: HashMap<(String, Oid), u64>,
+}
+
+/// Layer A: resolve every host's soonest cert expiry and its validity policy.
+async fn resolve_expiries(
+    git: &GitManager,
+    state: &HostStates,
+    memo: &mut Memo,
+) -> Result<Vec<HostExpiry>> {
+    let repo = git
+        .repo_path()
+        .ok_or_else(|| anyhow!("git manager has no repository path"))?;
+
+    // Fetch once if any referenced commit is missing locally, so Nix's `?rev=`
+    // lookup can resolve it.
+    let needed: Vec<Oid> = state
+        .host_states
+        .values()
+        .flat_map(|s| [s[CommitState::Current], s[CommitState::NextBoot]])
+        .flatten()
+        .collect();
+    if needed.iter().any(|oid| !git.has_commit(*oid)) {
+        git.fetch_updates().await?;
+    }
+
+    let main_tip = git.get_main_tip().ok();
+
+    let mut out = Vec::new();
+    for (host, states) in &state.host_states {
+        if let Some(expiry) = resolve_host(&repo, host, states, main_tip, memo).await {
+            out.push(expiry);
+        }
+    }
+    Ok(out)
+}
+
+/// Resolve one host, or `None` when nebula isn't in play for it (nothing to
+/// alert on).
+async fn resolve_host(
+    repo: &Path,
+    host: &str,
+    states: &enum_map::EnumMap<CommitState, Option<Oid>>,
+    main_tip: Option<Oid>,
+    memo: &mut Memo,
+) -> Option<HostExpiry> {
+    // The certs the host is actually pinned to: its current and nextboot
+    // commits, deduplicated (they're usually identical).
+    let mut seen = HashSet::new();
+    let mut pins = Vec::new();
+    for source in [CommitState::Current, CommitState::NextBoot] {
+        if let Some(oid) = states[source]
+            && seen.insert(oid)
+        {
+            pins.push((source, oid));
+        }
+    }
+    if pins.is_empty() {
+        return None;
+    }
+
+    let mut earliest: Option<(DateTime<Utc>, CommitState, Oid)> = None;
+    let mut relevant = false;
+    let mut note: Option<String> = None;
+
+    for (source, oid) in pins {
+        match resolve_pin(repo, oid, host, memo).await {
+            Ok(Some(not_after)) => {
+                relevant = true;
+                if earliest.is_none_or(|(e, _, _)| not_after < e) {
+                    earliest = Some((not_after, source, oid));
+                }
+            }
+            Ok(None) => {} // nebula disabled at this commit
+            Err(e) => {
+                relevant = true;
+                tracing::warn!(%host, %oid, "nebula cert eval failed: {e:#}");
+                note.get_or_insert_with(|| {
+                    format!("could not evaluate certificate at commit {}", short(oid))
+                });
+            }
+        }
+    }
+
+    if !relevant {
+        return None; // not a nebula host on either pinned commit
+    }
+
+    // validitySecs comes from the main tip (current policy). Fall back to the
+    // pinned commit that gave us the earliest expiry, then give up.
+    let validity_secs = resolve_validity(
+        repo,
+        host,
+        main_tip,
+        earliest.map(|(_, _, oid)| oid),
+        memo,
+        &mut note,
+    )
+    .await;
+
+    Some(HostExpiry {
+        host: host.to_string(),
+        not_after: earliest.map(|(na, _, _)| na),
+        source: earliest.map(|(_, s, _)| s),
+        validity_secs,
+        note,
+    })
+}
+
+/// Resolve a single `(host, commit)` cert to its expiry, memoizing both the
+/// eval and the parse. `Ok(None)` = nebula disabled there.
+async fn resolve_pin(
+    repo: &Path,
+    oid: Oid,
+    host: &str,
+    memo: &mut Memo,
+) -> Result<Option<DateTime<Utc>>> {
+    let key = (host.to_string(), oid);
+    let cert_path = match memo.cert_paths.get(&key) {
+        Some(cached) => cached.clone(),
+        None => {
+            let resolved = eval_cert_path(repo, oid, host).await?;
+            memo.cert_paths.insert(key, resolved.clone());
+            resolved
+        }
+    };
+
+    let Some(cert_path) = cert_path else {
+        return Ok(None);
+    };
+
+    if let Some(expiry) = memo.expiries.get(&cert_path) {
+        return Ok(Some(*expiry));
+    }
+    let expiry = cert_not_after(&cert_path).await?;
+    memo.expiries.insert(cert_path, expiry);
+    Ok(Some(expiry))
+}
+
+/// Resolve a host's validity policy, preferring the main tip and falling back
+/// to the deployed commit. Records a note (for a degraded alert) if neither
+/// works.
+async fn resolve_validity(
+    repo: &Path,
+    host: &str,
+    main_tip: Option<Oid>,
+    fallback: Option<Oid>,
+    memo: &mut Memo,
+    note: &mut Option<String>,
+) -> Option<u64> {
+    for oid in [main_tip, fallback].into_iter().flatten() {
+        let key = (host.to_string(), oid);
+        if let Some(v) = memo.validities.get(&key) {
+            return Some(*v);
+        }
+        match eval_validity_secs(repo, oid, host).await {
+            Ok(Some(v)) => {
+                memo.validities.insert(key, v);
+                return Some(v);
+            }
+            Ok(None) => {} // disabled here; try the fallback
+            Err(e) => tracing::warn!(%host, %oid, "nebula validitySecs eval failed: {e:#}"),
+        }
+    }
+    note.get_or_insert_with(|| "could not determine certificate validity policy".to_string());
+    None
+}
+
+/// Layer B: turn per-host expiry facts into alerts at the current instant.
+fn compute_alerts(expiries: &[HostExpiry], now: DateTime<Utc>) -> Vec<Alert> {
+    let mut alerts: Vec<Alert> = expiries.iter().filter_map(|e| alert_for(e, now)).collect();
+    // Most severe first.
+    alerts.sort_by_key(|a| std::cmp::Reverse(a.level));
+    alerts
+}
+
+fn alert_for(expiry: &HostExpiry, now: DateTime<Utc>) -> Option<Alert> {
+    let (Some(not_after), Some(validity)) = (expiry.not_after, expiry.validity_secs) else {
+        // Couldn't fully resolve — surface it rather than hide the host.
+        return expiry.note.as_ref().map(|note| Alert {
+            level: AlertLevel::Info,
+            title: format!("Nebula cert for {} could not be evaluated", expiry.host),
+            detail: note.clone(),
+            hosts: vec![expiry.host.clone()],
+        });
+    };
+
+    let remaining = (not_after - now).num_seconds();
+    let source = expiry
+        .source
+        .map(|s| s.as_ref().to_owned())
+        .unwrap_or_else(|| "deployed".to_owned());
+    let when = format!(
+        "{} ({})",
+        crate::web::format_relative_date(not_after).0,
+        not_after.format("%Y-%m-%d %H:%M:%S UTC")
+    );
+    let remediation = "Renew with `ogygia nebula rekey`, then deploy.";
+
+    if remaining <= 0 {
+        return Some(Alert {
+            level: AlertLevel::Critical,
+            title: format!("Nebula cert for {} has EXPIRED", expiry.host),
+            detail: format!("Certificate ({source}) expired {when}. {remediation}"),
+            hosts: vec![expiry.host.clone()],
+        });
+    }
+
+    let fraction = remaining as f64 / validity as f64;
+    let level = if fraction < WARNING_FRACTION {
+        AlertLevel::Warning
+    } else if fraction < INFO_FRACTION {
+        AlertLevel::Info
+    } else {
+        return None; // healthy runway
+    };
+
+    Some(Alert {
+        level,
+        title: format!("Nebula cert for {} expires soon", expiry.host),
+        detail: format!("Certificate ({source}) expires {when}. {remediation}"),
+        hosts: vec![expiry.host.clone()],
+    })
+}
+
+fn short(oid: Oid) -> String {
+    oid.to_string()[..12].to_string()
+}
+
+// --- Nix / nebula-cert primitives -----------------------------------------
+
+/// Locate the `nebula-cert` binary. A Nix build embeds the store path via
+/// `OGYGIA_NEBULA_CERT_BIN` so the derivation carries the runtime dependency;
+/// a plain `cargo build` falls back to `PATH` discovery.
+fn nebula_cert_bin() -> &'static str {
+    option_env!("OGYGIA_NEBULA_CERT_BIN").unwrap_or("nebula-cert")
+}
+
+/// The subset of `ogygia.nebula` we evaluate for a deployed commit.
+#[derive(Debug, Deserialize)]
+struct CertEval {
+    enable: bool,
+    #[serde(rename = "certPath")]
+    cert_path: Option<String>,
+}
+
+/// The subset of `ogygia.nebula` we evaluate for the validity policy.
+#[derive(Debug, Deserialize)]
+struct ValidityEval {
+    enable: bool,
+    #[serde(rename = "validitySecs")]
+    validity_secs: u64,
+}
+
+/// One entry of `nebula-cert print -json` output (a JSON array of certs); only
+/// `details.notAfter` is of interest.
+#[derive(Debug, Deserialize)]
+struct CertPrint {
+    details: CertDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct CertDetails {
+    #[serde(rename = "notAfter")]
+    not_after: DateTime<Utc>,
+}
+
+/// The store path of a host's certificate at a commit, or `None` when the host
+/// has nebula disabled or unconfigured there (no cert to track).
+async fn eval_cert_path(repo: &Path, rev: Oid, host: &str) -> Result<Option<PathBuf>> {
+    let eval: CertEval =
+        nix_eval(repo, rev, host, "cfg: { inherit (cfg) enable certPath; }").await?;
+    if !eval.enable {
+        return Ok(None);
+    }
+    Ok(eval.cert_path.map(PathBuf::from))
+}
+
+/// A host's configured certificate validity period at `rev`, or `None` when the
+/// host has nebula disabled there.
+async fn eval_validity_secs(repo: &Path, rev: Oid, host: &str) -> Result<Option<u64>> {
+    let eval: ValidityEval =
+        nix_eval(repo, rev, host, "cfg: { inherit (cfg) enable validitySecs; }").await?;
+    Ok(eval.enable.then_some(eval.validity_secs))
+}
+
+/// Read a signed Nebula certificate's expiry via `nebula-cert print -json`.
+async fn cert_not_after(cert: &Path) -> Result<DateTime<Utc>> {
+    let output = Command::new(nebula_cert_bin())
+        .arg("print")
+        .arg("-json")
+        .arg("-path")
+        .arg(cert)
+        .output()
+        .await
+        .context("failed to spawn nebula-cert print")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "nebula-cert print {} failed: {}",
+            cert.display(),
+            stderr.trim()
+        ));
+    }
+
+    let printed: Vec<CertPrint> = serde_json::from_slice(&output.stdout).with_context(|| {
+        format!("failed to parse nebula-cert print output for {}", cert.display())
+    })?;
+    let first = printed.into_iter().next().ok_or_else(|| {
+        anyhow!("nebula-cert print returned no certificates for {}", cert.display())
+    })?;
+    Ok(first.details.not_after)
+}
+
+/// `nix eval --json` of `ogygia.nebula` for one host at one commit, transformed
+/// by `apply` and deserialized into `T`.
+///
+/// The commit is addressed as a `git+file://…?rev=` flake so no working-tree
+/// checkout is needed; `allRefs=1` lets Nix find revs that are only reachable
+/// via remote-tracking refs (e.g. archived deployed commits). The host name is
+/// quoted as a single attribute-path component so FQDN attribute names work.
+async fn nix_eval<T: DeserializeOwned>(
+    repo: &Path,
+    rev: Oid,
+    host: &str,
+    apply: &str,
+) -> Result<T> {
+    let installable = format!(
+        "git+file://{repo}?rev={rev}&allRefs=1#nixosConfigurations.\"{host}\".config.ogygia.nebula",
+        repo = repo.display(),
+    );
+
+    let output = Command::new("nix")
+        .args(["eval", "--json"])
+        .arg(&installable)
+        .args(["--apply", apply])
+        .output()
+        .await
+        .with_context(|| format!("failed to spawn nix eval for {installable}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("nix eval {installable} failed: {}", stderr.trim()));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("failed to parse nix eval output for {installable}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host_expiry(remaining_secs: i64, validity: u64) -> HostExpiry {
+        HostExpiry {
+            host: "host1.example.com".to_string(),
+            not_after: Some(Utc::now() + chrono::Duration::seconds(remaining_secs)),
+            source: Some(CommitState::Current),
+            validity_secs: Some(validity),
+            note: None,
+        }
+    }
+
+    const VALIDITY: u64 = 90 * 86400;
+
+    #[test]
+    fn healthy_cert_has_no_alert() {
+        // 60% of a 90-day life remaining -> above the 50% info threshold.
+        let e = host_expiry((VALIDITY as i64) * 60 / 100, VALIDITY);
+        assert!(alert_for(&e, Utc::now()).is_none());
+    }
+
+    #[test]
+    fn below_half_is_info() {
+        let e = host_expiry((VALIDITY as i64) * 40 / 100, VALIDITY);
+        assert_eq!(alert_for(&e, Utc::now()).unwrap().level, AlertLevel::Info);
+    }
+
+    #[test]
+    fn below_quarter_is_warning() {
+        let e = host_expiry((VALIDITY as i64) * 20 / 100, VALIDITY);
+        assert_eq!(alert_for(&e, Utc::now()).unwrap().level, AlertLevel::Warning);
+    }
+
+    #[test]
+    fn expired_is_critical() {
+        let e = host_expiry(-1, VALIDITY);
+        let alert = alert_for(&e, Utc::now()).unwrap();
+        assert_eq!(alert.level, AlertLevel::Critical);
+        assert!(alert.title.contains("EXPIRED"));
+    }
+
+    #[test]
+    fn unresolved_with_note_is_info_degradation() {
+        let e = HostExpiry {
+            host: "host1.example.com".to_string(),
+            not_after: None,
+            source: None,
+            validity_secs: None,
+            note: Some("could not evaluate".to_string()),
+        };
+        assert_eq!(alert_for(&e, Utc::now()).unwrap().level, AlertLevel::Info);
+    }
+
+    #[test]
+    fn unresolved_without_note_is_silent() {
+        let e = HostExpiry {
+            host: "host1.example.com".to_string(),
+            not_after: None,
+            source: None,
+            validity_secs: None,
+            note: None,
+        };
+        assert!(alert_for(&e, Utc::now()).is_none());
+    }
+
+    #[test]
+    fn alerts_are_sorted_most_severe_first() {
+        let expiries = vec![
+            host_expiry((VALIDITY as i64) * 40 / 100, VALIDITY), // info
+            host_expiry(-1, VALIDITY),                           // critical
+            host_expiry((VALIDITY as i64) * 20 / 100, VALIDITY), // warning
+        ];
+        let alerts = compute_alerts(&expiries, Utc::now());
+        let levels: Vec<_> = alerts.iter().map(|a| a.level).collect();
+        assert_eq!(
+            levels,
+            vec![AlertLevel::Critical, AlertLevel::Warning, AlertLevel::Info]
+        );
+    }
+}

--- a/src/ogygia-dashboard/src/web.css
+++ b/src/ogygia-dashboard/src/web.css
@@ -410,3 +410,89 @@ h1 {
     color: #dc2626;
     border: 1px solid #fecaca;
 }
+
+/* Alerts */
+.alerts-section {
+    margin: 20px 0;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #e1e4e8;
+    text-align: left;
+}
+
+.alert {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 14px;
+    margin-bottom: 10px;
+    border: 1px solid;
+    border-left-width: 4px;
+    border-radius: 6px;
+}
+
+.alert:last-child {
+    margin-bottom: 0;
+}
+
+.alert-level {
+    flex-shrink: 0;
+    padding: 2px 10px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.alert-title {
+    font-weight: 600;
+    color: #24292f;
+}
+
+.alert-detail {
+    font-size: 13px;
+    color: #57606a;
+    margin-top: 2px;
+}
+
+.alert .host-badges {
+    margin-top: 6px;
+}
+
+.alert .host-badge {
+    background: #f3f4f6;
+    color: #374151;
+    border: 1px solid #e5e7eb;
+}
+
+.alert-info {
+    background: #ddf4ff;
+    border-color: #b6e3ff;
+}
+
+.alert-info .alert-level {
+    background: #0969da;
+    color: #fff;
+}
+
+.alert-warning {
+    background: #fff8c5;
+    border-color: #fcd34d;
+}
+
+.alert-warning .alert-level {
+    background: #d97706;
+    color: #fff;
+}
+
+.alert-critical {
+    background: #ffebe9;
+    border-color: #ffcecb;
+}
+
+.alert-critical .alert-level {
+    background: #cf222e;
+    color: #fff;
+}

--- a/src/ogygia-dashboard/src/web.rs
+++ b/src/ogygia-dashboard/src/web.rs
@@ -11,6 +11,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use tokio::sync::Mutex;
 
+use crate::alerts::AlertsSnapshot;
 use crate::config::Config;
 use crate::etcd::Etcd;
 use crate::etcd::HostStates;
@@ -44,6 +45,9 @@ pub struct AppState {
     commits_cache: Mutex<Arc<CachedCommits>>,
     html_cache: Mutex<Arc<CachedHtml>>,
     pr_count_cache: Mutex<Arc<CachedPrCount>>,
+    /// Latest alerts, maintained by background producers. Empty when none are
+    /// running (e.g. built without the `nebula` feature).
+    alerts: Arc<Mutex<Arc<AlertsSnapshot>>>,
 }
 
 impl AppState {
@@ -56,10 +60,23 @@ impl AppState {
             crate::archive::spawn(archive, git_manager.clone(), etcd.clone());
         }
 
+        let alerts = Arc::new(Mutex::new(Arc::new(AlertsSnapshot::default())));
+
+        #[cfg(feature = "nebula")]
+        if config.nebula.enable {
+            crate::nebula::spawn(
+                config.clone(),
+                git_manager.clone(),
+                etcd.clone(),
+                alerts.clone(),
+            );
+        }
+
         Ok(Self {
             config,
             git_manager,
             etcd,
+            alerts,
             commits_cache: Mutex::new(Arc::new(CachedCommits {
                 version: 0,
                 commits: Vec::new(),
@@ -194,6 +211,13 @@ impl AppState {
         Ok(html)
     }
 
+    /// Render the current alerts. Cheap string formatting over the background
+    /// snapshot, so it's safe on the request path.
+    async fn alerts_html(&self) -> String {
+        let snapshot = self.alerts.lock().await.clone();
+        crate::alerts::render_alerts_section(&snapshot.alerts, &self.config)
+    }
+
     async fn fetch_pr_count(&self) -> Option<u32> {
         let client = reqwest::Client::new();
         match client.get(self.config.pulls_api_url()).send().await {
@@ -226,6 +250,8 @@ pub async fn index(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         Err(_) => "<p>Error generating git graph</p>".to_string(),
     };
 
+    let alerts_content = state.alerts_html().await;
+
     let title = &state.config.title;
 
     let html = format!(
@@ -239,6 +265,8 @@ pub async fn index(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 <body>
     <div class="container">
         <h1>{title}</h1>
+
+        {alerts_content}
 
         <div class="status-section">
             <div class="git-graph-container">
@@ -651,7 +679,7 @@ fn analyze_commit_structure(commits: &[CommitInfo]) -> CommitGraph {
     CommitGraph { nodes }
 }
 
-fn format_relative_date(timestamp: DateTime<Utc>) -> (String, String) {
+pub(crate) fn format_relative_date(timestamp: DateTime<Utc>) -> (String, String) {
     let now = Utc::now();
     let duration = now.signed_duration_since(timestamp);
 


### PR DESCRIPTION
The dashboard tracked which commit each host runs but had no visibility into Nebula certificate expiry, and no alerts surface at all, so an operator only discovered an aging certificate once the mesh began failing. Renewal is manual (`ogygia nebula rekey --force`), so an early warning is the only signal available before a certificate lapses.

This adds a generic alert subsystem (model plus renderer, always compiled) and a Nebula producer behind a default-on `nebula` cargo feature and a `[nebula]` runtime config gate. A background task evaluates each host's current and nextboot certificate via `nix eval` of `ogygia.nebula.certPath`, reads the expiry with `nebula-cert print`, and keeps the soonest; severity is a fraction of the host's `validitySecs` (evaluated on main so policy changes apply at once) — under 50% informational, under 25% warning, expired critical. Work is kept off the request path with two cache layers: input-keyed evaluation and wall-clock-keyed severity.

Scaling the thresholds by validity keeps the warning windows meaningful as the policy changes, and resolving both pinned certificates rather than reasoning about commit order makes the expiry we surface exactly the one the host depends on.

Test plan:
- New unit tests cover the severity bucketing (info/warning/critical), the expired and degraded-evaluation branches, and most-severe-first ordering.
- `cargo test`, and clippy with the feature both on (default) and off (`--no-default-features`), pass.
- The live `nix eval` / `nebula-cert` path was not exercisable in this environment; the producer degrades to an informational alert on any evaluation failure rather than blanking the section.