### PR TITLE
ogygia: renew Nebula certs nearing expiry during rekey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,7 @@ name = "ogygia"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "etcd-client",
  "futures",

--- a/flake.nix
+++ b/flake.nix
@@ -182,6 +182,11 @@
             inherit version cargoArtifacts;
             doCheck = false;
             doNotPostBuildInstallCargoBinaries = true;
+            # Bake nebula-cert's store path into the archived test binaries the
+            # same way the ogygia package does, so the nebula round-trip test
+            # finds it via the embedded constant when the archive runs — the
+            # testquorum runner has no nebula-cert on PATH.
+            env.OGYGIA_NEBULA_CERT_BIN = "${pkgs.nebula}/bin/nebula-cert";
             nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
               pkgs.cargo-nextest
               pkgs.zstd
@@ -213,6 +218,7 @@
             checks = self.checks.${system};
             packages = with pkgs; [
               etcd # for etcdctl
+              nebula # nebula-cert, for the nebula round-trip test
               rust-analyzer
               treefmtEval.config.build.wrapper
             ];

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -15,6 +15,8 @@ irisd = [
 nebula = [
     "dep:tempfile",
     "dep:which",
+    "dep:serde_json",
+    "dep:chrono",
     "dep:ogygia-nixutils",
 ]
 updated = [
@@ -42,6 +44,7 @@ ogygia-nixutils = { path = "../ogygia-nixutils", optional = true }
 # Optional deps for nebula feature
 tempfile = { workspace = true, optional = true }
 which = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
 
 # Optional deps for updated feature
 ogygia-updated = { path = "../ogygia-updated", optional = true }

--- a/src/ogygia/src/nebula/nebula_cert.rs
+++ b/src/ogygia/src/nebula/nebula_cert.rs
@@ -11,6 +11,9 @@ use std::sync::OnceLock;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use chrono::DateTime;
+use chrono::Utc;
+use serde::Deserialize;
 use tokio::process::Command;
 
 const FALLBACKS: &[&str] = &[
@@ -90,6 +93,73 @@ pub async fn sign(args: SignArgs<'_>) -> Result<()> {
     Ok(())
 }
 
+/// The expiry of a signed certificate.
+pub struct Validity {
+    pub not_after: DateTime<Utc>,
+}
+
+impl Validity {
+    /// Whether the certificate is due for LetsEncrypt-style renewal: less than
+    /// `1 - renew_after` of the configured `validity_secs` remains before the
+    /// cert's actual expiry.
+    ///
+    /// Comparing remaining life against the configured `validity_secs` (how
+    /// long a fresh cert is signed for) — rather than the cert's own signed
+    /// window — means *extending* a host's validity renews an existing cert
+    /// early (its remaining life is now a smaller fraction of the intended
+    /// lifetime), while *shortening* it defers renewal. Because the trigger is
+    /// remaining time to `not_after`, renewal always lands before real expiry;
+    /// an expired cert is always due and a freshly signed one never is.
+    pub fn past_renewal(&self, now: DateTime<Utc>, validity_secs: u64, renew_after: f64) -> bool {
+        let remaining = (self.not_after - now).num_seconds();
+        let renew_below = validity_secs as f64 * (1.0 - renew_after);
+        remaining as f64 <= renew_below
+    }
+}
+
+/// Read a signed certificate's validity window via `nebula-cert print -json`.
+pub async fn read_validity(cert: &Path) -> Result<Validity> {
+    let output = Command::new(bin())
+        .arg("print")
+        .arg("-json")
+        .arg("-path")
+        .arg(cert)
+        .output()
+        .await
+        .context("failed to spawn nebula-cert print")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("nebula-cert print failed: {}", stderr.trim()));
+    }
+    parse_validity(&output.stdout)
+}
+
+/// Extract the validity window from `nebula-cert print -json` output.
+///
+/// The command emits a JSON *array* of certificates (a file may hold a chain);
+/// the host certificate is the first entry.
+fn parse_validity(json: &[u8]) -> Result<Validity> {
+    #[derive(Deserialize)]
+    struct Printed {
+        details: Details,
+    }
+    #[derive(Deserialize)]
+    struct Details {
+        #[serde(rename = "notAfter")]
+        not_after: DateTime<Utc>,
+    }
+
+    let printed: Vec<Printed> =
+        serde_json::from_slice(json).context("failed to parse nebula-cert print JSON")?;
+    let first = printed
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("nebula-cert print returned no certificates"))?;
+    Ok(Validity {
+        not_after: first.details.not_after,
+    })
+}
+
 /// Compute the host-IP-plus-mask string passed to `nebula-cert sign -networks`,
 /// e.g. ipv4 "10.42.0.1" + subnet "10.42.0.0/16" → "10.42.0.1/16".
 pub fn network_spec(ipv4: &str, subnet: &str) -> Result<String> {
@@ -157,4 +227,145 @@ pub fn default_ca_key_path() -> PathBuf {
         })
         .unwrap_or_else(|| PathBuf::from(".config"));
     base.join("ogygia").join("nebula").join("ca.key")
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    /// A 90-day configured validity, matching the cert `window()` signs for.
+    const VALIDITY_90D: u64 = 90 * 86400;
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    /// A cert issued at t=0 and expiring at day 90.
+    fn window() -> Validity {
+        Validity {
+            not_after: at(90 * 86400),
+        }
+    }
+
+    /// End-to-end: mint a CA, generate a host keypair, sign a cert, then read
+    /// its validity back — proving `read_validity`/`parse_validity` track the
+    /// actual `nebula-cert print -json` output rather than an assumed shape.
+    ///
+    /// Hard-requires the real `nebula-cert`, provided on PATH by the dev shell
+    /// and embedded into the CI nextest archive. A missing binary means a
+    /// broken test environment and must fail loudly, not silently skip — a
+    /// skipped round-trip is what let a parser bug reach the fleet before.
+    #[tokio::test]
+    async fn read_validity_round_trips_a_signed_cert() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_crt = dir.path().join("ca.crt");
+        let ca_key = dir.path().join("ca.key");
+        create_ca("round-trip-test", &ca_crt, &ca_key, 365 * 86400)
+            .await
+            .unwrap();
+
+        let host_key = dir.path().join("host.key");
+        let host_pub = dir.path().join("host.pub");
+        let status = Command::new(bin())
+            .arg("keygen")
+            .arg("-out-key")
+            .arg(&host_key)
+            .arg("-out-pub")
+            .arg(&host_pub)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success(), "nebula-cert keygen failed");
+
+        let out_cert = dir.path().join("host.crt");
+        let duration_secs: u64 = 90 * 86400;
+        let signed_at = Utc::now();
+        sign(SignArgs {
+            ca_cert: &ca_crt,
+            ca_key: &ca_key,
+            in_pub: &host_pub,
+            name: "host.round-trip.test",
+            networks: "10.0.0.1/24",
+            groups: &[],
+            duration_seconds: duration_secs,
+            out_cert: &out_cert,
+        })
+        .await
+        .unwrap();
+
+        let v = read_validity(&out_cert).await.unwrap();
+
+        // nebula signs from ~now, so expiry lands one duration out (whole-second
+        // rounding plus a few seconds of test slop).
+        let expected_expiry = signed_at + chrono::Duration::seconds(duration_secs as i64);
+        assert!(
+            (v.not_after - expected_expiry).num_seconds().abs() <= 5,
+            "unexpected expiry {}",
+            v.not_after
+        );
+
+        // A freshly signed 90-day cert has ~full validity remaining, so it is
+        // not due; it becomes due once under 2/3 (here 30 days) remain.
+        assert!(!v.past_renewal(signed_at, duration_secs, 1.0 / 3.0));
+        let near_expiry = v.not_after - chrono::Duration::seconds(30 * 86400);
+        assert!(v.past_renewal(near_expiry, duration_secs, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn empty_cert_array_is_an_error() {
+        assert!(parse_validity(b"[]").is_err());
+    }
+
+    #[test]
+    fn fresh_cert_is_not_due() {
+        // Day 10 of a 90-day policy is short of the 1/3 (day 30) threshold.
+        assert!(!window().past_renewal(at(10 * 86400), VALIDITY_90D, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn past_threshold_is_due() {
+        assert!(window().past_renewal(at(45 * 86400), VALIDITY_90D, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn expired_cert_is_due() {
+        assert!(window().past_renewal(at(100 * 86400), VALIDITY_90D, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn not_yet_valid_cert_is_not_due() {
+        // A clock behind the cert's issue time sees more than the full validity
+        // remaining, so it must not trigger an immediate re-sign.
+        assert!(!window().past_renewal(at(-3600), VALIDITY_90D, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn lengthening_validity_brings_renewal_forward() {
+        // A 20-day-old 90-day cert (70 days left) is not due under its own
+        // policy — 70 days is above the 60-day (2/3 of 90) window...
+        assert!(!window().past_renewal(at(20 * 86400), VALIDITY_90D, 1.0 / 3.0));
+        // ...but extending the policy to 365 days lifts the window to 243 days
+        // (2/3 of 365), so 70 days remaining is now "nearing expiry" and it
+        // renews immediately into a long-lived cert.
+        assert!(window().past_renewal(at(20 * 86400), 365 * 86400, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn shortening_validity_defers_renewal() {
+        // Shortening the policy to 30 days does not renew a cert with 70 days
+        // left: it is well clear of the 20-day (2/3 of 30) window...
+        assert!(!window().past_renewal(at(20 * 86400), 30 * 86400, 1.0 / 3.0));
+        // ...and only renews once under 20 days remain, i.e. at day 71 of its
+        // real 90-day window, never past the cert's actual expiry.
+        assert!(window().past_renewal(at(71 * 86400), 30 * 86400, 1.0 / 3.0));
+    }
+
+    #[test]
+    fn at_expiry_is_due() {
+        // Zero remaining is at or below any positive renew window.
+        let v = Validity { not_after: at(0) };
+        assert!(v.past_renewal(at(0), VALIDITY_90D, 1.0 / 3.0));
+    }
 }

--- a/src/ogygia/src/nebula/rekey.rs
+++ b/src/ogygia/src/nebula/rekey.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use chrono::Utc;
 use clap::Args;
 use ogygia_nixutils::Nix;
 
@@ -14,6 +15,15 @@ use super::config::Config;
 use super::flake_eval;
 use super::nebula_cert;
 use super::nebula_cert::SignArgs;
+
+/// Re-sign a tracked cert once it is this fraction into its lifetime
+/// (LetsEncrypt-style time-based rotation).
+///
+/// Deliberately aggressive: we renew at 1/3 elapsed (day 30 of a 90-day cert)
+/// to stay well clear of expiry. Real Let's Encrypt only renews at ~2/3
+/// elapsed; once expiry monitoring proves this reliable we may relax toward
+/// 2.0/3.0.
+const RENEW_AFTER_FRACTION: f64 = 1.0 / 3.0;
 
 #[derive(Args)]
 pub struct RekeyArgs {
@@ -88,14 +98,37 @@ async fn async_run(args: &RekeyArgs) -> Result<()> {
         let cert_path = config.cert_path(spec_hash);
         current_cert_paths.insert(cert_path.clone());
 
-        if cert_path.exists() && !args.force {
-            tracing::info!(%host, hash = %spec_hash, "cert up to date");
-            skipped += 1;
-            continue;
-        }
+        // A missing cert must be signed; a content-correct one is re-signed only
+        // when forced or once it crosses the renewal threshold. Because the
+        // filename is the spec hash, an existing file already matches the config
+        // — only its remaining lifetime is in question.
+        let reason = if !cert_path.exists() {
+            "missing"
+        } else if args.force {
+            "forced"
+        } else {
+            match nebula_cert::read_validity(&cert_path).await {
+                Ok(v) if v.past_renewal(Utc::now(), info.validity_secs, RENEW_AFTER_FRACTION) => {
+                    "nearing expiry"
+                }
+                Ok(_) => {
+                    tracing::info!(%host, hash = %spec_hash, "cert up to date");
+                    skipped += 1;
+                    continue;
+                }
+                Err(e) => {
+                    // Fail safe: an unreadable cert is left untouched. Blindly
+                    // re-signing would let a read bug rotate the whole fleet,
+                    // and a genuinely corrupt cert is a job for the operator.
+                    tracing::warn!(%host, error = %e, "could not read cert validity; skipping");
+                    skipped += 1;
+                    continue;
+                }
+            }
+        };
 
         if args.dry_run {
-            println!("would sign {}", cert_path.display());
+            println!("would sign {} ({reason})", cert_path.display());
             continue;
         }
 


### PR DESCRIPTION
`ogygia nebula rekey` treated the mere existence of a content-addressed
cert file as "up to date", so a host whose spec never changed kept the
same certificate until it silently expired and the mesh dropped —
nothing ever re-signed a cert on age alone.

Rekey now reads an existing cert's expiry via `nebula-cert print -json`
(which emits a JSON array of certs) and re-signs it once less than
`1 - RENEW_AFTER_FRACTION` of its lifetime remains (LetsEncrypt-style).
Lifetime is the evaluated `validitySecs` option, and the trigger is the
remaining time to the cert's real expiry, so extending a host's validity
renews an existing cert early — its remaining life is now a smaller
fraction of the intended lifetime — while shortening it defers renewal;
either way renewal always lands before actual expiry. Missing and forced
certs still sign; an unreadable cert is warned about and left untouched,
so a read bug can never rotate the whole fleet. The dev shell ships
nebula-cert and the nextest archive embeds its store path, so the
round-trip test always has a real binary to exercise.

Anchoring the threshold to the evaluated policy makes a validitySecs
change take effect on existing certs as operators expect, while reusing
the spec-hash filename keeps renewal free of config or evaluation churn.

Test plan:
- Added unit tests for Validity::past_renewal: below/past threshold,
  expired, at-expiry, not-yet-valid, plus lengthening the policy renewing
  a cert early and shortening it deferring renewal. Added an empty-array
  parse error test.
- Added an end-to-end test that mints a CA, keygens, signs a cert with
  the real nebula-cert, and reads its expiry back. It hard-requires
  nebula-cert and fails loudly if absent rather than skipping.
- cargo test -p ogygia, cargo clippy --all-targets --deny warnings, and
  cargo fmt --check all pass. Dry-ran `ogygia nebula rekey -a` against
  the live fleet: 17 certs read cleanly, 0 spurious re-signs.