### PR TITLE
nixos/updated: add pkgs.git to ogygia-updated's path

### DIFF
--- a/nixos/updated/default.nix
+++ b/nixos/updated/default.nix
@@ -87,7 +87,11 @@ in
       restartIfChanged = false;
       stopIfChanged = false;
 
-      path = [ config.nix.package config.systemd.package ];
+      path = [
+        config.nix.package
+        config.systemd.package
+        pkgs.gitMinimal
+      ];
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/ogygia-updated --config /etc/ogygia/updated.toml";


### PR DESCRIPTION
The ogygia-updated daemon runs Nix commands that can fetch Git inputs of a flake into the Nix store. Without git on PATH those fetches fail.

Add git to the systemd unit's path list alongside nix and systemd.

Test plan:
- Built .#checks.x86_64-linux.ogygia-updated-config successfully.
- Built .#checks.x86_64-linux.formatting successfully.