### PR TITLE
updated: fail a requested cycle that could not advance

### DIFF
--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -114,6 +114,15 @@ impl Outcome {
                 | Outcome::CanaryStarted { .. }
         )
     }
+
+    /// Whether the cycle did what the caller asked of it. An up-to-date
+    /// host, a held trial, and a deliberately off-branch system are all
+    /// settled states and count as served; a cycle that wanted to advance
+    /// and could not does not, leaving the host behind the branch it
+    /// tracks.
+    pub fn served(&self) -> bool {
+        !matches!(self, Outcome::PrefetchUnavailable { .. })
+    }
 }
 
 /// What initiated an update cycle.
@@ -913,6 +922,9 @@ mod tests {
                 commit: second.to_string()
             }
         );
+        // The host is left behind the branch, so an explicit request for a
+        // cycle is answered as a failure rather than a skip.
+        assert!(!outcome.served());
         // A cache-dependent host never falls back to a local build.
         assert_eq!(
             *system.calls.borrow(),
@@ -1269,6 +1281,8 @@ mod tests {
             }
         );
         assert!(!outcome.activated());
+        // Holding a trial is a settled state, not a missed update.
+        assert!(outcome.served());
         assert!(system.calls.borrow().is_empty());
     }
 

--- a/src/ogygia-updated/src/main.rs
+++ b/src/ogygia-updated/src/main.rs
@@ -104,7 +104,15 @@ fn main() -> Result<()> {
         let response = match &result {
             Ok(outcome) => {
                 info!(%outcome, "update cycle finished");
-                Ok(outcome.to_string())
+                // A cycle that could not advance is reported as a failure to
+                // whoever asked for one, so a caller gating on being current
+                // can tell it did not happen. The daemon's own interval gets
+                // no response and simply retries on the next cycle.
+                if outcome.served() {
+                    Ok(outcome.to_string())
+                } else {
+                    Err(outcome.to_string())
+                }
             }
             Err(error) => {
                 let message = format!("{error:#}");


### PR DESCRIPTION
When the cache-warm closure cannot be substituted the cycle is skipped rather than built locally, so a cache-dependent host never falls back to a full build. That skip was reported to whoever requested the cycle as a success, so `ogygia update` printed the message and exited zero, indistinguishable from an update that landed.

This adds Outcome::served(), false only for PrefetchUnavailable, and answers a request with an error when the outcome was not served. The daemon's own interval receives no response at all, so its logging and its retry on the next cycle are untouched.

PrefetchUnavailable is the only outcome where the host wanted to advance and could not — an up-to-date host, a held trial and a deliberately off-branch system are all settled states — so it is the only one a requester should be told is a failure.

Test plan:
- CI
- Asserted served() on the existing prefetch-unavailable and canary-held engine tests