### PR TITLE
ogygia: complete canary branch names from the tracked remote

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -282,6 +282,12 @@
               ogygiaModule = self.nixosModules.default;
             };
 
+            ogygia-updated-config = import ./nixos/tests/updated-config.nix {
+              inherit pkgs;
+              inherit (nixpkgs) lib;
+              ogygiaModule = self.nixosModules.default;
+            };
+
             ogygia-nebula-module = import ./nixos/tests/nebula-module.nix {
               inherit pkgs;
               inherit (nixpkgs) lib;

--- a/nixos/tests/updated-config.nix
+++ b/nixos/tests/updated-config.nix
@@ -1,0 +1,57 @@
+{ pkgs, lib, ogygiaModule }:
+
+let
+  system = lib.nixosSystem {
+    modules = [
+      { nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system; }
+      ogygiaModule
+      {
+        ogygia.enable = true;
+        ogygia.domain = "neb.test";
+        ogygia.gitRemoteUrl = "https://git.neb.test/user/nixos.git";
+        ogygia.updated.enable = true;
+        networking.hostName = "host";
+        networking.domain = "neb.test";
+      }
+    ];
+  };
+
+  etcEntry = system.config.environment.etc."ogygia/updated.toml";
+  execStart = system.config.systemd.services.ogygia-updated.serviceConfig.ExecStart;
+
+  # `ogygia update canary` locates this file through a constant compiled into
+  # the CLI. Nothing at runtime reconciles the two, and a mismatch degrades
+  # silently to no branch candidates, so pin them together here.
+  cliDefaultPath = builtins.head (builtins.match
+    ".*DEFAULT_CONFIG_PATH: &str = \"([^\"]+)\";.*"
+    (builtins.readFile ../../src/ogygia-updated/src/config.rs));
+in
+pkgs.runCommand "ogygia-updated-config"
+{
+  nativeBuildInputs = [ pkgs.python3 ];
+} ''
+  ${lib.optionalString (cliDefaultPath != "/etc/ogygia/updated.toml") (throw ''
+    The CLI's DEFAULT_CONFIG_PATH is "${cliDefaultPath}" but the module renders
+    the daemon config to /etc/ogygia/updated.toml. Branch completion for
+    `ogygia update canary` reads the CLI's path, so these must agree.
+  '')}
+
+  # The daemon and the CLI must read the same file, not two copies that can
+  # drift; the unit is what proves the daemon uses the well-known path.
+  case "${execStart}" in
+    *" --config ${cliDefaultPath}") ;;
+    *) echo "ExecStart does not use ${cliDefaultPath}: ${execStart}" >&2; exit 1 ;;
+  esac
+
+  python3 - <<'PY'
+  import tomllib
+  from pathlib import Path
+
+  data = tomllib.loads(Path("${etcEntry.source}").read_text())
+  assert data["repo"]["url"] == "https://git.neb.test/user/nixos.git", data
+  assert data["host"]["name"] == "host.neb.test", data
+  PY
+
+  mkdir -p $out
+  cp "${etcEntry.source}" "$out/updated.toml"
+''

--- a/nixos/updated/default.nix
+++ b/nixos/updated/default.nix
@@ -69,6 +69,11 @@ in
       host.name = lib.mkDefault config.networking.fqdn;
     };
 
