### PR TITLE
ogygia: summarise what a nebula rekey changes before signing

### DIFF
--- a/src/ogygia/src/nebula/nebula_cert.rs
+++ b/src/ogygia/src/nebula/nebula_cert.rs
@@ -93,12 +93,17 @@ pub async fn sign(args: SignArgs<'_>) -> Result<()> {
     Ok(())
 }
 
-/// The expiry of a signed certificate.
-pub struct Validity {
+/// A signed certificate, as reported by `nebula-cert print`.
+pub struct Cert {
+    /// The name the certificate was signed with. `ogygia nebula rekey` signs
+    /// with the `nixosConfigurations` attribute name, so this identifies the
+    /// host a certificate on disk belongs to.
+    pub name: String,
+    pub groups: Vec<String>,
     pub not_after: DateTime<Utc>,
 }
 
-impl Validity {
+impl Cert {
     /// Whether the certificate is due for LetsEncrypt-style renewal: less than
     /// `1 - renew_after` of the configured `validity_secs` remains before the
     /// cert's actual expiry.
@@ -117,8 +122,8 @@ impl Validity {
     }
 }
 
-/// Read a signed certificate's validity window via `nebula-cert print -json`.
-pub async fn read_validity(cert: &Path) -> Result<Validity> {
+/// Read a signed certificate via `nebula-cert print -json`.
+pub async fn read_cert(cert: &Path) -> Result<Cert> {
     let output = Command::new(bin())
         .arg("print")
         .arg("-json")
@@ -131,20 +136,23 @@ pub async fn read_validity(cert: &Path) -> Result<Validity> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(anyhow!("nebula-cert print failed: {}", stderr.trim()));
     }
-    parse_validity(&output.stdout)
+    parse_cert(&output.stdout)
 }
 
-/// Extract the validity window from `nebula-cert print -json` output.
+/// Extract the certificate from `nebula-cert print -json` output.
 ///
 /// The command emits a JSON *array* of certificates (a file may hold a chain);
 /// the host certificate is the first entry.
-fn parse_validity(json: &[u8]) -> Result<Validity> {
+fn parse_cert(json: &[u8]) -> Result<Cert> {
     #[derive(Deserialize)]
     struct Printed {
         details: Details,
     }
     #[derive(Deserialize)]
     struct Details {
+        name: String,
+        /// `null`, not `[]`, for a certificate signed without groups.
+        groups: Option<Vec<String>>,
         #[serde(rename = "notAfter")]
         not_after: DateTime<Utc>,
     }
@@ -155,7 +163,9 @@ fn parse_validity(json: &[u8]) -> Result<Validity> {
         .into_iter()
         .next()
         .ok_or_else(|| anyhow!("nebula-cert print returned no certificates"))?;
-    Ok(Validity {
+    Ok(Cert {
+        name: first.details.name,
+        groups: first.details.groups.unwrap_or_default(),
         not_after: first.details.not_after,
     })
 }
@@ -242,23 +252,29 @@ mod tests {
         Utc.timestamp_opt(secs, 0).unwrap()
     }
 
-    /// A cert issued at t=0 and expiring at day 90.
-    fn window() -> Validity {
-        Validity {
-            not_after: at(90 * 86400),
+    fn cert_expiring_at(secs: i64) -> Cert {
+        Cert {
+            name: "host".to_string(),
+            groups: Vec::new(),
+            not_after: at(secs),
         }
     }
 
+    /// A cert issued at t=0 and expiring at day 90.
+    fn window() -> Cert {
+        cert_expiring_at(90 * 86400)
+    }
+
     /// End-to-end: mint a CA, generate a host keypair, sign a cert, then read
-    /// its validity back — proving `read_validity`/`parse_validity` track the
-    /// actual `nebula-cert print -json` output rather than an assumed shape.
+    /// it back — proving `read_cert`/`parse_cert` track the actual
+    /// `nebula-cert print -json` output rather than an assumed shape.
     ///
     /// Hard-requires the real `nebula-cert`, provided on PATH by the dev shell
     /// and embedded into the CI nextest archive. A missing binary means a
     /// broken test environment and must fail loudly, not silently skip — a
     /// skipped round-trip is what let a parser bug reach the fleet before.
     #[tokio::test]
-    async fn read_validity_round_trips_a_signed_cert() {
+    async fn read_cert_round_trips_a_signed_cert() {
         let dir = tempfile::tempdir().unwrap();
         let ca_crt = dir.path().join("ca.crt");
         let ca_key = dir.path().join("ca.key");
@@ -288,14 +304,17 @@ mod tests {
             in_pub: &host_pub,
             name: "host.round-trip.test",
             networks: "10.0.0.1/24",
-            groups: &[],
+            groups: &["servers".to_string(), "laptops".to_string()],
             duration_seconds: duration_secs,
             out_cert: &out_cert,
         })
         .await
         .unwrap();
 
-        let v = read_validity(&out_cert).await.unwrap();
+        let v = read_cert(&out_cert).await.unwrap();
+
+        assert_eq!(v.name, "host.round-trip.test");
+        assert_eq!(v.groups, ["servers", "laptops"]);
 
         // nebula signs from ~now, so expiry lands one duration out (whole-second
         // rounding plus a few seconds of test slop).
@@ -315,7 +334,14 @@ mod tests {
 
     #[test]
     fn empty_cert_array_is_an_error() {
-        assert!(parse_validity(b"[]").is_err());
+        assert!(parse_cert(b"[]").is_err());
+    }
+
+    #[test]
+    fn null_groups_parse_as_empty() {
+        let json =
+            br#"[{"details":{"name":"bare","groups":null,"notAfter":"2026-10-27T18:28:48Z"}}]"#;
+        assert!(parse_cert(json).unwrap().groups.is_empty());
     }
 
     #[test]
@@ -365,7 +391,6 @@ mod tests {
     #[test]
     fn at_expiry_is_due() {
         // Zero remaining is at or below any positive renew window.
-        let v = Validity { not_after: at(0) };
-        assert!(v.past_renewal(at(0), VALIDITY_90D, 1.0 / 3.0));
+        assert!(cert_expiring_at(0).past_renewal(at(0), VALIDITY_90D, 1.0 / 3.0));
     }
 }

--- a/src/ogygia/src/nebula/rekey.rs
+++ b/src/ogygia/src/nebula/rekey.rs
@@ -1,5 +1,6 @@
 //! `ogygia nebula rekey` — sign missing host certificates by walking the flake.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
@@ -7,6 +8,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use chrono::DateTime;
+use chrono::TimeDelta;
 use chrono::Utc;
 use clap::Args;
 use ogygia_nixutils::Nix;
@@ -14,6 +17,7 @@ use ogygia_nixutils::Nix;
 use super::config::Config;
 use super::flake_eval;
 use super::nebula_cert;
+use super::nebula_cert::Cert;
 use super::nebula_cert::SignArgs;
 
 /// Re-sign a tracked cert once it is this fraction into its lifetime
@@ -75,6 +79,9 @@ async fn async_run(args: &RekeyArgs) -> Result<()> {
         flake_eval::list_hosts(&nix, &args.flake).await?
     };
 
+    let on_disk = read_cert_dir(&config.cert_dir).await?;
+    let now = Utc::now();
+
     let mut current_cert_paths: HashSet<PathBuf> = HashSet::new();
     let mut signed = 0usize;
     let mut skipped = 0usize;
@@ -98,37 +105,57 @@ async fn async_run(args: &RekeyArgs) -> Result<()> {
         let cert_path = config.cert_path(spec_hash);
         current_cert_paths.insert(cert_path.clone());
 
+        // What the new cert is replacing: the cert filed under this spec when
+        // one exists, otherwise the last cert signed for this host under a
+        // different spec — the filename is the spec hash, so any spec change
+        // moves the host to a new file.
+        let previous = on_disk
+            .get(&cert_path)
+            .or_else(|| latest_signed_for(&on_disk, &info.host));
+
         // A missing cert must be signed; a content-correct one is re-signed only
         // when forced or once it crosses the renewal threshold. Because the
         // filename is the spec hash, an existing file already matches the config
         // — only its remaining lifetime is in question.
         let reason = if !cert_path.exists() {
-            "missing"
+            if previous.is_some() {
+                "spec changed"
+            } else {
+                "new host"
+            }
         } else if args.force {
             "forced"
-        } else {
-            match nebula_cert::read_validity(&cert_path).await {
-                Ok(v) if v.past_renewal(Utc::now(), info.validity_secs, RENEW_AFTER_FRACTION) => {
-                    "nearing expiry"
-                }
-                Ok(_) => {
-                    tracing::info!(%host, hash = %spec_hash, "cert up to date");
-                    skipped += 1;
-                    continue;
-                }
-                Err(e) => {
-                    // Fail safe: an unreadable cert is left untouched. Blindly
-                    // re-signing would let a read bug rotate the whole fleet,
-                    // and a genuinely corrupt cert is a job for the operator.
-                    tracing::warn!(%host, error = %e, "could not read cert validity; skipping");
-                    skipped += 1;
-                    continue;
-                }
+        } else if let Some(cert) = on_disk.get(&cert_path) {
+            if cert.past_renewal(now, info.validity_secs, RENEW_AFTER_FRACTION) {
+                "nearing expiry"
+            } else {
+                tracing::info!(%host, hash = %spec_hash, "cert up to date");
+                skipped += 1;
+                continue;
             }
+        } else {
+            // Fail safe: an unreadable cert is left untouched. Blindly
+            // re-signing would let a read bug rotate the whole fleet, and a
+            // genuinely corrupt cert is a job for the operator.
+            tracing::warn!(%host, "could not read existing cert; skipping");
+            skipped += 1;
+            continue;
         };
 
+        // Printed before signing so the operator sees the change ahead of the
+        // CA passphrase prompt that `nebula-cert sign` puts on the terminal.
+        let delta = Delta {
+            host: &info.host,
+            reason,
+            previous,
+            groups: &spec.groups,
+            not_after: now + TimeDelta::seconds(info.validity_secs as i64),
+        };
+        for line in delta.lines(args.dry_run) {
+            println!("{line}");
+        }
+
         if args.dry_run {
-            println!("would sign {} ({reason})", cert_path.display());
             continue;
         }
 
@@ -168,6 +195,98 @@ async fn async_run(args: &RekeyArgs) -> Result<()> {
 
     eprintln!("rekey: {signed} signed, {skipped} unchanged, {pruned} orphans pruned");
     Ok(())
+}
+
+/// What a rekey is about to change for one host.
+struct Delta<'a> {
+    /// The `nixosConfigurations` attribute name, which is also the cert name.
+    host: &'a str,
+    reason: &'static str,
+    /// The cert being replaced, absent for a host signed for the first time.
+    previous: Option<&'a Cert>,
+    groups: &'a [String],
+    not_after: DateTime<Utc>,
+}
+
+impl Delta<'_> {
+    /// The summary to show the operator, one line per element.
+    fn lines(&self, dry_run: bool) -> Vec<String> {
+        let verb = if dry_run { "would rekey" } else { "rekey" };
+        let mut lines = vec![format!("{verb} {} ({})", self.host, self.reason)];
+
+        let was: &[String] = self.previous.map_or(&[], |c| &c.groups);
+        let added = only_in(self.groups, was);
+        let removed = only_in(was, self.groups);
+        if !added.is_empty() {
+            lines.push(format!("  + {}", added.join(" ")));
+        }
+        if !removed.is_empty() {
+            lines.push(format!("  - {}", removed.join(" ")));
+        }
+
+        // Re-signing a spec change usually lands on the same expiry day it
+        // would have anyway, so only spell out a move that actually happened.
+        let expiry = date(self.not_after);
+        lines.push(match self.previous.map(|prev| date(prev.not_after)) {
+            Some(before) if before != expiry => format!("  expires {before} → {expiry}"),
+            _ => format!("  expires {expiry}"),
+        });
+        lines
+    }
+}
+
+fn only_in<'a>(groups: &'a [String], other: &[String]) -> Vec<&'a str> {
+    groups
+        .iter()
+        .filter(|g| !other.contains(g))
+        .map(String::as_str)
+        .collect()
+}
+
+fn date(when: DateTime<Utc>) -> String {
+    when.format("%Y-%m-%d").to_string()
+}
+
+/// Every readable host certificate in `cert_dir`, keyed by path.
+///
+/// A file that is present but unreadable is omitted and warned about, so a
+/// caller must treat "on disk but absent here" as corrupt rather than missing.
+async fn read_cert_dir(cert_dir: &Path) -> Result<HashMap<PathBuf, Cert>> {
+    let mut certs = HashMap::new();
+    if !cert_dir.exists() {
+        return Ok(certs);
+    }
+    for entry in std::fs::read_dir(cert_dir)
+        .with_context(|| format!("failed to read {}", cert_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("crt") {
+            continue;
+        }
+        if path.file_name().and_then(|n| n.to_str()) == Some("ca.crt") {
+            continue;
+        }
+        match nebula_cert::read_cert(&path).await {
+            Ok(cert) => {
+                certs.insert(path, cert);
+            }
+            Err(e) => tracing::warn!(path = %path.display(), error = %e, "could not read cert"),
+        }
+    }
+    Ok(certs)
+}
+
+/// The longest-lived cert signed for `host`, which is the one it is currently
+/// running if its spec has moved on since.
+fn latest_signed_for<'a>(certs: &'a HashMap<PathBuf, Cert>, host: &str) -> Option<&'a Cert> {
+    certs
+        .values()
+        .filter(|c| c.name == host)
+        .max_by_key(|c| c.not_after)
 }
 
 async fn sign_with_atomic_rename(final_path: &Path, args: SignArgs<'_>) -> Result<()> {
@@ -223,4 +342,141 @@ fn prune_orphans(cert_dir: &Path, keep: &HashSet<PathBuf>) -> Result<usize> {
         pruned += 1;
     }
     Ok(pruned)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    fn groups(names: &[&str]) -> Vec<String> {
+        names.iter().map(|g| g.to_string()).collect()
+    }
+
+    fn previous(names: &[&str], not_after: i64) -> Cert {
+        Cert {
+            name: "willow".to_string(),
+            groups: groups(names),
+            not_after: at(not_after),
+        }
+    }
+
+    #[test]
+    fn a_new_host_has_no_previous_expiry() {
+        let delta = Delta {
+            host: "willow",
+            reason: "new host",
+            previous: None,
+            groups: &groups(&["servers", "monitoring"]),
+            not_after: at(90 * 86400),
+        };
+        assert_eq!(
+            delta.lines(false),
+            [
+                "rekey willow (new host)",
+                "  + servers monitoring",
+                "  expires 1970-04-01",
+            ]
+        );
+    }
+
+    #[test]
+    fn group_changes_show_as_additions_and_removals() {
+        let prev = previous(&["laptops", "servers"], 30 * 86400);
+        let delta = Delta {
+            host: "willow",
+            reason: "spec changed",
+            previous: Some(&prev),
+            groups: &groups(&["servers", "monitoring"]),
+            not_after: at(90 * 86400),
+        };
+        assert_eq!(
+            delta.lines(false),
+            [
+                "rekey willow (spec changed)",
+                "  + monitoring",
+                "  - laptops",
+                "  expires 1970-01-31 → 1970-04-01",
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unmoved_expiry_is_stated_once() {
+        let prev = previous(&["laptops"], 90 * 86400);
+        let delta = Delta {
+            host: "willow",
+            reason: "spec changed",
+            previous: Some(&prev),
+            groups: &groups(&["servers"]),
+            not_after: at(90 * 86400),
+        };
+        assert_eq!(
+            delta.lines(false),
+            [
+                "rekey willow (spec changed)",
+                "  + servers",
+                "  - laptops",
+                "  expires 1970-04-01",
+            ]
+        );
+    }
+
+    #[test]
+    fn an_extension_shows_only_the_expiry_move() {
+        let prev = previous(&["servers"], 30 * 86400);
+        let delta = Delta {
+            host: "willow",
+            reason: "nearing expiry",
+            previous: Some(&prev),
+            groups: &groups(&["servers"]),
+            not_after: at(90 * 86400),
+        };
+        assert_eq!(
+            delta.lines(false),
+            [
+                "rekey willow (nearing expiry)",
+                "  expires 1970-01-31 → 1970-04-01",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_dry_run_is_phrased_as_a_proposal() {
+        let delta = Delta {
+            host: "willow",
+            reason: "forced",
+            previous: None,
+            groups: &[],
+            not_after: at(90 * 86400),
+        };
+        assert_eq!(
+            delta.lines(true),
+            ["would rekey willow (forced)", "  expires 1970-04-01"]
+        );
+    }
+
+    #[test]
+    fn the_newest_cert_wins_when_a_host_has_several() {
+        let certs = HashMap::from([
+            (PathBuf::from("old.crt"), previous(&["servers"], 30 * 86400)),
+            (PathBuf::from("new.crt"), previous(&["laptops"], 60 * 86400)),
+            (
+                PathBuf::from("other.crt"),
+                Cert {
+                    name: "birch".to_string(),
+                    groups: Vec::new(),
+                    not_after: at(90 * 86400),
+                },
+            ),
+        ]);
+        let found = latest_signed_for(&certs, "willow").unwrap();
+        assert_eq!(found.groups, ["laptops"]);
+        assert!(latest_signed_for(&certs, "absent").is_none());
+    }
 }


### PR DESCRIPTION
`ogygia nebula rekey` printed nothing but a cert path and a terse reason before invoking `nebula-cert sign`, so the operator confirming the CA passphrase had no way to tell whether a host was gaining a group, losing one, or simply having its lifetime extended. Certificates are filed by spec hash, so a group change lands under a brand-new filename and the whole rekey looked indistinguishable from a first-time signing.

This commit reads every certificate in the cert directory up front and extends the `nebula-cert print -json` parser to carry the cert's name and groups alongside its expiry. Because rekey signs with the `nixosConfigurations` attribute name, the cert being replaced can be found by name even once the spec hash has moved, and a new `Delta` type renders the nixos configuration name, a `+` line for added groups, a `-` line for removed ones, and the old and new expiry dates when they differ. The reason is now `new host` or `spec changed` rather than `missing`, which that lookup can finally distinguish.

Printing the summary before the sign call puts it ahead of the passphrase prompt `nebula-cert` writes to the terminal, so the operator sees exactly what they are approving. Reusing the up-front scan for the renewal check keeps the fail-safe behaviour: a cert on disk that cannot be read is absent from the scan and is skipped rather than blindly re-signed.

Test plan:
- Added unit tests covering the rendered summary for a new host, a group change, a lifetime extension, an unmoved expiry, and a dry run, plus picking the longest-lived cert when a host has several on disk.
- Added a `nebula-cert print` parser test for the `groups: null` a cert signed without groups emits, and extended the existing round-trip test to sign with groups and assert the name and groups come back.
- Manually ran `ogygia nebula rekey --host willow` against a scratch flake with a real CA and host key, exercising new host, spec changed, nearing expiry, forced, and up-to-date.
- `cargo test -p ogygia --features nebula`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all pass. The two `tests/completions.rs` failures are pre-existing in this environment (the spawned binary cannot find `libssl.so.3`).