### PR TITLE
ogygia: complete subcommands and flags in the shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +1913,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "etcd-client",
  "futures",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "ogygia-workspace"
 [workspace.dependencies]
 # CLI and config
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 anyhow = "1.0"
 humantime = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/flake.nix
+++ b/flake.nix
@@ -137,8 +137,17 @@
             # carries a runtime dependency on nebula. Only set here, so plain
             # cargo builds (e.g. the dev shell) keep runtime PATH discovery.
             env.OGYGIA_NEBULA_CERT_BIN = "${pkgs.nebula}/bin/nebula-cert";
+            nativeBuildInputs = individualCrateArgs.nativeBuildInputs ++ [ pkgs.installShellFiles ];
+            # The completion shims are emitted by the binary itself, so this
+            # runs after patchelf has made it loadable. Each shim embeds the
+            # store path it was generated from, leaving no way for the
+            # completions and the binary they call to drift apart.
             postInstall = ''
               ${pkgs.patchelf}/bin/patchelf --set-rpath "${lib.makeLibraryPath [ pkgs.openssl ]}" $out/bin/ogygia
+              installShellCompletion --cmd ogygia \
+                --bash <(COMPLETE=bash $out/bin/ogygia) \
+                --zsh <(COMPLETE=zsh $out/bin/ogygia) \
+                --fish <(COMPLETE=fish $out/bin/ogygia)
             '';
           });
 

--- a/src/ogygia/Cargo.toml
+++ b/src/ogygia/Cargo.toml
@@ -26,6 +26,7 @@ updated = [
 
 [dependencies]
 clap = { workspace = true }
+clap_complete = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }

--- a/src/ogygia/src/main.rs
+++ b/src/ogygia/src/main.rs
@@ -36,8 +36,10 @@ mod update;
 use std::process;
 
 use anyhow::Result;
+use clap::CommandFactory as _;
 use clap::Parser;
 use clap::Subcommand;
+use clap_complete::CompleteEnv;
 use tracing::error;
 use tracing_subscriber::EnvFilter;
 
@@ -79,6 +81,11 @@ impl Command {
 }
 
 fn main() {
+    // Serves the shell shim's COMPLETE=<shell> invocations and exits. Runs
+    // before logging is set up so no diagnostic can reach the candidate
+    // stream; a no-op when COMPLETE is unset.
+    CompleteEnv::with_factory(Cli::command).complete();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env()

--- a/src/ogygia/tests/completions.rs
+++ b/src/ogygia/tests/completions.rs
@@ -1,0 +1,59 @@
+//! Guards the contract between the installed completion shims and the binary.
+//!
+//! `clap_complete`'s dynamic engine sits behind an unstable feature, and the
+//! protocol exercised here is the one the shims in `share/` speak. A breaking
+//! upgrade otherwise surfaces as completions that silently stop producing
+//! candidates, which nothing else in the build would catch.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The binary under test.
+///
+/// `CARGO_BIN_EXE_ogygia` is substituted at compile time and points into the
+/// build tree, which is gone by the time a nextest archive is unpacked on the
+/// runner. Nextest republishes the extracted binary through the same variable
+/// at run time, so that takes precedence when it is set.
+fn ogygia() -> PathBuf {
+    env::var_os("CARGO_BIN_EXE_ogygia")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_BIN_EXE_ogygia")))
+}
+
+#[test]
+fn emits_a_registration_shim_per_shell() {
+    for shell in ["bash", "zsh", "fish"] {
+        let output = Command::new(ogygia())
+            .env("COMPLETE", shell)
+            .output()
+            .expect("running ogygia");
+
+        assert!(output.status.success(), "{shell} shim failed: {output:?}");
+        let shim = String::from_utf8(output.stdout).expect("shim is utf-8");
+        assert!(
+            shim.contains("ogygia"),
+            "{shell} shim does not reference the command: {shim}"
+        );
+    }
+}
+
+#[test]
+fn answers_the_shim_with_filtered_candidates() {
+    // `status` carries no feature gate, so this asserts the engine responds
+    // rather than asserting which subcommands happen to be compiled in.
+    let candidates = |word: &str| {
+        let output = Command::new(ogygia())
+            .env("COMPLETE", "bash")
+            .env("_CLAP_COMPLETE_INDEX", "1")
+            .args(["--", "ogygia", word])
+            .output()
+            .expect("running ogygia");
+
+        assert!(output.status.success(), "completion failed: {output:?}");
+        String::from_utf8(output.stdout).expect("candidates are utf-8")
+    };
+
+    assert!(candidates("").lines().any(|line| line == "status"));
+    assert_eq!(candidates("stat").lines().collect::<Vec<_>>(), ["status"]);
+}


### PR DESCRIPTION
ogygia shipped no shell completions, so subcommands and flags had to be
recalled from memory or looked up with --help. A statically generated
script cannot serve the case that motivates this work, completing the
branch argument of `ogygia update canary`, because that value is only
knowable at completion time.

This commit adopts clap_complete's dynamic completion engine. CompleteEnv
runs as the first statement in main, so COMPLETE=<shell> invocations are
served before the tracing subscriber exists and no diagnostic can reach
the candidate stream. The ogygia package gains installShellFiles and
emits bash, zsh, and fish shims by running the freshly patchelf'd binary,
which embeds its own store path in each shim.

Driving completion from the binary rather than a generated script makes
subcommand and flag candidates correct by construction, and leaves the
per-argument hook free for value completers that must consult runtime
state. Generating the shims inside the derivation that builds the binary
means the two are switched together and cannot drift.

Test plan:
- New tests/completions.rs covers the two things nothing else would
  catch if an unstable-dynamic upgrade broke them: that a registration
  shim is emitted for each shell, and that the engine answers a shim
  invocation with prefix-filtered candidates. It deliberately asserts
  only on the ungated `status` subcommand, so enabling or disabling a
  feature cannot make it fail for reasons unrelated to completion.
- Those tests resolve the binary from CARGO_BIN_EXE_ogygia at run time,
  falling back to the compile-time value. The baked-in path points into
  the build tree, which does not exist once the nextest archive is
  unpacked on the runner; nextest republishes the extracted binary
  through the same variable. Verified by running the archive with
  --workspace-remap rather than only under cargo test, where the
  distinction is invisible.
- cargo fmt --check and cargo clippy -p ogygia --all-targets are clean.
- nix build .#ogygia succeeds and installs shims to
  share/bash-completion/completions/ogygia.bash,
  share/zsh/site-functions/_ogygia, and
  share/fish/vendor_completions.d/ogygia.fish, each referencing the
  binary by its store path.