+    # Rendered to a stable path rather than only interpolated into the unit,
+    # so `ogygia update canary` can read repo.url to complete branch names
+    # without needing the daemon to be running.
+    environment.etc."ogygia/updated.toml".source = configFile;
+
     systemd.services.ogygia-updated = {
       description = "Ogygia Automatic Update Daemon";
       wantedBy = [ "multi-user.target" ];
@@ -85,7 +90,7 @@ in
       path = [ config.nix.package config.systemd.package ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/ogygia-updated --config ${configFile}";
+        ExecStart = "${cfg.package}/bin/ogygia-updated --config /etc/ogygia/updated.toml";
         Restart = "always";
         RestartSec = "5s";
         StateDirectory = "ogygia-updated";

--- a/src/ogygia-updated/src/branches.rs
+++ b/src/ogygia-updated/src/branches.rs
@@ -1,0 +1,133 @@
+//! Branch names available to trial with `ogygia update canary`.
+
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+use git2::BranchType;
+use git2::Direction;
+use git2::Remote;
+use git2::Repository;
+
+use crate::config::Config;
+
+/// Bounds on the remote query. Completion is interactive, so an unreachable
+/// remote must fail fast enough to fall back rather than stall the terminal.
+const CONNECT_TIMEOUT_MS: i32 = 750;
+const OPERATION_TIMEOUT_MS: i32 = 1_500;
+
+/// Branch names to offer for a canary, sorted.
+///
+/// Prefers the remote, which is authoritative for a branch pushed moments
+/// ago, and falls back to the daemon's clone when the remote is slow or
+/// unreachable. Yields an empty list rather than an error because the caller
+/// is shell completion, where a diagnostic would corrupt the candidates.
+pub fn list(config: &Config) -> Vec<String> {
+    list_remote(&config.repo.url)
+        .or_else(|_| list_cloned(&config.repo_path()))
+        .unwrap_or_default()
+}
+
+/// Branch names on the remote, without cloning it.
+pub fn list_remote(url: &str) -> Result<Vec<String>> {
+    // SAFETY: these set process-global libgit2 options. Completion is
+    // single-threaded and does no other libgit2 work concurrently.
+    unsafe {
+        git2::opts::set_server_connect_timeout_in_milliseconds(CONNECT_TIMEOUT_MS)
+            .context("setting connect timeout")?;
+        git2::opts::set_server_timeout_in_milliseconds(OPERATION_TIMEOUT_MS)
+            .context("setting operation timeout")?;
+    }
+
+    let mut remote = Remote::create_detached(url).with_context(|| format!("resolving {url}"))?;
+    remote
+        .connect(Direction::Fetch)
+        .with_context(|| format!("connecting to {url}"))?;
+
+    let mut branches: Vec<String> = remote
+        .list()
+        .with_context(|| format!("listing refs on {url}"))?
+        .iter()
+        .filter_map(|head| head.name().strip_prefix("refs/heads/"))
+        .map(str::to_owned)
+        .collect();
+    remote.disconnect().context("disconnecting")?;
+
+    branches.sort();
+    Ok(branches)
+}
+
+/// Branch names the daemon's clone last mirrored from the remote.
+pub fn list_cloned(path: &Path) -> Result<Vec<String>> {
+    let repository =
+        Repository::open(path).with_context(|| format!("opening repository {}", path.display()))?;
+
+    let mut branches = Vec::new();
+    for branch in repository.branches(Some(BranchType::Remote))? {
+        let (branch, _) = branch?;
+        // `origin/HEAD` is a symbolic ref, not a branch anyone can trial.
+        if let Some(name) = branch.name()?.and_then(|name| name.strip_prefix("origin/"))
+            && name != "HEAD"
+        {
+            branches.push(name.to_owned());
+        }
+    }
+
+    branches.sort();
+    Ok(branches)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::repo::Repo;
+    use crate::repo::testutil::commit;
+    use crate::repo::testutil::init_origin;
+
+    #[test]
+    fn lists_remote_branches_without_cloning() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let (origin, initial) = init_origin(&origin_path);
+        commit(&origin, "jh/canary", &[initial], "canary");
+
+        let branches = list_remote(origin_path.to_str().unwrap()).unwrap();
+
+        assert_eq!(branches, ["jh/canary", "main"]);
+        // Nothing was written next to the caller's cwd or the origin.
+        assert!(!origin_path.join("clone").exists());
+    }
+
+    #[test]
+    fn remote_listing_fails_for_an_unreachable_url() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+
+        assert!(list_remote(missing.to_str().unwrap()).is_err());
+    }
+
+    #[test]
+    fn lists_cloned_branches_without_the_origin_head_ref() {
+        let dir = TempDir::new().unwrap();
+        let origin_path = dir.path().join("origin");
+        let clone_path = dir.path().join("clone");
+        let (origin, initial) = init_origin(&origin_path);
+        commit(&origin, "jh/canary", &[initial], "canary");
+
+        let repo = Repo::open_or_clone(&clone_path, origin_path.to_str().unwrap()).unwrap();
+        repo.fetch().unwrap();
+
+        let branches = list_cloned(&clone_path).unwrap();
+
+        assert_eq!(branches, ["jh/canary", "main"]);
+    }
+
+    #[test]
+    fn cloned_listing_fails_when_the_daemon_has_no_clone_yet() {
+        let dir = TempDir::new().unwrap();
+
+        assert!(list_cloned(&dir.path().join("absent")).is_err());
+    }
+}

--- a/src/ogygia-updated/src/config.rs
+++ b/src/ogygia-updated/src/config.rs
@@ -6,6 +6,10 @@ use anyhow::Context;
 use anyhow::Result;
 use serde::Deserialize;
 
+/// Where the NixOS module renders the daemon's configuration. Stable so
+/// that `ogygia update` can read `repo.url` without asking the daemon.
+pub const DEFAULT_CONFIG_PATH: &str = "/etc/ogygia/updated.toml";
+
 /// Daemon configuration, deserialized from TOML.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/ogygia-updated/src/lib.rs
