### PR TITLE
flake: stop forwarding checks into the default devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -226,7 +226,7 @@
           };
 
           devShells.default = craneLib.devShell {
-            checks = self.checks.${system};
+            inputsFrom = [ cargoArtifacts ];
             packages = with pkgs; [
               etcd # for etcdctl
               jujutsu # jj, for the ogygia-updated change-id tests


### PR DESCRIPTION
The default devShell passed self.checks to craneLib.devShell, which routes them through mkShell's inputsFrom. Because the check set includes several full NixOS VM tests, this forced an entire NixOS system to be evaluated on every direnv entry, emitting stateVersion warnings and adding ~6s of latency.

Point inputsFrom at cargoArtifacts instead, so the shell inherits only the crate build environment (openssl, protobuf, pkg-config) that the Rust tooling actually needs.

The dev shell only ever needed the crate's build inputs, so dropping the check evaluation removes the per-entry cost without changing anything a developer relies on in the shell.

Test plan:
- direnv exec . true: no stateVersion warnings, warm entry ~0.7s (was ~6.5s)
- CI