### PR TITLE
updated: add a tick command to force and confirm one update cycle

### DIFF
--- a/src/ogygia-updated/src/control.rs
+++ b/src/ogygia-updated/src/control.rs
@@ -35,6 +35,11 @@ pub enum Request {
     /// Reset the target to the configured branch tip and run a cycle now,
     /// clearing any active canary.
     Update,
+    /// Run one cycle now on the daemon's own terms — an active canary is
+    /// held, and a deliberately off-branch system is left alone — and
+    /// answer once it has been served. Callers that must not fall behind
+    /// use this to force a cycle and confirm it happened.
+    Tick,
     /// Trial `branch`: pin its tip and hold the host there until `timeout`
     /// seconds pass (no timeout if `None`), the commit merges, or an
     /// update supersedes it. `persist` also makes it the boot default, so
@@ -56,6 +61,13 @@ pub type Response = Result<String, String>;
 /// Reset the host to the tracked branch tip now, clearing any canary.
 pub fn request_update(socket_path: &Path) -> Result<String> {
     send(socket_path, &Request::Update)
+}
+
+/// Run one cycle now as the daemon's interval would, returning once it has
+/// finished. Errors if the cycle failed, so a caller gating on being
+/// current can tell a served tick from a missed one.
+pub fn request_tick(socket_path: &Path) -> Result<String> {
+    send(socket_path, &Request::Tick)
 }
 
 /// Start a canary trialling `branch`, held for `timeout` seconds (no
@@ -193,6 +205,10 @@ mod tests {
             let (request, mut stream) = receiver.recv().unwrap();
             assert_eq!(request, Request::CanaryStatus);
             respond(&mut stream, Ok("no canary".to_string()));
+
+            let (request, mut stream) = receiver.recv().unwrap();
+            assert_eq!(request, Request::Tick);
+            respond(&mut stream, Ok("holding canary def".to_string()));
         });
 
         assert_eq!(request_update(&socket_path).unwrap(), "switched to abc");
@@ -200,6 +216,7 @@ mod tests {
             request_canary(&socket_path, "feature".to_string(), Some(3600), true).unwrap_err();
         assert_eq!(error.to_string(), "no such branch");
         assert_eq!(request_canary_status(&socket_path).unwrap(), "no canary");
+        assert_eq!(request_tick(&socket_path).unwrap(), "holding canary def");
         server.join().unwrap();
     }
 

--- a/src/ogygia-updated/src/main.rs
+++ b/src/ogygia-updated/src/main.rs
@@ -77,6 +77,10 @@ fn main() -> Result<()> {
                     info!("manual update requested over the control socket");
                     (Trigger::Manual, Some(stream))
                 }
+                Request::Tick => {
+                    info!("tick requested over the control socket");
+                    (Trigger::Scheduled, Some(stream))
+                }
                 Request::Canary {
                     branch,
                     timeout,

--- a/src/ogygia/src/update/mod.rs
+++ b/src/ogygia/src/update/mod.rs
@@ -31,6 +31,9 @@ pub struct UpdateArgs {
 
 #[derive(Subcommand)]
 enum UpdateCommand {
+    /// Run one update cycle now and wait for it to finish, holding any
+    /// active canary. Exits non-zero if the cycle failed.
+    Tick,
     /// Trial a branch on this host, or report the active trial
     Canary(CanaryArgs),
 }
@@ -101,6 +104,7 @@ impl UpdateArgs {
     pub fn run(&self) -> Result<()> {
         let message = match &self.command {
             None => ogygia_updated::control::request_update(&self.socket)?,
+            Some(UpdateCommand::Tick) => ogygia_updated::control::request_tick(&self.socket)?,
             Some(UpdateCommand::Canary(canary)) => canary.run(&self.socket)?,
         };
         println!("{message}");


### PR DESCRIPTION
A host that rarely stays booted into NixOS can go a long time without the daemon's interval ever firing, leaving it arbitrarily far behind the branch it tracks. There was no way for another unit to demand a cycle and block on the outcome: the existing manual update clears any active canary and forces a deliberately off-branch host back onto the tip, so it is unusable as a routine gate.

This adds a Tick request to the control socket, exposed as `ogygia update tick`, which runs a cycle under Trigger::Scheduled — the same one the interval would have run — and answers only once it has been served. A new Outcome::served() decides what that answer is: an up-to-date host, a held trial, and a deliberately off-branch system are all settled states and succeed, while PrefetchUnavailable fails, being the one outcome where the host wanted to advance and could not. The daemon's own interval receives no response, so its logging is unaffected.

Running the scheduled cycle rather than a manual one lets a caller force an update before every boot without disturbing a trial under way, and reporting an unavailable cache-warm closure as a failure means a host quietly making no progress says so instead of passing green.

Test plan:
- CI
- Extended the control socket round-trip test to cover Tick, and asserted served() on the existing prefetch-unavailable and canary-held engine tests