### PR TITLE
updated: add --persist to hold a canary across a reboot

### DIFF
--- a/src/ogygia-updated/src/canary.rs
+++ b/src/ogygia-updated/src/canary.rs
@@ -30,6 +30,20 @@ pub enum CanaryTarget {
     // Following { branch: String },  // future: re-resolve the tip each cycle
 }
 
+/// How a trial is held on the host, and so what a reboot does to it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum CanaryHold {
+    /// An ephemeral test activation, with a safe floor staged for boot. A
+    /// reboot loses the activation and ends the trial, which is why the
+    /// boot id it started in is recorded.
+    Ephemeral { boot_id: String },
+    /// The trial is the boot default, so it survives a reboot — the only
+    /// way to exercise a new kernel or new boot flags. Nothing is staged
+    /// to fall back to, so there is no boot id worth comparing.
+    Persistent,
+}
+
 /// Lifecycle of the current or most-recent canary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
@@ -39,9 +53,7 @@ pub enum CanaryState {
         target: CanaryTarget,
         /// Absolute deadline; `None` for a canary with no timeout.
         expires_at: Option<DateTime<Utc>>,
-        /// Kernel boot id when the trial began. A change means the host
-        /// rebooted, losing the trial's ephemeral test activation.
-        boot_id: String,
+        hold: CanaryHold,
     },
     /// A trial that ended, retained so `canary status` can explain how.
     Finished {
@@ -96,15 +108,15 @@ impl CanaryState {
         Ok(Some(state))
     }
 
-    /// A human-readable status line. `running` and `boot_floor` are the
+    /// A human-readable status line. `running` and `next_boot` are the
     /// commits the host currently runs and will next boot; they are only
     /// rendered for an in-progress trial.
-    pub fn describe(&self, now: DateTime<Utc>, running: &str, boot_floor: &str) -> String {
+    pub fn describe(&self, now: DateTime<Utc>, running: &str, next_boot: &str) -> String {
         match self {
             CanaryState::Active {
                 target: CanaryTarget::Pinned { branch, commit },
                 expires_at,
-                ..
+                hold,
             } => {
                 let expiry = match expires_at {
                     Some(at) => format!(
@@ -114,9 +126,15 @@ impl CanaryState {
                     ),
                     None => "no timeout".to_string(),
                 };
-                format!(
-                    "trialling {branch} @{commit}; running {running}, boot floor {boot_floor}; {expiry}"
-                )
+                // An ephemeral trial's next-boot commit is the floor it
+                // falls back to; a persistent one's is the trial itself.
+                let boot = match hold {
+                    CanaryHold::Ephemeral { .. } => format!("boot floor {next_boot}"),
+                    CanaryHold::Persistent => {
+                        format!("boot default {next_boot}, kept across reboot")
+                    }
+                };
+                format!("trialling {branch} @{commit}; running {running}, {boot}; {expiry}")
             }
             CanaryState::Finished {
                 target: CanaryTarget::Pinned { branch, commit },
@@ -153,6 +171,22 @@ mod tests {
         assert!(CanaryState::load(&path).unwrap().is_none());
     }
 
+    /// State written before `hold` existed carries a bare `boot_id`, which
+    /// no longer parses. The engine turns that into "no active trial" so a
+    /// host is not wedged by it; this pins the loud half of that contract.
+    #[test]
+    fn state_written_before_hold_is_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("canary.json");
+        fs::write(
+            &path,
+            r#"{"state":"active","target":{"mode":"pinned","branch":"feature","commit":"abc"},"expires_at":null,"boot_id":"boot-1"}"#,
+        )
+        .unwrap();
+
+        assert!(CanaryState::load(&path).is_err());
+    }
+
     #[test]
     fn active_and_finished_round_trip() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -165,7 +199,9 @@ mod tests {
         let active = CanaryState::Active {
             target: target.clone(),
             expires_at: Some("2026-07-18T12:00:00Z".parse().unwrap()),
-            boot_id: "boot-1".to_string(),
+            hold: CanaryHold::Ephemeral {
+                boot_id: "boot-1".to_string(),
+            },
         };
         active.store(&path).unwrap();
         assert!(matches!(
@@ -200,10 +236,14 @@ mod tests {
             commit: "abc".to_string(),
         };
 
+        let ephemeral = CanaryHold::Ephemeral {
+            boot_id: "boot-1".to_string(),
+        };
+
         let active = CanaryState::Active {
             target: target.clone(),
             expires_at: Some("2026-07-18T00:00:00Z".parse().unwrap()),
-            boot_id: "boot-1".to_string(),
+            hold: ephemeral.clone(),
         };
         assert_eq!(
             active.describe(now, "def", "ghi"),
@@ -213,11 +253,22 @@ mod tests {
         let forever = CanaryState::Active {
             target: target.clone(),
             expires_at: None,
-            boot_id: "boot-1".to_string(),
+            hold: ephemeral,
         };
         assert_eq!(
             forever.describe(now, "def", "ghi"),
             "trialling feature @abc; running def, boot floor ghi; no timeout"
+        );
+
+        // A persistent trial is the next-boot system, not a floor under it.
+        let persistent = CanaryState::Active {
+            target: target.clone(),
+            expires_at: None,
+            hold: CanaryHold::Persistent,
+        };
+        assert_eq!(
+            persistent.describe(now, "abc", "abc"),
+            "trialling feature @abc; running abc, boot default abc, kept across reboot; no timeout"
         );
 
         let finished = CanaryState::Finished {

--- a/src/ogygia-updated/src/control.rs
+++ b/src/ogygia-updated/src/control.rs
@@ -37,10 +37,12 @@ pub enum Request {
     Update,
     /// Trial `branch`: pin its tip and hold the host there until `timeout`
     /// seconds pass (no timeout if `None`), the commit merges, or an
-    /// update supersedes it.
+    /// update supersedes it. `persist` also makes it the boot default, so
+    /// a reboot does not end it.
     Canary {
         branch: String,
         timeout: Option<u64>,
+        persist: bool,
     },
     /// Report the current or most-recent canary without running a cycle.
     CanaryStatus,
@@ -57,9 +59,21 @@ pub fn request_update(socket_path: &Path) -> Result<String> {
 }
 
 /// Start a canary trialling `branch`, held for `timeout` seconds (no
-/// timeout if `None`).
-pub fn request_canary(socket_path: &Path, branch: String, timeout: Option<u64>) -> Result<String> {
-    send(socket_path, &Request::Canary { branch, timeout })
+/// timeout if `None`). `persist` keeps the trial across a reboot.
+pub fn request_canary(
+    socket_path: &Path,
+    branch: String,
+    timeout: Option<u64>,
+    persist: bool,
+) -> Result<String> {
+    send(
+        socket_path,
+        &Request::Canary {
+            branch,
+            timeout,
+            persist,
+        },
+    )
 }
 
 /// Ask the daemon to describe the current or most-recent canary.
@@ -171,6 +185,7 @@ mod tests {
                 Request::Canary {
                     branch: "feature".to_string(),
                     timeout: Some(3600),
+                    persist: true,
                 }
             );
             respond(&mut stream, Err("no such branch".to_string()));
@@ -181,7 +196,8 @@ mod tests {
         });
 
         assert_eq!(request_update(&socket_path).unwrap(), "switched to abc");
-        let error = request_canary(&socket_path, "feature".to_string(), Some(3600)).unwrap_err();
+        let error =
+            request_canary(&socket_path, "feature".to_string(), Some(3600), true).unwrap_err();
         assert_eq!(error.to_string(), "no such branch");
         assert_eq!(request_canary_status(&socket_path).unwrap(), "no canary");
         server.join().unwrap();

--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -12,6 +12,7 @@ use git2::Oid;
 use tracing::info;
 use tracing::warn;
 
+use crate::canary::CanaryHold;
 use crate::canary::CanaryState;
 use crate::canary::CanaryTarget;
 use crate::canary::FinishReason;
@@ -40,16 +41,17 @@ pub enum Outcome {
     /// The cache-warm closure could not be substituted, so the cycle was
     /// skipped rather than built locally. Retried on the next cycle.
     PrefetchUnavailable { commit: String },
-    /// A canary was started: the commit runs while a safe boot floor is
-    /// staged for the next reboot.
+    /// A canary was started: the commit runs, and `next_boot` is what a
+    /// reboot lands on — a safe floor, or the trial itself when it persists.
     CanaryStarted {
         commit: String,
-        floor: String,
+        next_boot: String,
+        persist: bool,
         expires_at: Option<DateTime<Utc>>,
     },
     /// A scheduled cycle held the running trial in place, keeping the boot
     /// floor current without touching the running system.
-    CanaryHeld { commit: String, floor: String },
+    CanaryHeld { commit: String, next_boot: String },
 }
 
 impl fmt::Display for Outcome {
@@ -77,17 +79,22 @@ impl fmt::Display for Outcome {
             }
             Outcome::CanaryStarted {
                 commit,
-                floor,
+                next_boot,
+                persist,
                 expires_at,
             } => {
-                write!(f, "trialling {commit}; boot floor {floor}; ")?;
+                if *persist {
+                    write!(f, "trialling {commit}, staged for boot; ")?;
+                } else {
+                    write!(f, "trialling {commit}; boot floor {next_boot}; ")?;
+                }
                 match expires_at {
                     Some(at) => write!(f, "expires {}", at.format("%Y-%m-%d %H:%MZ")),
                     None => write!(f, "no timeout"),
                 }
             }
-            Outcome::CanaryHeld { commit, floor } => {
-                write!(f, "holding canary {commit}; boot floor {floor}")
+            Outcome::CanaryHeld { commit, next_boot } => {
+                write!(f, "holding canary {commit}; boot floor {next_boot}")
             }
         }
     }
@@ -121,10 +128,12 @@ pub enum Trigger {
     Manual,
     /// An operator asked to trial `branch`. Its tip is pinned now and the
     /// host is held there until the timeout elapses, the commit merges, or
-    /// a manual update supersedes it.
+    /// a manual update supersedes it. `persist` makes the trial the boot
+    /// default so it also survives a reboot.
     StartCanary {
         branch: String,
         timeout: Option<Duration>,
+        persist: bool,
     },
 }
 
@@ -143,15 +152,30 @@ fn run(
     let repo = Repo::open_or_clone(&config.repo_path(), &config.repo.url)?;
     repo.fetch()?;
     let main_tip = repo.tip(&config.repo.branch)?;
-    let canary = CanaryState::load(&config.canary_state_path())?;
+    // Unreadable state must not wedge the host: failing the cycle would
+    // stall every future one too, so an unparseable record is reported and
+    // treated as no trial, letting the guarded tracking path resume.
+    let canary = CanaryState::load(&config.canary_state_path()).unwrap_or_else(|error| {
+        warn!(%error, "unreadable canary state; treating it as no active trial");
+        None
+    });
     info!(%main_tip, branch = %config.repo.branch, ?trigger, "fetched");
 
     match trigger {
-        Trigger::StartCanary { branch, timeout } => {
+        Trigger::StartCanary {
+            branch,
+            timeout,
+            persist,
+        } => {
             let expires_at = timeout.map(|d| now + chrono::Duration::seconds(d.as_secs() as i64));
-            start_canary(
-                config, system, &repo, boot_id, main_tip, &branch, expires_at,
-            )
+            let hold = if persist {
+                CanaryHold::Persistent
+            } else {
+                CanaryHold::Ephemeral {
+                    boot_id: boot_id.to_string(),
+                }
+            };
+            start_canary(config, system, &repo, main_tip, &branch, expires_at, hold)
         }
         Trigger::Manual => {
             if let Some(CanaryState::Active { target, .. }) = &canary {
@@ -190,7 +214,7 @@ fn scheduled(
     let Some(CanaryState::Active {
         target,
         expires_at,
-        boot_id: started_boot,
+        hold,
     }) = canary
     else {
         return update_to_tip(config, system, repo, main_tip, false);
@@ -198,11 +222,15 @@ fn scheduled(
 
     let commit = target_commit(&target)?;
 
-    // A reboot loses the ephemeral test activation, so the trial is over.
+    // A reboot loses an ephemeral test activation, so that trial is over.
     // This outranks merge and expiry, which may both have come true while
     // the host was down. The trial is never reapplied; we record the reason
     // and resume normal tracking this cycle, rolling forward from the floor.
-    if boot_id != started_boot {
+    // A persistent trial is the boot default and comes back up on it, so a
+    // reboot is the point rather than the end.
+    if let CanaryHold::Ephemeral { boot_id: started } = &hold
+        && boot_id != started
+    {
         finish_canary(config, now, &target, FinishReason::Rebooted)?;
         info!("canary host rebooted; ending the trial and resuming the tracked branch");
         return update_to_tip(config, system, repo, main_tip, false);
@@ -232,41 +260,68 @@ fn scheduled(
         return update_to_tip(config, system, repo, main_tip, true);
     }
 
-    // Hold the trial open: keep the boot floor recent, but never re-drive
-    // the running system.
-    let floor = stage_boot_floor(config, system, repo, commit, main_tip)?;
+    // Hold the trial open without re-driving the running system: keep an
+    // ephemeral trial's floor recent, while a persistent trial already owns
+    // the boot default and needs nothing staged under it.
+    let next_boot = match hold {
+        CanaryHold::Ephemeral { .. } => stage_boot_floor(config, system, repo, commit, main_tip)?,
+        CanaryHold::Persistent => commit,
+    };
     Ok(Outcome::CanaryHeld {
         commit: commit.to_string(),
-        floor: floor.to_string(),
+        next_boot: next_boot.to_string(),
     })
 }
 
-/// Pin `branch`'s tip and hold the host on it.
+/// Pin `branch`'s tip and hold the host on it. A `Persistent` hold trades
+/// the boot floor for the trial itself as the boot default, so it survives
+/// a reboot.
 fn start_canary(
     config: &Config,
     system: &impl System,
     repo: &Repo,
-    boot_id: &str,
     main_tip: Oid,
     branch: &str,
     expires_at: Option<DateTime<Utc>>,
+    hold: CanaryHold,
 ) -> Result<Outcome> {
     let commit = repo.tip(branch)?;
+    let persist = matches!(hold, CanaryHold::Persistent);
     CanaryState::Active {
         target: CanaryTarget::Pinned {
             branch: branch.to_string(),
             commit: commit.to_string(),
         },
         expires_at,
-        boot_id: boot_id.to_string(),
+        hold,
     }
     .store(&config.canary_state_path())?;
+
+    let current = read_revision(&config.host.current_revision_path)?;
+
+    // A persistent trial owns the boot default, so it is applied like a
+    // normal update: profile moved and switched. That deliberately leaves
+    // no floor to fall back to — the operator reboots when ready to
+    // exercise the trial's kernel and recovers from the bootloader menu.
+    if persist {
+        let next_boot = read_revision(&config.next_boot_revision_path())?;
+        if current != commit || next_boot != commit {
+            let store_path = checkout_and_build(config, system, repo, commit)?;
+            system.set_profile(&config.activate.profile, &store_path)?;
+            system.switch_to_configuration(&store_path, Activation::Switch)?;
+        }
+        return Ok(Outcome::CanaryStarted {
+            commit: commit.to_string(),
+            next_boot: commit.to_string(),
+            persist,
+            expires_at,
+        });
+    }
 
     let floor = stage_boot_floor(config, system, repo, commit, main_tip)?;
 
     // Apply the trial once, as an ephemeral test activation. Scheduled
     // cycles never reapply it, so a reboot ends it for good.
-    let current = read_revision(&config.host.current_revision_path)?;
     if current != commit {
         let store_path = checkout_and_build(config, system, repo, commit)?;
         system.switch_to_configuration(&store_path, Activation::Test)?;
@@ -274,7 +329,8 @@ fn start_canary(
 
     Ok(Outcome::CanaryStarted {
         commit: commit.to_string(),
-        floor: floor.to_string(),
+        next_boot: floor.to_string(),
+        persist,
         expires_at,
     })
 }
@@ -941,13 +997,29 @@ mod tests {
     }
 
     fn store_active(config: &Config, commit: Oid, expires_at: Option<DateTime<Utc>>) {
+        store_hold(
+            config,
+            commit,
+            expires_at,
+            CanaryHold::Ephemeral {
+                boot_id: BOOT.to_string(),
+            },
+        );
+    }
+
+    fn store_hold(
+        config: &Config,
+        commit: Oid,
+        expires_at: Option<DateTime<Utc>>,
+        hold: CanaryHold,
+    ) {
         CanaryState::Active {
             target: CanaryTarget::Pinned {
                 branch: "canary".to_string(),
                 commit: commit.to_string(),
             },
             expires_at,
-            boot_id: BOOT.to_string(),
+            hold,
         }
         .store(&config.canary_state_path())
         .unwrap();
@@ -980,6 +1052,7 @@ mod tests {
             Trigger::StartCanary {
                 branch: "canary".to_string(),
                 timeout: Some(Duration::from_secs(86400)),
+                persist: false,
             },
         )
         .unwrap();
@@ -990,7 +1063,8 @@ mod tests {
             outcome,
             Outcome::CanaryStarted {
                 commit: side.to_string(),
-                floor: second.to_string(),
+                next_boot: second.to_string(),
+                persist: false,
                 expires_at: Some(now() + chrono::Duration::seconds(86400)),
             }
         );
@@ -1017,9 +1091,162 @@ mod tests {
             CanaryState::Active {
                 target: CanaryTarget::Pinned { commit, .. },
                 expires_at: Some(_),
-                boot_id,
+                hold: CanaryHold::Ephemeral { boot_id },
             } if commit == side.to_string() && boot_id == BOOT
         ));
+    }
+
+    #[test]
+    fn persistent_canary_takes_the_boot_default_with_no_floor() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+
+        let system = MockSystem::default();
+        let outcome = run(
+            &fixture.config,
+            &system,
+            now(),
+            BOOT,
+            Trigger::StartCanary {
+                branch: "canary".to_string(),
+                timeout: None,
+                persist: true,
+            },
+        )
+        .unwrap();
+
+        // The trial itself is the next-boot system; no floor is staged.
+        assert_eq!(
+            outcome,
+            Outcome::CanaryStarted {
+                commit: side.to_string(),
+                next_boot: side.to_string(),
+                persist: true,
+                expires_at: None,
+            }
+        );
+        assert!(outcome.activated());
+
+        // One build, and the profile moves — unlike the ephemeral path,
+        // which builds the floor as well and only test-activates.
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(flake_ref(&fixture.config)),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+
+        let state = CanaryState::load(&fixture.config.canary_state_path())
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            state,
+            CanaryState::Active {
+                hold: CanaryHold::Persistent,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn persistent_canary_survives_a_reboot() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        // Rebooted straight back onto the trial, which owns the boot default.
+        fixture.set_current(side);
+        fixture.set_next_boot(side);
+        store_hold(&fixture.config, side, None, CanaryHold::Persistent);
+
+        let system = MockSystem::default();
+        let outcome = run(
+            &fixture.config,
+            &system,
+            now(),
+            "boot-session-b",
+            Trigger::Scheduled,
+        )
+        .unwrap();
+
+        // A changed boot id does not end the trial, and nothing is staged
+        // under it.
+        assert_eq!(
+            outcome,
+            Outcome::CanaryHeld {
+                commit: side.to_string(),
+                next_boot: side.to_string(),
+            }
+        );
+        assert!(system.calls.borrow().is_empty());
+        assert!(matches!(
+            CanaryState::load(&fixture.config.canary_state_path())
+                .unwrap()
+                .unwrap(),
+            CanaryState::Active { .. }
+        ));
+    }
+
+    #[test]
+    fn expired_persistent_canary_reverts_to_the_tracked_tip() {
+        let (fixture, initial) = Fixture::new();
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let side = commit(&fixture.origin, "canary", &[second], "side");
+        fixture.set_current(side);
+        fixture.set_next_boot(side);
+        store_hold(
+            &fixture.config,
+            side,
+            Some(now() - chrono::Duration::hours(1)),
+            CanaryHold::Persistent,
+        );
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        // Expiry forces the host back onto the tip, reclaiming the boot
+        // default the trial held.
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Expired);
+        assert_eq!(
+            *system.calls.borrow(),
+            vec![
+                Call::Build(flake_ref(&fixture.config)),
+                Call::SetProfile(fixture.config.activate.profile.clone()),
+                Call::SwitchToConfiguration(Activation::Switch),
+            ]
+        );
+    }
+
+    #[test]
+    fn unreadable_canary_state_does_not_wedge_the_cycle() {
+        let (fixture, initial) = Fixture::new();
+        fixture.set_current(initial);
+        fixture.set_next_boot(initial);
+        let second = commit(&fixture.origin, "main", &[initial], "second");
+        // A record from a build that predates `hold`, or plain corruption.
+        fs::write(fixture.config.canary_state_path(), "{\"state\":\"active\"}").unwrap();
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        // Treated as no trial, so guarded tracking resumes rather than the
+        // cycle failing and stalling every one after it.
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: second.to_string()
+            }
+        );
     }
 
     #[test]
@@ -1038,7 +1265,7 @@ mod tests {
             outcome,
             Outcome::CanaryHeld {
                 commit: side.to_string(),
-                floor: second.to_string(),
+                next_boot: second.to_string(),
             }
         );
         assert!(!outcome.activated());

--- a/src/ogygia-updated/src/lib.rs
+++ b/src/ogygia-updated/src/lib.rs
@@ -20,6 +20,7 @@ mod engine;
 mod repo;
 mod system;
 
+pub use canary::CanaryHold;
 pub use canary::CanaryState;
 pub use canary::CanaryTarget;
 pub use canary::FinishReason;

--- a/src/ogygia-updated/src/main.rs
+++ b/src/ogygia-updated/src/main.rs
@@ -77,12 +77,22 @@ fn main() -> Result<()> {
                     info!("manual update requested over the control socket");
                     (Trigger::Manual, Some(stream))
                 }
-                Request::Canary { branch, timeout } => {
-                    info!(branch, ?timeout, "canary requested over the control socket");
+                Request::Canary {
+                    branch,
+                    timeout,
+                    persist,
+                } => {
+                    info!(
+                        branch,
+                        ?timeout,
+                        persist,
+                        "canary requested over the control socket"
+                    );
                     (
                         Trigger::StartCanary {
                             branch,
                             timeout: timeout.map(Duration::from_secs),
+                            persist,
                         },
                         Some(stream),
                     )
@@ -151,8 +161,8 @@ fn canary_status(config: &Config) -> Result<String> {
         None => Ok("no canary".to_string()),
         Some(state) => {
             let running = read_revision(&config.host.current_revision_path);
-            let boot_floor = read_revision(&config.next_boot_revision_path());
-            Ok(state.describe(Utc::now(), &running, &boot_floor))
+            let next_boot = read_revision(&config.next_boot_revision_path());
+            Ok(state.describe(Utc::now(), &running, &next_boot))
         }
     }
 }

--- a/src/ogygia/src/update/mod.rs
+++ b/src/ogygia/src/update/mod.rs
@@ -56,6 +56,12 @@ struct CanaryArgs {
     #[arg(long)]
     forever: bool,
 
+    /// Make the trial the boot default, so a reboot keeps it instead of
+    /// falling back to the tracked branch. Needed to trial a new kernel or
+    /// new boot flags; recovery is by hand from the bootloader menu.
+    #[arg(long)]
+    persist: bool,
+
     #[command(subcommand)]
     command: Option<CanaryCommand>,
 }
@@ -112,7 +118,7 @@ impl CanaryArgs {
                     .clone()
                     .context("a branch to trial is required (or use `canary status`)")?;
                 let timeout = (!self.forever).then(|| Duration::from(self.duration).as_secs());
-                ogygia_updated::control::request_canary(socket, branch, timeout)
+                ogygia_updated::control::request_canary(socket, branch, timeout, self.persist)
             }
         }
     }


### PR DESCRIPTION
A canary is applied as an ephemeral test activation over a boot floor staged from the branch point, so a reboot always ends the trial. That makes it impossible to trial anything that only takes effect at boot, such as a new kernel or changed boot flags, since the reboot needed to exercise the change is also what discards it.

This adds a `--persist` flag, threaded through the control request into the engine, which instead applies the trial like a normal update — the system profile is moved and the configuration switched — and stages nothing beneath it. The persisted record's boot id and persistence are modelled as one `CanaryHold` enum rather than a boot id plus a flag, so the boot id exists only on the ephemeral variant that consults it, and the reboot check is skipped for a persistent hold. No reboot is scheduled: the operator picks the moment, and recovery from a trial that does not boot is by hand from the bootloader menu.

Because the trial is the boot default it comes back up after a reboot, while the timeout, merge, manual-clear, and out-of-band-switch endings all still apply — a persistent canary is time limited but no longer reboot limited. The enum retires the bare `boot_id` field, so state written by an older daemon no longer parses; an unreadable record is now reported and treated as no active trial rather than failing the cycle, which would otherwise stall every later cycle on that host.

Test plan:
- New engine tests cover a persistent start taking the boot default with no floor built, a changed boot id not ending the trial, expiry reverting it to the tracked tip, and an unparseable record falling back to no trial instead of failing the cycle.
- New canary tests cover the persistent status line and the rejection of state predating `hold`.
- Existing canary and engine tests cover the unchanged ephemeral path.
- Manually drove `ogygia update canary` against a stub control socket and confirmed the wire request carries `persist` as false by default and true with the flag.
- CI