+++ b/src/ogygia-updated/src/lib.rs
@@ -11,6 +11,7 @@
 //! an interval; `ogygia update` asks it to run a cycle now over its
 //! control socket.
 
+pub mod branches;
 pub mod control;
 
 mod canary;
@@ -23,6 +24,7 @@ pub use canary::CanaryState;
 pub use canary::CanaryTarget;
 pub use canary::FinishReason;
 pub use config::Config;
+pub use config::DEFAULT_CONFIG_PATH;
 pub use engine::Outcome;
 pub use engine::Trigger;
 pub use engine::run_once;

--- a/src/ogygia/src/update/mod.rs
+++ b/src/ogygia/src/update/mod.rs
@@ -1,5 +1,7 @@
 //! Client for the ogygia-updated daemon: manual updates and canaries.
 
+use std::env;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -8,6 +10,12 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
 use clap::Subcommand;
+use clap_complete::engine::ArgValueCompleter;
+use clap_complete::engine::CompletionCandidate;
+
+/// Environment override for the daemon configuration the branch completer
+/// reads, mirroring `OGYGIA_CONFIG` for the CLI's own config.
+const CONFIG_OVERRIDE_ENV: &str = "OGYGIA_UPDATED_CONFIG";
 
 /// Drive the ogygia-updated daemon (root only). With no subcommand, reset
 /// the host to the tracked branch tip now.
@@ -32,6 +40,7 @@ enum UpdateCommand {
 #[command(args_conflicts_with_subcommands = true)]
 struct CanaryArgs {
     /// Branch to trial; its tip is pinned onto this host now
+    #[arg(add = ArgValueCompleter::new(complete_branch))]
     branch: Option<String>,
 
     /// How long to hold the trial before reverting (e.g. 24h, 90m, 2d)
@@ -55,6 +64,31 @@ struct CanaryArgs {
 enum CanaryCommand {
     /// Show the current or most-recent canary
     Status,
+}
+
+/// Branches the daemon could pin onto this host, for shell completion.
+///
+/// Reads the daemon's configuration for its remote rather than asking the
+/// daemon itself, so completion works whatever state the service is in. Any
+/// failure yields no candidates: this writes to the shell's completion
+/// stream, where an error message would be offered as a branch name.
+fn complete_branch(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some(prefix) = current.to_str() else {
+        return Vec::new();
+    };
+
+    let path = env::var_os(CONFIG_OVERRIDE_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(ogygia_updated::DEFAULT_CONFIG_PATH));
+    let Ok(config) = ogygia_updated::Config::load(&path) else {
+        return Vec::new();
+    };
+
+    ogygia_updated::branches::list(&config)
+        .into_iter()
+        .filter(|branch| branch.starts_with(prefix))
+        .map(CompletionCandidate::new)
+        .collect()
 }
 
 impl UpdateArgs {


### PR DESCRIPTION
`ogygia update canary` takes a branch name that had to be typed from memory, with a typo surfacing only as a rejected request to the daemon. The candidates are knowable only at completion time, and the CLI had no way to reach them: the daemon's configuration, which names the remote, existed solely as a store path interpolated into its systemd unit.

This commit renders that configuration to /etc/ogygia/updated.toml and points the unit at it, so the daemon and the CLI read one file rather than two copies that can drift. A new ogygia-updated::branches module lists refs through a detached libgit2 remote, which is ls-remote with no repository behind it, and falls back to the daemon's existing clone when the remote is slow or unreachable; libgit2's connect and operation timeouts bound the interactive path. The canary branch argument gains an ArgValueCompleter that resolves repo.url from the config and filters that list by prefix.

Querying the remote keeps the freshly pushed branch, which is the one a canary is usually for, in the candidate list where the clone's hourly refresh would miss it. Reading the config instead of adding a control socket request keeps completion a pure function of on-disk state, so it answers whatever state the daemon is in and needs no privilege beyond reading /etc.

Test plan:
- New branches unit tests cover listing a remote without leaving a clone behind, listing the daemon's clone while excluding the origin/HEAD symbolic ref, and the failure of each source that triggers the fallback.
- New nixos/tests/updated-config.nix asserts the rendered TOML, that ExecStart consumes the well-known path, and that the CLI's compiled-in DEFAULT_CONFIG_PATH agrees with the path the module writes. Confirmed the last guard fails by temporarily pointing the constant elsewhere, since a silent mismatch would degrade to empty completions.
- Manually, against a local origin holding main, two jh/* branches and a release/* branch: completion offered all four sorted alongside the status subcommand, the jh/ prefix narrowed it to two, an absent config returned only subcommands and flags at exit 0, and an unreachable remote with a populated clone still answered from the clone in ~10ms.
- cargo fmt --check, cargo clippy --workspace --all-targets --deny warnings, and cargo test --workspace are clean.