### PR TITLE
updated: end a canary once its jj changes land rewritten

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -191,11 +191,13 @@
             inherit version cargoArtifacts;
             doCheck = false;
             doNotPostBuildInstallCargoBinaries = true;
-            # Bake nebula-cert's store path into the archived test binaries the
-            # same way the ogygia package does, so the nebula round-trip test
-            # finds it via the embedded constant when the archive runs — the
-            # testquorum runner has no nebula-cert on PATH.
+            # Bake nebula-cert's and jj's store paths into the archived test
+            # binaries the same way the ogygia package does, so the nebula
+            # round-trip test and the ogygia-updated change-id tests find them
+            # via the embedded constants when the archive runs — the testquorum
+            # runner has neither on PATH.
             env.OGYGIA_NEBULA_CERT_BIN = "${pkgs.nebula}/bin/nebula-cert";
+            env.OGYGIA_JJ_BIN = "${pkgs.jujutsu}/bin/jj";
             nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
               pkgs.cargo-nextest
               pkgs.zstd
@@ -227,6 +229,7 @@
             checks = self.checks.${system};
             packages = with pkgs; [
               etcd # for etcdctl
+              jujutsu # jj, for the ogygia-updated change-id tests
               nebula # nebula-cert, for the nebula round-trip test
               rust-analyzer
               treefmtEval.config.build.wrapper

--- a/src/ogygia-updated/src/engine.rs
+++ b/src/ogygia-updated/src/engine.rs
@@ -256,8 +256,11 @@ fn scheduled(
     }
 
     // Still trialling. Once the commit lands on the tracked branch the
-    // canary has served its purpose; resume following the tip.
-    if repo.is_ancestor(commit, main_tip)? {
+    // canary has served its purpose; resume following the tip. The trial's
+    // own commit is often rewritten before it lands — reworded, or amended
+    // after review — so under jj its changes reaching the branch under new
+    // hashes ends the trial just as an untouched merge does.
+    if on_branch(repo, commit, main_tip)? {
         finish_canary(config, now, &target, FinishReason::Merged)?;
         info!("canary merged; resuming the tracked branch");
         return update_to_tip(config, system, repo, main_tip, false);
@@ -453,11 +456,11 @@ fn target_commit(target: &CanaryTarget) -> Result<Oid> {
     }
 }
 
-/// Whether `revision` is on the branch leading to `tip`, either as a plain
-/// ancestor or as a deployed jj revision whose every change has since
+/// Whether `revision` has reached the branch leading to `tip`, either as a
+/// plain ancestor or as a deployed jj revision whose every change has since
 /// landed there (rewritten, keeping its change-id). Such a fully-landed
-/// revision updates like a merged one; a stack with any change still
-/// outstanding does not.
+/// revision counts as merged; a stack with any change still outstanding
+/// does not.
 fn on_branch(repo: &Repo, revision: Oid, tip: Oid) -> Result<bool> {
     if repo.is_ancestor(revision, tip)? {
         return Ok(true);
@@ -528,6 +531,7 @@ mod tests {
     use crate::config::DaemonConfig;
     use crate::config::HostConfig;
     use crate::config::RepoConfig;
+    use crate::jjtest::Jj;
     use crate::repo::testutil::commit;
     use crate::repo::testutil::commit_with_change_id;
     use crate::repo::testutil::init_origin;
@@ -607,19 +611,35 @@ mod tests {
         }
     }
 
+    /// The host-side state a cycle reads and writes: the daemon's config
+    /// plus the revision files standing in for the running and next-boot
+    /// systems. The origin it tracks is built separately, by git2 or by jj.
     struct Fixture {
         // Held so the temporary directory outlives the test.
         _dir: TempDir,
-        origin: git2::Repository,
         config: Config,
     }
 
     impl Fixture {
-        fn new() -> (Self, Oid) {
+        fn new() -> (Self, git2::Repository, Oid) {
             let dir = TempDir::new().unwrap();
             let origin_path = dir.path().join("origin");
             let (origin, initial) = init_origin(&origin_path);
+            let fixture = Self::tracking(dir, &origin_path);
+            (fixture, origin, initial)
+        }
 
+        /// A fixture tracking an origin built by the real `jj` binary, so
+        /// the commits the daemon sees carry the change-ids jj writes rather
+        /// than a hand-rolled imitation of them.
+        fn jj() -> (Self, Jj) {
+            let dir = TempDir::new().unwrap();
+            let jj = Jj::init(dir.path());
+            let fixture = Self::tracking(dir, jj.origin());
+            (fixture, jj)
+        }
+
+        fn tracking(dir: TempDir, origin_path: &Path) -> Self {
             let profile = dir.path().join("profile");
             fs::create_dir_all(profile.join("sw/share/ogygia")).unwrap();
 
@@ -641,12 +661,7 @@ mod tests {
                 daemon: DaemonConfig::default(),
             };
 
-            let fixture = Self {
-                _dir: dir,
-                origin,
-                config,
-            };
-            (fixture, initial)
+            Self { _dir: dir, config }
         }
 
         fn set_current(&self, revision: Oid) {
@@ -668,7 +683,7 @@ mod tests {
 
     #[test]
     fn up_to_date_makes_no_changes() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, _origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
 
@@ -681,10 +696,10 @@ mod tests {
 
     #[test]
     fn update_switches_to_the_new_commit() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let second = commit(&origin, "main", &[initial], "second");
 
         let system = MockSystem::default();
         let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
@@ -717,9 +732,9 @@ mod tests {
 
     #[test]
     fn off_branch_current_revision_blocks_the_update() {
-        let (fixture, initial) = Fixture::new();
-        let side = commit(&fixture.origin, "side", &[initial], "side");
-        commit(&fixture.origin, "main", &[initial], "second");
+        let (fixture, origin, initial) = Fixture::new();
+        let side = commit(&origin, "side", &[initial], "side");
+        commit(&origin, "main", &[initial], "second");
         fixture.set_current(side);
         fixture.set_next_boot(initial);
 
@@ -737,9 +752,9 @@ mod tests {
 
     #[test]
     fn off_branch_next_boot_gets_test_activation_only() {
-        let (fixture, initial) = Fixture::new();
-        let side = commit(&fixture.origin, "side", &[initial], "side");
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let (fixture, origin, initial) = Fixture::new();
+        let side = commit(&origin, "side", &[initial], "side");
+        let second = commit(&origin, "main", &[initial], "second");
         fixture.set_current(initial);
         fixture.set_next_boot(side);
 
@@ -767,23 +782,12 @@ mod tests {
 
     #[test]
     fn landed_revision_updates_like_a_merge() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         // The host runs a jj commit deployed from a branch; it has since
         // landed on main rewritten, keeping its change-id.
-        let deployed = commit_with_change_id(
-            &fixture.origin,
-            "deploy",
-            &[initial],
-            "deployed",
-            "kxyzkxyzkxyz",
-        );
-        let landed = commit_with_change_id(
-            &fixture.origin,
-            "main",
-            &[initial],
-            "landed",
-            "kxyzkxyzkxyz",
-        );
+        let deployed =
+            commit_with_change_id(&origin, "deploy", &[initial], "deployed", "kxyzkxyzkxyz");
+        let landed = commit_with_change_id(&origin, "main", &[initial], "landed", "kxyzkxyzkxyz");
         fixture.set_current(deployed);
         fixture.set_next_boot(deployed);
 
@@ -809,9 +813,9 @@ mod tests {
 
     #[test]
     fn manual_recovers_an_off_branch_running_system() {
-        let (fixture, initial) = Fixture::new();
-        let side = commit(&fixture.origin, "side", &[initial], "side");
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let (fixture, origin, initial) = Fixture::new();
+        let side = commit(&origin, "side", &[initial], "side");
+        let second = commit(&origin, "main", &[initial], "second");
         fixture.set_current(side);
         fixture.set_next_boot(initial);
 
@@ -841,9 +845,9 @@ mod tests {
 
     #[test]
     fn manual_resets_an_off_branch_next_boot() {
-        let (fixture, initial) = Fixture::new();
-        let side = commit(&fixture.origin, "side", &[initial], "side");
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let (fixture, origin, initial) = Fixture::new();
+        let side = commit(&origin, "side", &[initial], "side");
+        let second = commit(&origin, "main", &[initial], "second");
         fixture.set_current(initial);
         fixture.set_next_boot(side);
 
@@ -873,10 +877,10 @@ mod tests {
 
     #[test]
     fn prefetch_precedes_the_build() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let second = commit(&origin, "main", &[initial], "second");
         let mut config = fixture.config;
         config.build.prefetch_attr = Some("checks.x86_64-linux.prefetch".to_string());
 
@@ -903,10 +907,10 @@ mod tests {
 
     #[test]
     fn failed_prefetch_skips_the_build() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let second = commit(&origin, "main", &[initial], "second");
         let mut config = fixture.config;
         config.build.prefetch_attr = Some("checks.x86_64-linux.prefetch".to_string());
 
@@ -937,10 +941,10 @@ mod tests {
 
     #[test]
     fn unchanged_kernel_switches_without_reboot() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let second = commit(&origin, "main", &[initial], "second");
         let mut config = fixture.config;
         config.activate.allow_reboot = true;
         config.activate.booted_system = PathBuf::from("/run/booted-system");
@@ -970,10 +974,10 @@ mod tests {
 
     #[test]
     fn changed_kernel_schedules_a_reboot() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let second = commit(&origin, "main", &[initial], "second");
         let mut config = fixture.config;
         config.activate.allow_reboot = true;
         config.activate.booted_system = PathBuf::from("/run/booted-system");
@@ -1049,9 +1053,9 @@ mod tests {
 
     #[test]
     fn start_canary_runs_commit_and_stages_boot_floor() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
 
@@ -1110,9 +1114,9 @@ mod tests {
 
     #[test]
     fn persistent_canary_takes_the_boot_default_with_no_floor() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
 
@@ -1167,9 +1171,9 @@ mod tests {
 
     #[test]
     fn persistent_canary_survives_a_reboot() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         // Rebooted straight back onto the trial, which owns the boot default.
         fixture.set_current(side);
         fixture.set_next_boot(side);
@@ -1205,9 +1209,9 @@ mod tests {
 
     #[test]
     fn expired_persistent_canary_reverts_to_the_tracked_tip() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         fixture.set_current(side);
         fixture.set_next_boot(side);
         store_hold(
@@ -1241,10 +1245,10 @@ mod tests {
 
     #[test]
     fn unreadable_canary_state_does_not_wedge_the_cycle() {
-        let (fixture, initial) = Fixture::new();
+        let (fixture, origin, initial) = Fixture::new();
         fixture.set_current(initial);
         fixture.set_next_boot(initial);
-        let second = commit(&fixture.origin, "main", &[initial], "second");
+        let second = commit(&origin, "main", &[initial], "second");
         // A record from a build that predates `hold`, or plain corruption.
         fs::write(fixture.config.canary_state_path(), "{\"state\":\"active\"}").unwrap();
 
@@ -1263,9 +1267,9 @@ mod tests {
 
     #[test]
     fn scheduled_holds_an_active_canary_in_place() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         fixture.set_current(side);
         fixture.set_next_boot(second);
         store_active(&fixture.config, side, None);
@@ -1288,10 +1292,10 @@ mod tests {
 
     #[test]
     fn rebooted_canary_ends_and_resumes_tracking() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let third = commit(&fixture.origin, "main", &[second], "third");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let third = commit(&origin, "main", &[second], "third");
+        let side = commit(&origin, "canary", &[second], "side");
         // Rebooted onto the boot floor (merge-base(side, third) = second);
         // the timeout also lapsed while the host was down.
         fixture.set_current(second);
@@ -1334,10 +1338,10 @@ mod tests {
 
     #[test]
     fn overwritten_canary_ends_and_respects_off_branch_switch() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
-        let hand = commit(&fixture.origin, "hand", &[second], "hand");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
+        let hand = commit(&origin, "hand", &[second], "hand");
         // Same boot session, but the host was hand-switched to an off-branch
         // commit.
         fixture.set_current(hand);
@@ -1361,9 +1365,9 @@ mod tests {
 
     #[test]
     fn expired_canary_reverts_to_the_tracked_tip() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         fixture.set_current(side);
         fixture.set_next_boot(second);
         store_active(
@@ -1395,11 +1399,11 @@ mod tests {
 
     #[test]
     fn merged_canary_resumes_the_tracked_tip() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         // The branch merges back into main via a merge commit.
-        let merge = commit(&fixture.origin, "main", &[second, side], "merge");
+        let merge = commit(&origin, "main", &[second, side], "merge");
         fixture.set_current(side);
         fixture.set_next_boot(second);
         store_active(&fixture.config, side, None);
@@ -1418,9 +1422,9 @@ mod tests {
 
     #[test]
     fn manual_update_clears_an_active_canary() {
-        let (fixture, initial) = Fixture::new();
-        let second = commit(&fixture.origin, "main", &[initial], "second");
-        let side = commit(&fixture.origin, "canary", &[second], "side");
+        let (fixture, origin, initial) = Fixture::new();
+        let second = commit(&origin, "main", &[initial], "second");
+        let side = commit(&origin, "canary", &[second], "side");
         fixture.set_current(side);
         fixture.set_next_boot(second);
         store_active(&fixture.config, side, None);
@@ -1435,5 +1439,175 @@ mod tests {
             }
         );
         assert_eq!(finish_reason(&fixture.config), FinishReason::Cleared);
+    }
+
+    /// Trial `branch`'s tip on a host currently running main, and leave the
+    /// fixture as the next scheduled cycle finds it: the trial running, the
+    /// branch point staged for boot. Returns the commit the daemon pinned.
+    fn apply_canary(fixture: &Fixture, jj: &Jj, branch: &str) -> Oid {
+        let base = jj.tip("main");
+        fixture.set_current(base);
+        fixture.set_next_boot(base);
+
+        let outcome = run(
+            &fixture.config,
+            &MockSystem::default(),
+            now(),
+            BOOT,
+            Trigger::StartCanary {
+                branch: branch.to_string(),
+                timeout: None,
+                persist: false,
+            },
+        )
+        .unwrap();
+
+        let Outcome::CanaryStarted {
+            commit, next_boot, ..
+        } = outcome
+        else {
+            panic!("expected a canary to start, got {outcome:?}")
+        };
+        assert_eq!(next_boot, base.to_string());
+        let pinned = Oid::from_str(&commit).unwrap();
+        fixture.set_current(pinned);
+        pinned
+    }
+
+    #[test]
+    fn a_reworded_jj_canary_merges_and_resumes_the_tracked_tip() {
+        let (fixture, jj) = Fixture::jj();
+        jj.commit("main", "canary change", "canary");
+        jj.set_bookmark("jj/blah", "@");
+        let pushed = jj.push("jj/blah");
+        let pinned = apply_canary(&fixture, &jj, "jj/blah");
+        assert_eq!(pinned, pushed);
+
+        // Reworded during review, then merged. jj rewrote the commit, so the
+        // hash the daemon pinned is on no branch at all any more — only its
+        // change-id ties the running system to what landed.
+        jj.describe("jj/blah", "canary change, reworded");
+        let rewritten = jj.push("jj/blah");
+        assert_ne!(rewritten, pinned);
+        jj.merge_into_main("jj/blah", "merge jj/blah");
+        let main_tip = jj.push("main");
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: main_tip.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Merged);
+    }
+
+    #[test]
+    fn a_squashed_jj_canary_merges_when_its_change_lands() {
+        let (fixture, jj) = Fixture::jj();
+        jj.commit("main", "canary change", "canary");
+        jj.set_bookmark("jj/blah", "@");
+        jj.push("jj/blah");
+        let pinned = apply_canary(&fixture, &jj, "jj/blah");
+
+        // Amended rather than reworded, and landed by fast-forward instead of
+        // a merge commit: main's tip is the rewrite itself.
+        jj.squash_into("jj/blah", "amended");
+        let rewritten = jj.push("jj/blah");
+        assert_ne!(rewritten, pinned);
+        jj.set_bookmark("main", "jj/blah");
+        let main_tip = jj.push("main");
+        assert_eq!(main_tip, rewritten);
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: main_tip.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Merged);
+    }
+
+    #[test]
+    fn a_rewritten_jj_canary_is_held_until_its_change_lands() {
+        let (fixture, jj) = Fixture::jj();
+        let base = jj.tip("main");
+        jj.commit("main", "canary change", "canary");
+        jj.set_bookmark("jj/blah", "@");
+        jj.push("jj/blah");
+        let pinned = apply_canary(&fixture, &jj, "jj/blah");
+
+        // Rewritten but not merged, while main moved on without it.
+        jj.describe("jj/blah", "canary change, reworded");
+        jj.push("jj/blah");
+        jj.commit("main", "unrelated", "unrelated");
+        jj.set_bookmark("main", "@");
+        jj.push("main");
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        // A rewrite alone is not a merge; the trial holds at its floor.
+        assert_eq!(
+            outcome,
+            Outcome::CanaryHeld {
+                commit: pinned.to_string(),
+                next_boot: base.to_string(),
+            }
+        );
+        assert!(system.calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn a_jj_canary_stack_merges_only_once_all_of_it_lands() {
+        let (fixture, jj) = Fixture::jj();
+        let base = jj.tip("main");
+        jj.commit("main", "lower", "lower");
+        jj.set_bookmark("lower", "@");
+        jj.commit("lower", "upper", "upper");
+        jj.set_bookmark("jj/stack", "@");
+        jj.push("lower");
+        jj.push("jj/stack");
+        let pinned = apply_canary(&fixture, &jj, "jj/stack");
+
+        // The upper change is pulled out of the stack and landed on its own.
+        // The host runs both changes, so it must not roll forward yet: the
+        // tracked tip is missing the lower one.
+        jj.rebase("jj/stack", "main");
+        jj.push("jj/stack");
+        jj.merge_into_main("jj/stack", "merge the upper change");
+        jj.push("main");
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::CanaryHeld {
+                commit: pinned.to_string(),
+                next_boot: base.to_string(),
+            }
+        );
+
+        // The lower change lands too, so every change the host runs is now
+        // on the branch and the trial is done.
+        jj.merge_into_main("lower", "merge the lower change");
+        let main_tip = jj.push("main");
+
+        let system = MockSystem::default();
+        let outcome = run(&fixture.config, &system, now(), BOOT, Trigger::Scheduled).unwrap();
+
+        assert_eq!(
+            outcome,
+            Outcome::Switched {
+                commit: main_tip.to_string()
+            }
+        );
+        assert_eq!(finish_reason(&fixture.config), FinishReason::Merged);
     }
 }

--- a/src/ogygia-updated/src/jjtest.rs
+++ b/src/ogygia-updated/src/jjtest.rs
@@ -1,0 +1,157 @@
+//! Test harness driving the real `jj` binary against a bare git origin.
+//!
+//! The change-id support in [`crate::repo`] keys off a header jj writes and
+//! preserves across rewrites, so these tests build their history with jj
+//! itself rather than imitating the commit objects it produces.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use git2::Oid;
+use git2::Repository;
+use git2::RepositoryInitOptions;
+
+/// A bare git origin with a `main` branch, plus a jj working copy that
+/// pushes to it. Every method panics on failure: a harness that cannot
+/// drive jj has nothing to report beyond the command that broke.
+pub struct Jj {
+    origin: PathBuf,
+    work: PathBuf,
+}
+
+impl Jj {
+    /// Create the origin with an initial commit on `main`, and a jj working
+    /// copy cloned from it.
+    pub fn init(root: &Path) -> Self {
+        let origin = root.join("origin.git");
+        let work = root.join("work");
+        Repository::init_opts(
+            &origin,
+            RepositoryInitOptions::new().bare(true).initial_head("main"),
+        )
+        .unwrap();
+        run(
+            root,
+            &[
+                "git",
+                "clone",
+                origin.to_str().unwrap(),
+                work.to_str().unwrap(),
+            ],
+        );
+
+        let jj = Self { origin, work };
+        jj.write("initial");
+        jj.run(&["describe", "-m", "initial"]);
+        jj.set_bookmark("main", "@");
+        jj.push("main");
+        jj
+    }
+
+    /// Path the daemon clones from.
+    pub fn origin(&self) -> &Path {
+        &self.origin
+    }
+
+    /// Start a commit on top of `parent` adding the file `file`, and leave
+    /// the working copy on it.
+    pub fn commit(&self, parent: &str, message: &str, file: &str) {
+        self.run(&["new", parent]);
+        self.write(file);
+        self.run(&["describe", "-m", message]);
+    }
+
+    /// Reword `revision`, rewriting it under a new git hash while keeping
+    /// its change-id — the `jj describe` half of the review cycle.
+    pub fn describe(&self, revision: &str, message: &str) {
+        self.run(&["describe", "-r", revision, "-m", message]);
+    }
+
+    /// Fold the file `file` into `revision`, rewriting it under a new git
+    /// hash while keeping its change-id — the `jj squash` half of the review
+    /// cycle.
+    pub fn squash_into(&self, revision: &str, file: &str) {
+        self.run(&["new", revision]);
+        self.write(file);
+        self.run(&["squash"]);
+    }
+
+    /// Move `revision` onto `destination`, rewriting it under a new git hash
+    /// while keeping its change-id — how a single change lands ahead of the
+    /// rest of the stack it was written on.
+    pub fn rebase(&self, revision: &str, destination: &str) {
+        self.run(&["rebase", "-r", revision, "-d", destination]);
+    }
+
+    /// Merge `revision` into `main` with a merge commit, leaving main's new
+    /// tip unpushed. A merge commit keeps the branch's commits verbatim, so
+    /// only their change-ids tie them to what the host was deployed on.
+    pub fn merge_into_main(&self, revision: &str, message: &str) {
+        self.run(&["new", "main", revision, "-m", message]);
+        self.set_bookmark("main", "@");
+    }
+
+    /// Create `bookmark` or move it to `revision`. jj moves a bookmark with
+    /// the commit it names when that commit is rewritten, so this is only
+    /// needed to place one.
+    pub fn set_bookmark(&self, bookmark: &str, revision: &str) {
+        self.run(&["bookmark", "set", bookmark, "-r", revision]);
+    }
+
+    /// Push `bookmark` to the origin, returning the commit it now names
+    /// there. jj force-pushes a bookmark whose remote value it knows, so
+    /// this covers a rewrite as well as a first push.
+    pub fn push(&self, bookmark: &str) -> Oid {
+        self.run(&["git", "push", "--bookmark", bookmark]);
+        self.tip(bookmark)
+    }
+
+    /// The commit `bookmark` names on the origin.
+    pub fn tip(&self, bookmark: &str) -> Oid {
+        Repository::open(&self.origin)
+            .unwrap()
+            .find_reference(&format!("refs/heads/{bookmark}"))
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id()
+    }
+
+    /// Add a file to the working copy. jj snapshots it on the next command,
+    /// so nothing needs adding. One file per change, so a change rebases
+    /// onto a history without its neighbours rather than conflicting.
+    fn write(&self, file: &str) {
+        std::fs::write(self.work.join(file), file).unwrap();
+    }
+
+    fn run(&self, args: &[&str]) {
+        run(&self.work, args);
+    }
+}
+
+/// The `jj` binary. A Nix build bakes its store path in so the test archive
+/// carries jj as a runtime dependency and needs nothing on the runner's
+/// PATH; a plain `cargo test` falls back to PATH.
+fn jj_bin() -> &'static str {
+    option_env!("OGYGIA_JJ_BIN").unwrap_or("jj")
+}
+
+/// Run jj in `dir` under a fixed identity and no user configuration, so the
+/// harness is unaffected by the developer's own jj settings.
+fn run(dir: &Path, args: &[&str]) {
+    let output = Command::new(jj_bin())
+        .args(args)
+        .current_dir(dir)
+        .env("JJ_USER", "test")
+        .env("JJ_EMAIL", "test@example.com")
+        .env("JJ_CONFIG", "/dev/null")
+        .output()
+        .unwrap_or_else(|error| panic!("running `jj {}`: {error}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`jj {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/src/ogygia-updated/src/lib.rs
+++ b/src/ogygia-updated/src/lib.rs
@@ -20,6 +20,9 @@ mod engine;
 mod repo;
 mod system;
 
+#[cfg(test)]
+mod jjtest;
+
 pub use canary::CanaryHold;
 pub use canary::CanaryState;
 pub use canary::CanaryTarget;


### PR DESCRIPTION
A canary pinned to a jj commit was never retired once its change merged. The scheduled cycle asked only whether the pinned git hash was an ancestor of the tracked branch, but jj rewrites a commit as it is reworded with `jj describe` or amended with `jj squash` during review, so the hash that lands is not the one the host was deployed on. The trial was held indefinitely, until its timeout lapsed or an operator intervened.

The merge check now goes through `on_branch`, the helper the tracking path already used to recognize a deployed revision whose every change has reappeared on the branch under a new hash. Its doc comment moves from "updates like a merged one" to the more general "counts as merged", since retiring a trial is now one of its callers.

Routing both paths through one helper means the canary and the tracked branch agree on what reaching the branch means, so a trial ends as merged exactly when following the tip would carry the changes it was trialling.

Test plan:
- Added engine tests that build their history with the real `jj` binary against a bare git origin, so they exercise the change-id header jj writes rather than an imitation of it: a canary reworded with `jj describe` and merged with a merge commit, one amended with `jj squash` and landed by fast-forward, one rewritten but not merged (still held), and a two-commit stack that only merges once both changes land.
- Confirmed the three merge cases fail, and the held case still passes, if the check reverts to plain hash ancestry.
- jj is baked into the nextest archive the way nebula-cert already is; ran the built archive with no jj on PATH to confirm all 46 ogygia-updated tests pass off the embedded store path.
- cargo test --workspace, cargo clippy --workspace --all-targets -- --deny warnings, cargo fmt, nix fmt.